### PR TITLE
feat: add display_settings role for automatic login and screen blank off

### DIFF
--- a/ansible/playbooks/setup_kit.yaml
+++ b/ansible/playbooks/setup_kit.yaml
@@ -58,6 +58,7 @@
     - { role: raspberry_pi_setup }
     - { role: hardware_interfaces }
     - { role: robotics_workspace }
+    - { role: display_settings }
 
   post_tasks:
     - name: Display completion message

--- a/ansible/playbooks/vars/dev.yaml
+++ b/ansible/playbooks/vars/dev.yaml
@@ -13,3 +13,7 @@ workspace_path: /home/{{ ansible_user | default(ansible_env.SUDO_USER) }}/robot_
 enable_i2c: false
 enable_spi: false
 configure_udev_rules: false
+
+# Display settings (disabled for dev)
+enable_autologin: false
+disable_screen_blank: false

--- a/ansible/playbooks/vars/setup_kit_vars.yaml
+++ b/ansible/playbooks/vars/setup_kit_vars.yaml
@@ -39,3 +39,7 @@ workspace_path: /home/{{ ansible_user | default(ansible_env.SUDO_USER) }}/robot_
 enable_i2c: true
 enable_spi: true
 configure_udev_rules: true
+
+# Display settings
+enable_autologin: true
+disable_screen_blank: true

--- a/ansible/roles/display_settings/README.md
+++ b/ansible/roles/display_settings/README.md
@@ -1,0 +1,56 @@
+# display_settings
+
+ディスプレイ関連の設定を管理するAnsibleロールです。ロボットキット（Raspberry Pi 5）向けに、自動ログインとスクリーンブランク防止を設定します。
+
+## 機能
+
+### 自動ログイン
+
+- **GDM3 が存在する場合**: `/etc/gdm3/custom.conf` に `AutomaticLogin` を設定
+- **GDM3 が存在しない場合**: systemd getty override (`getty@tty1`) でコンソール自動ログインを設定
+
+### スクリーンブランク防止
+
+dconf のシステムワイドオーバーライドで以下を無効化します:
+
+| 設定 | パス | 値 |
+|------|------|-----|
+| セッションアイドル | `org/gnome/desktop/session` | `idle-delay=0` |
+| スクリーンロック | `org/gnome/desktop/screensaver` | `lock-enabled=false` |
+| スクリーンセーバー起動 | `org/gnome/desktop/screensaver` | `idle-activation-enabled=false` |
+| 画面暗転 | `org/gnome/settings-daemon/plugins/power` | `idle-dim=false` |
+| AC電源スリープ | `org/gnome/settings-daemon/plugins/power` | `sleep-inactive-ac-type='nothing'` |
+| バッテリースリープ | `org/gnome/settings-daemon/plugins/power` | `sleep-inactive-battery-type='nothing'` |
+
+## 変数
+
+| 変数名 | デフォルト値 | 説明 |
+|--------|-------------|------|
+| `target_user` | `{{ ansible_user }}` | 自動ログイン対象ユーザー |
+| `enable_autologin` | `true` | 自動ログインの有効/無効 |
+| `disable_screen_blank` | `true` | スクリーンブランク防止の有効/無効 |
+
+## 使い方
+
+### Ansible (playbook経由)
+
+```yaml
+roles:
+  - { role: display_settings }
+```
+
+変数のオーバーライド:
+
+```bash
+ansible-playbook setup_kit.yaml -e "enable_autologin=false"
+```
+
+### シェルスクリプト (手動実行)
+
+Ansible を使わずに同等の設定を適用する場合:
+
+```bash
+sudo ./scripts/configure-display.sh [username]
+```
+
+引数を省略した場合は `$SUDO_USER` (または `$USER`) が使用されます。

--- a/ansible/roles/display_settings/defaults/main.yaml
+++ b/ansible/roles/display_settings/defaults/main.yaml
@@ -1,0 +1,10 @@
+---
+# Default variables for display_settings role
+
+target_user: "{{ ansible_user | default(ansible_env.SUDO_USER) }}"
+
+# Enable automatic login via GDM3 / getty
+enable_autologin: true
+
+# Disable screen blanking, screensaver, and power-saving idle
+disable_screen_blank: true

--- a/ansible/roles/display_settings/handlers/main.yaml
+++ b/ansible/roles/display_settings/handlers/main.yaml
@@ -1,0 +1,7 @@
+---
+# Handlers for display_settings role
+
+- name: update_dconf
+  ansible.builtin.command: dconf update
+  changed_when: false
+  become: true

--- a/ansible/roles/display_settings/meta/main.yaml
+++ b/ansible/roles/display_settings/meta/main.yaml
@@ -1,0 +1,15 @@
+---
+# Role metadata for display_settings
+
+galaxy_info:
+  author: Scramble Robot Team
+  description: Configure automatic login and disable screen blanking for kiosk/robot use
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+dependencies: []

--- a/ansible/roles/display_settings/tasks/main.yaml
+++ b/ansible/roles/display_settings/tasks/main.yaml
@@ -1,0 +1,90 @@
+---
+# Display Settings Tasks
+# - Automatic login (GDM3 + systemd-getty fallback)
+# - Screen blank / screensaver / power-saving disable (dconf system-wide)
+
+# ============================================================
+#  Automatic Login
+# ============================================================
+
+- name: Check if GDM3 is installed
+  ansible.builtin.stat:
+    path: /etc/gdm3/custom.conf
+  register: gdm3_conf
+  when: enable_autologin
+
+- name: Enable GDM3 automatic login
+  ansible.builtin.blockinfile:
+    path: /etc/gdm3/custom.conf
+    marker: "# {mark} ANSIBLE MANAGED - display_settings autologin"
+    insertafter: '^\[daemon\]'
+    block: |
+      AutomaticLoginEnable=True
+      AutomaticLogin={{ target_user }}
+  when: enable_autologin and gdm3_conf.stat.exists
+
+- name: Create getty autologin override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/getty@tty1.service.d
+    state: directory
+    mode: "0755"
+  when: enable_autologin and not gdm3_conf.stat.exists
+
+- name: Configure getty automatic login (fallback when GDM3 is absent)
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/getty@tty1.service.d/autologin.conf
+    mode: "0644"
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=-/sbin/agetty --autologin {{ target_user }} --noclear %I $TERM
+  when: enable_autologin and not gdm3_conf.stat.exists
+
+# ============================================================
+#  Disable Screen Blanking (dconf system-wide override)
+# ============================================================
+
+- name: Ensure dconf CLI is available
+  ansible.builtin.apt:
+    name: dconf-cli
+    state: present
+  when: disable_screen_blank
+
+- name: Create dconf profile for user
+  ansible.builtin.copy:
+    dest: /etc/dconf/profile/user
+    mode: "0644"
+    content: |
+      user-db:user
+      system-db:local
+  when: disable_screen_blank
+  notify: update_dconf
+
+- name: Create dconf local database directory
+  ansible.builtin.file:
+    path: /etc/dconf/db/local.d
+    state: directory
+    mode: "0755"
+  when: disable_screen_blank
+
+- name: Write dconf overrides to disable screen blanking
+  ansible.builtin.copy:
+    dest: /etc/dconf/db/local.d/00-disable-screen-blank
+    mode: "0644"
+    content: |
+      # Managed by Ansible – display_settings role
+      # Disable screen blanking, screensaver, and power-saving idle
+
+      [org/gnome/desktop/session]
+      idle-delay=uint32 0
+
+      [org/gnome/desktop/screensaver]
+      lock-enabled=false
+      idle-activation-enabled=false
+
+      [org/gnome/settings-daemon/plugins/power]
+      idle-dim=false
+      sleep-inactive-ac-type='nothing'
+      sleep-inactive-battery-type='nothing'
+  when: disable_screen_blank
+  notify: update_dconf

--- a/scripts/configure-display.sh
+++ b/scripts/configure-display.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# configure-display.sh
+# Configure automatic login and disable screen blanking for robot kiosk use.
+# This script applies the same settings as the Ansible display_settings role,
+# intended for manual execution on an already-running system.
+#
+# Usage: sudo ./configure-display.sh [username]
+#   username  — the user to auto-login (default: current $SUDO_USER or $USER)
+
+set -e
+
+# ----------------------------------------------------------------
+#  Argument handling
+# ----------------------------------------------------------------
+TARGET_USER="${1:-${SUDO_USER:-$USER}}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "❌ This script must be run as root (use sudo)."
+    exit 1
+fi
+
+if ! id "$TARGET_USER" &>/dev/null; then
+    echo "❌ User '$TARGET_USER' does not exist."
+    exit 1
+fi
+
+echo "🖥️  Configuring display settings for user: $TARGET_USER"
+
+# ================================================================
+#  1. Automatic Login
+# ================================================================
+echo "🔑 Setting up automatic login..."
+
+GDM3_CONF="/etc/gdm3/custom.conf"
+MARKER_BEGIN="# BEGIN ANSIBLE MANAGED - display_settings autologin"
+MARKER_END="# END ANSIBLE MANAGED - display_settings autologin"
+
+if [ -f "$GDM3_CONF" ]; then
+    echo "   → GDM3 detected – configuring $GDM3_CONF"
+
+    # Remove any previous managed block
+    sed -i "/$MARKER_BEGIN/,/$MARKER_END/d" "$GDM3_CONF"
+
+    # Insert autologin lines after [daemon]
+    sed -i "/^\[daemon\]/a\\
+$MARKER_BEGIN\\
+AutomaticLoginEnable=True\\
+AutomaticLogin=$TARGET_USER\\
+$MARKER_END" "$GDM3_CONF"
+
+    echo "   ✅ GDM3 automatic login enabled"
+else
+    echo "   → GDM3 not found – falling back to systemd getty override"
+
+    OVERRIDE_DIR="/etc/systemd/system/getty@tty1.service.d"
+    mkdir -p "$OVERRIDE_DIR"
+    cat > "$OVERRIDE_DIR/autologin.conf" << EOF
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin $TARGET_USER --noclear %I \$TERM
+EOF
+
+    systemctl daemon-reload
+    echo "   ✅ Getty automatic login enabled"
+fi
+
+# ================================================================
+#  2. Disable Screen Blanking (dconf system-wide override)
+# ================================================================
+echo "🔅 Disabling screen blanking..."
+
+# Ensure dconf-cli is installed
+if ! command -v dconf &>/dev/null; then
+    echo "   → Installing dconf-cli..."
+    apt-get update -qq
+    apt-get install -y -qq dconf-cli
+fi
+
+# Create dconf user profile (if missing or different)
+DCONF_PROFILE="/etc/dconf/profile/user"
+mkdir -p "$(dirname "$DCONF_PROFILE")"
+cat > "$DCONF_PROFILE" << 'EOF'
+user-db:user
+system-db:local
+EOF
+
+# Create dconf local override
+DCONF_DIR="/etc/dconf/db/local.d"
+mkdir -p "$DCONF_DIR"
+cat > "$DCONF_DIR/00-disable-screen-blank" << 'EOF'
+# Managed by configure-display.sh
+# Disable screen blanking, screensaver, and power-saving idle
+
+[org/gnome/desktop/session]
+idle-delay=uint32 0
+
+[org/gnome/desktop/screensaver]
+lock-enabled=false
+idle-activation-enabled=false
+
+[org/gnome/settings-daemon/plugins/power]
+idle-dim=false
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
+EOF
+
+dconf update
+echo "   ✅ Screen blanking disabled (dconf system-wide)"
+
+# ================================================================
+#  Done
+# ================================================================
+echo ""
+echo "🎉 Display configuration complete!"
+echo "   • Automatic login : $TARGET_USER"
+echo "   • Screen blanking : disabled"
+echo ""
+echo "💡 A reboot is recommended to apply all changes: sudo reboot"


### PR DESCRIPTION
# description
自動ログインとスリープするのをなくした

# test
実機ラズパイで動作確認済み