### PR TITLE
feat: add UART Switch2 joy driver and stabilize robot control path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 .vscode
 **/__pycache__/**
 scripts/robot_manager.*
+docs
+rosbag2_*

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.yaml
@@ -13,9 +13,15 @@ esc_motor_control:
     max_speed: 1.0 # Maximum forward speed (maps to max_pulse_width)
     min_speed: -1.0 # Maximum reverse speed (maps to min_pulse_width)
 
-    # Joystick settings
-    full_speed_button: 3 # Button index for full speed (0=A, 1=B, 2=X, 3=Y)
+    # Roller spin button / ローラー回転ボタン
+    # DualShock: Square button, UART(Switch2): remapped from ZR button.
+    # DualShock: □ボタン, UART(Switch2): ZRボタンをここへ変換します。
+    full_speed_button: 3
     full_speed_value: 1.0 # Speed value when full speed button is pressed
+    # ローラモータのコマンド状態出力先
+    # ここには実測回転数ではなく、ESCへ送っている現在の指令値が出ます。
+    status_topic: "/roller_motor_status"
+    emergency_status_topic: "/roller_emergency_status"
 
     # Safety settings
     enable_safety_stop: true # Enable automatic safety stop

--- a/esc_motor_control_cpp/include/esc_motor_control_cpp/esc_motor_control_component.hpp
+++ b/esc_motor_control_cpp/include/esc_motor_control_cpp/esc_motor_control_component.hpp
@@ -43,6 +43,8 @@ private:
   double full_speed_value_;
   bool test_mode_;
   std::string joy_topic_;
+  std::string status_topic_;
+  std::string emergency_status_topic_;
   int min_pulse_width_us_;
   int max_pulse_width_us_;
   int neutral_pulse_width_us_;

--- a/esc_motor_control_cpp/src/esc_motor_control_component.cpp
+++ b/esc_motor_control_cpp/src/esc_motor_control_component.cpp
@@ -20,6 +20,8 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   this->declare_parameter<double>("full_speed_value", 1.0);
   this->declare_parameter<bool>("test_mode", false);
   this->declare_parameter<std::string>("joy_topic", "/joy");
+  this->declare_parameter<std::string>("status_topic", "/roller_motor_status");
+  this->declare_parameter<std::string>("emergency_status_topic", "/roller_emergency_status");
   this->declare_parameter<int>("min_pulse_width", 0);         // μs (speed=-1.0)
   this->declare_parameter<int>("max_pulse_width", 2000);      // μs (speed=1.0)
   this->declare_parameter<int>("neutral_pulse_width", 1000);  // μs (ESC arm/idle)
@@ -37,6 +39,8 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   full_speed_value_ = this->get_parameter("full_speed_value").as_double();
   test_mode_ = this->get_parameter("test_mode").as_bool();
   joy_topic_ = this->get_parameter("joy_topic").as_string();
+  status_topic_ = this->get_parameter("status_topic").as_string();
+  emergency_status_topic_ = this->get_parameter("emergency_status_topic").as_string();
   min_pulse_width_us_ = this->get_parameter("min_pulse_width").as_int();
   max_pulse_width_us_ = this->get_parameter("max_pulse_width").as_int();
   neutral_pulse_width_us_ = this->get_parameter("neutral_pulse_width").as_int();
@@ -56,8 +60,9 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
       std::bind(&EscMotorControlComponent::joy_callback, this, std::placeholders::_1));
 
   // ---- Publishers ----
-  status_pub_ = this->create_publisher<std_msgs::msg::Float32>("motor_status", 10);
-  emergency_pub_ = this->create_publisher<std_msgs::msg::Bool>("emergency_status", qos_transient);
+  status_pub_ = this->create_publisher<std_msgs::msg::Float32>(status_topic_, 10);
+  emergency_pub_ =
+      this->create_publisher<std_msgs::msg::Bool>(emergency_status_topic_, qos_transient);
 
   // ---- Timers ----
   status_timer_ =
@@ -74,6 +79,8 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   RCLCPP_INFO(this->get_logger(), "ESC Motor Control Node (C++) initialized on pin %d", pwm_pin_);
   RCLCPP_INFO(this->get_logger(), "PWM backend: %s", pwm_ ? pwm_->name().c_str() : "none");
   RCLCPP_INFO(this->get_logger(), "Test Mode: %s", test_mode_ ? "true" : "false");
+  RCLCPP_INFO(this->get_logger(), "Status topic: %s", status_topic_.c_str());
+  RCLCPP_INFO(this->get_logger(), "Emergency topic: %s", emergency_status_topic_.c_str());
   RCLCPP_INFO(this->get_logger(), "Pulse range: %d - %d μs  (neutral %d μs)", min_pulse_width_us_,
               max_pulse_width_us_, neutral_pulse_width_us_);
 
@@ -184,15 +191,14 @@ void EscMotorControlComponent::joy_callback(const sensor_msgs::msg::Joy::SharedP
     full_speed_active_ = true;
     set_motor_speed(full_speed_value_);
 
+  } else if (full_speed_pressed && full_speed_active_) {
+    std::lock_guard<std::mutex> guard(lock_);
+    last_command_time_ = this->now();
+
   } else if (!full_speed_pressed && full_speed_active_) {
     RCLCPP_INFO(this->get_logger(), "Full-speed button RELEASED");
     full_speed_active_ = false;
     set_motor_speed(0.0);
-
-  } else if (full_speed_pressed && full_speed_active_) {
-    // Held – refresh timestamp to prevent safety timeout
-    std::lock_guard<std::mutex> guard(lock_);
-    last_command_time_ = this->now();
   }
 }
 

--- a/joy_controller/config/joy_controller_params.yaml
+++ b/joy_controller/config/joy_controller_params.yaml
@@ -4,15 +4,20 @@
 # Movement control parameters
 joy_controller:
   ros__parameters:
-    # Input scaling ratios
-    longitudinal_input_ratio: 0.1 # Forward/backward movement scaling
-    lateral_input_ratio: 0.3 # Left/right movement scaling (for holonomic robots)
-    angular_input_ratio: 0.1 # Rotational movement scaling
+    # Input scaling ratios / 入力スケール
+    # Lower these values to make the robot slower and easier to control.
+    # 数値を小さくすると、ロボットの最高速度を抑えて扱いやすくできます。
+    longitudinal_input_ratio: 0.1 # Forward/backward speed / 前後移動の速度
+    lateral_input_ratio: 0.3 # Left/right speed for holonomic robots / 全方向移動の左右速度
+    # Rotation direction and speed / 旋回の向きと速度
+    # Positive and negative switch the turning direction. Smaller absolute values reduce turning speed.
+    # 符号で旋回方向、絶対値で旋回速度が決まります。逆回転なら符号を反転してください。
+    angular_input_ratio: -0.1
 
     # Controller mapping (button and axis indices)
     linear_x_axis: 1 # Axis for forward/backward (typically left stick Y)
-    linear_y_axis: 3 # Axis for left/right (typically left stick X)
-    angular_z_axis: 0 # Axis for rotation (typically right stick X)
+    linear_y_axis: 0 # Axis for left/right (typically left stick X)
+    angular_z_axis: 3 # Axis for rotation (typically right stick X)
     right_stick_x_axis: 4 # Axis for servo control (typically right stick X)
 
     # Button mapping for servo shot

--- a/launcher/launch/shot_component.launch.xml
+++ b/launcher/launch/shot_component.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <!-- Launch Arguments -->
 
-  <arg name="shot_config_file" default="$(find-pkg-share motor_control_app)/config/shot_component.yaml" description="Configuration file path" />
+  <arg name="shot_config_file" default="$(find-pkg-share motor_control_app)/config/shot_config.yaml" description="Configuration file path" />
   <arg name="enable_gpio_ref" default="false" description="Enable GPIO reference system (gpio_reader + joy_gate)" />
   <arg name="use_sim_time" default="false" description="Use simulation time" />
   <!-- joy topic selection based on enable_gpio_ref -->

--- a/motor_control_app/config/drive_component.yaml
+++ b/motor_control_app/config/drive_component.yaml
@@ -11,7 +11,12 @@ drive_component:
     # モータ設定
     left_motor_id: 4 # 左モータID
     right_motor_id: 5 # 右モータID
+    # 走行モータの上限回転数
+    # 値を下げるとロボット全体の最高速度が下がります。組立直後の安全確認では低めを推奨します。
     max_motor_rpm: 1000 # 最大RPM
 
     # パブリッシュ設定
     status_publish_rate: 10.0 # ステータスパブリッシュ頻度 [Hz]
+    # 左右モータのフィードバック出力先
+    # 左右RPMや現在速度を見たいときは、このトピックを ros2 topic echo してください。
+    status_topic: "/drive_motor_status"

--- a/motor_control_app/config/shot_config.yaml
+++ b/motor_control_app/config/shot_config.yaml
@@ -4,8 +4,14 @@ shot_component:
     baudrate: 115200
     pan_servo_id: 11
     trigger_servo_id: 10
-    fire_button: 0 # Aボタン（通常0番）
+    # Disc fire button / ディスク射出ボタン
+    # DualShock: X button, UART(Switch2): remapped from R button.
+    # DualShock: ×ボタン, UART(Switch2): Rボタンをここへ変換します。
+    fire_button: 0
     fire_duration_ms: 300 # 射撃持続時間（ミリ秒）
+    # Tilt axis / 仰角軸
+    # DualShock: D-pad up/down, UART(Switch2): remapped from L / ZL buttons.
+    # DualShock: 十字キー上下, UART(Switch2): L / ZLボタンをここへ変換します。
     pan_axis: 7
     fire_angle: 145.0 # 射撃角度（度）
     home_angle: 245.0 # ホーム角度（度）

--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -73,6 +73,7 @@ private:
   int right_motor_id_;
   int max_motor_rpm_;
   double status_publish_rate_;
+  std::string status_topic_;
 
   // 状態フラグ
   bool motor_initialized_;

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -24,7 +24,7 @@ DriveComponent::DriveComponent(const rclcpp::NodeOptions& options)
   twist_subscription_ = this->create_subscription<geometry_msgs::msg::Twist>(
       "/target_twist", 1, std::bind(&DriveComponent::twistCallback, this, std::placeholders::_1));
 
-  status_publisher_ = this->create_publisher<std_msgs::msg::String>("motor_status", 1);
+  status_publisher_ = this->create_publisher<std_msgs::msg::String>(status_topic_, 1);
 
   // ステータスパブリッシュタイマー
   auto timer_period = std::chrono::duration<double>(1.0 / status_publish_rate_);
@@ -56,6 +56,7 @@ void DriveComponent::initializeParameters() {
   this->declare_parameter("right_motor_id", 2);
   this->declare_parameter("max_motor_rpm", 1000);
   this->declare_parameter("status_publish_rate", 10.0);
+  this->declare_parameter("status_topic", "/drive_motor_status");
 
   // パラメータを取得
   serial_port_ = this->get_parameter("serial_port").as_string();
@@ -66,6 +67,7 @@ void DriveComponent::initializeParameters() {
   right_motor_id_ = this->get_parameter("right_motor_id").as_int();
   max_motor_rpm_ = this->get_parameter("max_motor_rpm").as_int();
   status_publish_rate_ = this->get_parameter("status_publish_rate").as_double();
+  status_topic_ = this->get_parameter("status_topic").as_string();
 
   RCLCPP_INFO(this->get_logger(), "Parameters initialized:");
   RCLCPP_INFO(this->get_logger(), "  serial_port: %s", serial_port_.c_str());
@@ -76,6 +78,7 @@ void DriveComponent::initializeParameters() {
   RCLCPP_INFO(this->get_logger(), "  right_motor_id: %d", right_motor_id_);
   RCLCPP_INFO(this->get_logger(), "  max_motor_rpm: %d", max_motor_rpm_);
   RCLCPP_INFO(this->get_logger(), "  status_publish_rate: %.1f", status_publish_rate_);
+  RCLCPP_INFO(this->get_logger(), "  status_topic: %s", status_topic_.c_str());
 }
 
 bool DriveComponent::initializeMotorLib() {

--- a/uart_joy_driver/config/uart_joy_driver_params.yaml
+++ b/uart_joy_driver/config/uart_joy_driver_params.yaml
@@ -7,8 +7,48 @@ uart_joy_driver:
     serial_port: "/dev/ttyAMA0"   # RPi built-in UART (GPIO14/15)
     baud_rate: 115200
 
-    # Publishing rate (Hz)
+    # UART polling rate (Hz)
+    read_poll_rate: 50.0
+    # Joy publish rate (Hz)
+    # UARTの受信とは別に、最後の有効なJoyをこの周期で再送します。
     publish_rate: 50.0
 
     # Stick deadzone (0.0-1.0)
     deadzone: 0.05
+
+    # Publish a neutral Joy message if input stops.
+    # UART入力が完全に止まったとき、この秒数でニュートラルに戻します。
+    message_timeout_sec: 0.5
+
+    # Dropout filter for slow UART input / 低速UART向けドロップアウト対策
+    # Release an active stick command only after this many consecutive neutral frames.
+    # 有効なスティック入力を解除するには、連続でこの回数だけニュートラルを確認します。
+    axis_release_confirm_frames: 2
+    # Release a pressed button only after this many consecutive released frames.
+    # 押下中のボタンを解除するには、連続でこの回数だけ離した状態を確認します。
+    button_release_confirm_frames: 2
+    # Treat axes larger than this value as an intentional command.
+    # この値より大きい軸入力を「本当に操作している入力」とみなします。
+    hold_axis_threshold: 0.1
+
+    # Print raw UART frames for debugging when true.
+    debug_raw_input: false
+
+    # UART special button remap / UARTの特別キー割り当て
+    # These input button indices are the raw Switch2 button numbers from UART.
+    # これらの入力ボタン番号は、UARTで届くSwitch2の生ボタン番号です。
+    pan_up_button_index: 4      # L button / Lボタン
+    pan_down_button_index: 6    # ZL button / ZLボタン
+    fire_input_button_index: 5  # R button / Rボタン
+    roller_input_button_index: 7 # ZR button / ZRボタン
+
+    # Semantic output remap / 意味ベースの出力先
+    # Downstream nodes read these Joy positions, so users can change only this file.
+    # 下流ノードはこのJoy位置を読むので、ユーザーはこのファイルだけ変更すればOKです。
+    pan_output_axis_index: 7     # Tilt axis / 仰角軸
+    # Tilt direction sign / 仰角方向の符号
+    # Use 1.0 for normal, -1.0 for inverted.
+    # 通常方向は1.0、上下が逆なら-1.0にします。
+    pan_output_axis_scale: -1.0
+    fire_output_button_index: 0  # Disc fire button / ディスク射出ボタン
+    roller_output_button_index: 3 # Roller spin button / ローラー回転ボタン

--- a/uart_joy_driver/include/uart_joy_driver/uart_joy_driver_component.hpp
+++ b/uart_joy_driver/include/uart_joy_driver/uart_joy_driver_component.hpp
@@ -53,7 +53,10 @@ extern "C" {
 #endif
 
 #include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+
 #include <string>
+#include <vector>
 
 namespace uart_joy_driver {
 
@@ -74,17 +77,51 @@ private:
   // Read a complete line from serial buffer
   bool readLine(std::string& line);
 
+  // Convert one ASCII line from the receiver module into a Joy message.
+  bool parseControllerLine(const std::string& line, sensor_msgs::msg::Joy& joy_msg);
+  bool parseHexByte(const std::string& token, uint8_t& value) const;
+  double normalizeAxis(uint8_t value, bool invert) const;
+  void fillDpadAxes(uint8_t dpad_value, sensor_msgs::msg::Joy& joy_msg) const;
+  void applyDropoutFilter(sensor_msgs::msg::Joy& joy_msg);
+  void applySemanticRemap(sensor_msgs::msg::Joy& joy_msg) const;
+  void publishNeutralJoy();
+
   // Parameters
   std::string serial_port_;
   int baud_rate_;
+  double read_poll_rate_;
   double publish_rate_;
+  double deadzone_;
+  double message_timeout_sec_;
+  double hold_axis_threshold_;
+  int axis_release_confirm_frames_;
+  int button_release_confirm_frames_;
+  bool debug_raw_input_;
+  int pan_up_button_index_;
+  int pan_down_button_index_;
+  int fire_input_button_index_;
+  int fire_output_button_index_;
+  int roller_input_button_index_;
+  int roller_output_button_index_;
+  int pan_output_axis_index_;
+  double pan_output_axis_scale_;
 
   // Serial
   int serial_fd_;
   std::string read_buffer_;
 
   // ROS interfaces
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_raw_pub_;
   rclcpp::TimerBase::SharedPtr read_timer_;
+  rclcpp::Time last_frame_time_;
+  bool have_received_frame_;
+  bool neutral_published_;
+  sensor_msgs::msg::Joy last_valid_joy_msg_;
+  std::vector<float> filtered_axes_;
+  std::vector<int> filtered_buttons_;
+  std::vector<int> axis_release_counts_;
+  std::vector<int> button_release_counts_;
 };
 
 }  // namespace uart_joy_driver

--- a/uart_joy_driver/src/uart_joy_driver_component.cpp
+++ b/uart_joy_driver/src/uart_joy_driver_component.cpp
@@ -16,42 +16,112 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
 #include <string>
-#include <uart_joy_driver/uart_joy_driver_component.hpp>
+#include <vector>
 
-using namespace std::chrono_literals;
+#include <uart_joy_driver/uart_joy_driver_component.hpp>
 
 namespace uart_joy_driver {
 
+namespace {
+
+constexpr size_t kJoyAxisCount = 8;
+constexpr size_t kJoyButtonCount = 16;
+constexpr int kExpectedFunctionId = 0x01;
+
+std::vector<std::string> splitString(const std::string& input, char delimiter) {
+  std::vector<std::string> tokens;
+  std::stringstream ss(input);
+  std::string token;
+
+  while (std::getline(ss, token, delimiter)) {
+    tokens.push_back(token);
+  }
+
+  return tokens;
+}
+
+}  // namespace
+
 UartJoyDriverComponent::UartJoyDriverComponent(const rclcpp::NodeOptions& options)
-    : Node("uart_joy_driver", options), serial_fd_(-1) {
-  // Declare and load parameters
+    : Node("uart_joy_driver", options),
+      serial_fd_(-1),
+      last_frame_time_(0, 0, RCL_ROS_TIME),
+      have_received_frame_(false),
+      neutral_published_(false) {
   declare_parameter("serial_port", "/dev/ttyAMA0");
   declare_parameter("baud_rate", 115200);
+  declare_parameter("read_poll_rate", 50.0);
   declare_parameter("publish_rate", 50.0);
+  declare_parameter("deadzone", 0.05);
+  declare_parameter("message_timeout_sec", 0.5);
+  declare_parameter("hold_axis_threshold", 0.1);
+  declare_parameter("axis_release_confirm_frames", 2);
+  declare_parameter("button_release_confirm_frames", 2);
+  declare_parameter("debug_raw_input", false);
+  declare_parameter("pan_up_button_index", 4);
+  declare_parameter("pan_down_button_index", 6);
+  declare_parameter("fire_input_button_index", 5);
+  declare_parameter("fire_output_button_index", 0);
+  declare_parameter("roller_input_button_index", 7);
+  declare_parameter("roller_output_button_index", 3);
+  declare_parameter("pan_output_axis_index", 7);
+  declare_parameter("pan_output_axis_scale", -1.0);
 
   get_parameter("serial_port", serial_port_);
   get_parameter("baud_rate", baud_rate_);
+  get_parameter("read_poll_rate", read_poll_rate_);
   get_parameter("publish_rate", publish_rate_);
+  get_parameter("deadzone", deadzone_);
+  get_parameter("message_timeout_sec", message_timeout_sec_);
+  get_parameter("hold_axis_threshold", hold_axis_threshold_);
+  get_parameter("axis_release_confirm_frames", axis_release_confirm_frames_);
+  get_parameter("button_release_confirm_frames", button_release_confirm_frames_);
+  get_parameter("debug_raw_input", debug_raw_input_);
+  get_parameter("pan_up_button_index", pan_up_button_index_);
+  get_parameter("pan_down_button_index", pan_down_button_index_);
+  get_parameter("fire_input_button_index", fire_input_button_index_);
+  get_parameter("fire_output_button_index", fire_output_button_index_);
+  get_parameter("roller_input_button_index", roller_input_button_index_);
+  get_parameter("roller_output_button_index", roller_output_button_index_);
+  get_parameter("pan_output_axis_index", pan_output_axis_index_);
+  get_parameter("pan_output_axis_scale", pan_output_axis_scale_);
 
-  // Initialize serial port
+  joy_pub_ = this->create_publisher<sensor_msgs::msg::Joy>("/joy", 10);
+  joy_raw_pub_ = this->create_publisher<sensor_msgs::msg::Joy>("/joy_raw_uart", 10);
+  filtered_axes_.assign(kJoyAxisCount, 0.0F);
+  filtered_buttons_.assign(kJoyButtonCount, 0);
+  axis_release_counts_.assign(kJoyAxisCount, 0);
+  button_release_counts_.assign(kJoyButtonCount, 0);
+  last_valid_joy_msg_.axes.assign(kJoyAxisCount, 0.0F);
+  last_valid_joy_msg_.buttons.assign(kJoyButtonCount, 0);
+  last_frame_time_ = this->now();
+
   if (!initializeSerial()) {
     RCLCPP_ERROR(this->get_logger(), "シリアルポートの初期化に失敗しました: %s",
                  serial_port_.c_str());
     RCLCPP_ERROR(this->get_logger(),
-                 "ポートが接続されていない可能性があります。タイマーは起動しますが、"
-                 "データは送信されません。");
+                 "UARTの配線、受信モジュール、デバイス名を確認してください。");
   }
 
-  // Create periodic read timer
-  auto period = std::chrono::duration<double>(1.0 / publish_rate_);
+  const auto period = std::chrono::duration<double>(1.0 / std::max(1.0, read_poll_rate_));
   read_timer_ =
       this->create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(period),
                               std::bind(&UartJoyDriverComponent::readTimerCallback, this));
 
-  RCLCPP_INFO(this->get_logger(), "UART Joy Driver initialized: port=%s, baud=%d, rate=%.1fHz",
-              serial_port_.c_str(), baud_rate_, publish_rate_);
+  RCLCPP_INFO(this->get_logger(),
+              "UART Joy Driver initialized: port=%s, baud=%d, read=%.1fHz, publish=%.1fHz, axis_release_frames=%d, button_release_frames=%d, timeout=%.2fs",
+              serial_port_.c_str(), baud_rate_, read_poll_rate_, publish_rate_,
+              axis_release_confirm_frames_, button_release_confirm_frames_,
+              message_timeout_sec_);
 }
 
 UartJoyDriverComponent::~UartJoyDriverComponent() { closeSerial(); }
@@ -63,14 +133,13 @@ bool UartJoyDriverComponent::initializeSerial() {
     return false;
   }
 
-  struct termios tty;
+  struct termios tty {};
   if (tcgetattr(serial_fd_, &tty) != 0) {
     RCLCPP_ERROR(this->get_logger(), "tcgetattr エラー");
     closeSerial();
     return false;
   }
 
-  // Baud rate
   speed_t speed = B115200;
   switch (baud_rate_) {
     case 9600:
@@ -90,26 +159,22 @@ bool UartJoyDriverComponent::initializeSerial() {
       break;
     default:
       RCLCPP_WARN(this->get_logger(), "未対応のボーレート %d、115200を使用", baud_rate_);
-      speed = B115200;
       break;
   }
   cfsetospeed(&tty, speed);
   cfsetispeed(&tty, speed);
 
-  // 8N1 configuration
   tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8;
   tty.c_cflag |= (CLOCAL | CREAD);
   tty.c_cflag &= ~(PARENB | PARODD);
   tty.c_cflag &= ~CSTOPB;
   tty.c_cflag &= ~CRTSCTS;
 
-  // Raw input - no canonical processing, but we handle line parsing ourselves
   tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL);
   tty.c_iflag &= ~(IXON | IXOFF | IXANY);
   tty.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
   tty.c_oflag &= ~OPOST;
 
-  // Non-blocking reads: return immediately with whatever is available
   tty.c_cc[VMIN] = 0;
   tty.c_cc[VTIME] = 0;
 
@@ -119,9 +184,7 @@ bool UartJoyDriverComponent::initializeSerial() {
     return false;
   }
 
-  // Flush any stale data in buffers
   tcflush(serial_fd_, TCIOFLUSH);
-
   RCLCPP_INFO(this->get_logger(), "シリアルポートが開きました: %s (baud=%d)", serial_port_.c_str(),
               baud_rate_);
   return true;
@@ -135,47 +198,86 @@ void UartJoyDriverComponent::closeSerial() {
 }
 
 void UartJoyDriverComponent::readTimerCallback() {
-  if (serial_fd_ < 0) {
+  if (serial_fd_ >= 0) {
+    char buf[256];
+
+    while (true) {
+      const ssize_t bytes_read = read(serial_fd_, buf, sizeof(buf));
+      if (bytes_read > 0) {
+        if (debug_raw_input_) {
+          std::string raw_hex;
+          raw_hex.reserve(static_cast<size_t>(bytes_read) * 3);
+          for (ssize_t i = 0; i < bytes_read; ++i) {
+            char hex[4];
+            std::snprintf(hex, sizeof(hex), "%02X ", static_cast<unsigned char>(buf[i]));
+            raw_hex += hex;
+          }
+          RCLCPP_INFO(this->get_logger(), "Raw(%zd bytes): %s", bytes_read, raw_hex.c_str());
+        }
+
+        read_buffer_.append(buf, static_cast<size_t>(bytes_read));
+        continue;
+      }
+
+      if (bytes_read < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                             "UART read error: %s", std::strerror(errno));
+      }
+      break;
+    }
+  }
+
+  if (read_buffer_.size() > 2048) {
+    read_buffer_ = read_buffer_.substr(read_buffer_.size() - 1024);
+  }
+
+  std::string line;
+  while (readLine(line)) {
+    sensor_msgs::msg::Joy raw_joy_msg;
+    if (!parseControllerLine(line, raw_joy_msg)) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                           "Failed to parse UART controller line: %s", line.c_str());
+      continue;
+    }
+
+    const auto now = this->now();
+    raw_joy_msg.header.stamp = now;
+    joy_raw_pub_->publish(raw_joy_msg);
+
+    auto joy_msg = raw_joy_msg;
+    applyDropoutFilter(joy_msg);
+    applySemanticRemap(joy_msg);
+    joy_msg.header.stamp = now;
+    last_valid_joy_msg_ = joy_msg;
+    last_frame_time_ = now;
+    have_received_frame_ = true;
+    neutral_published_ = false;
+
+    if (debug_raw_input_) {
+      RCLCPP_INFO(this->get_logger(),
+                  "Received Joy: axes[0]=%.2f axes[1]=%.2f axes[3]=%.2f axes[7]=%.2f buttons[0]=%d buttons[3]=%d",
+                  joy_msg.axes[0], joy_msg.axes[1], joy_msg.axes[3], joy_msg.axes[7],
+                  joy_msg.buttons[0], joy_msg.buttons[3]);
+    }
+  }
+
+  if (!have_received_frame_) {
     return;
   }
 
-  // Read available data from serial port
-  char buf[256];
-  ssize_t n = read(serial_fd_, buf, sizeof(buf) - 1);
-  if (n > 0) {
-    // Debug: print raw bytes as hex
-    buf[n] = '\0';
-    std::string raw_hex;
-    for (ssize_t i = 0; i < n; ++i) {
-      char hex[8];
-      snprintf(hex, sizeof(hex), "%02X ", static_cast<unsigned char>(buf[i]));
-      raw_hex += hex;
-    }
-    RCLCPP_INFO(this->get_logger(), "Raw(%zd bytes): %s", n, raw_hex.c_str());
-
-    read_buffer_.append(buf, static_cast<size_t>(n));
-  }
-
-  // Prevent buffer from growing unbounded if no valid lines are found
-  if (read_buffer_.size() > 1024) {
-    read_buffer_ = read_buffer_.substr(read_buffer_.size() - 512);
-  }
-
-  // Process all complete lines, use only the latest one
-  std::string latest_line;
-  std::string line;
-  while (readLine(line)) {
-    latest_line = line;
-  }
-
-  if (!latest_line.empty()) {
-    RCLCPP_INFO(this->get_logger(), "Line: %s", latest_line.c_str());
+  const auto now = this->now();
+  if ((now - last_frame_time_).seconds() <= message_timeout_sec_) {
+    auto held_msg = last_valid_joy_msg_;
+    held_msg.header.stamp = now;
+    joy_pub_->publish(held_msg);
+  } else if (!neutral_published_) {
+    publishNeutralJoy();
+    neutral_published_ = true;
   }
 }
 
 bool UartJoyDriverComponent::readLine(std::string& line) {
-  // Look for \r\n or \n delimiter
-  auto pos = read_buffer_.find('\n');
+  const auto pos = read_buffer_.find('\n');
   if (pos == std::string::npos) {
     return false;
   }
@@ -183,12 +285,10 @@ bool UartJoyDriverComponent::readLine(std::string& line) {
   line = read_buffer_.substr(0, pos);
   read_buffer_.erase(0, pos + 1);
 
-  // Strip trailing \r if present
   if (!line.empty() && line.back() == '\r') {
     line.pop_back();
   }
 
-  // Strip leading/trailing whitespace
   while (!line.empty() && (line.front() == ' ' || line.front() == '\t')) {
     line.erase(line.begin());
   }
@@ -197,6 +297,240 @@ bool UartJoyDriverComponent::readLine(std::string& line) {
   }
 
   return !line.empty();
+}
+
+bool UartJoyDriverComponent::parseControllerLine(const std::string& line,
+                                                 sensor_msgs::msg::Joy& joy_msg) {
+  std::string payload = line;
+  const auto separator_pos = payload.find(':');
+  if (separator_pos != std::string::npos) {
+    payload = payload.substr(separator_pos + 1);
+  }
+
+  const auto tokens = splitString(payload, ',');
+  size_t data_start_index = 0;
+  if (tokens.size() == 8) {
+    uint8_t function_id = 0;
+    if (!parseHexByte(tokens[0], function_id) || function_id != kExpectedFunctionId) {
+      return false;
+    }
+    data_start_index = 1;
+  } else if (tokens.size() != 7) {
+    return false;
+  }
+
+  uint8_t byte0 = 0;
+  uint8_t byte1 = 0;
+  uint8_t dpad = 0;
+  uint8_t lx = 0x80;
+  uint8_t ly = 0x80;
+  uint8_t rx = 0x80;
+  uint8_t ry = 0x80;
+
+  if (!parseHexByte(tokens[data_start_index + 0], byte0) ||
+      !parseHexByte(tokens[data_start_index + 1], byte1) ||
+      !parseHexByte(tokens[data_start_index + 2], dpad) ||
+      !parseHexByte(tokens[data_start_index + 3], lx) ||
+      !parseHexByte(tokens[data_start_index + 4], ly) ||
+      !parseHexByte(tokens[data_start_index + 5], rx) ||
+      !parseHexByte(tokens[data_start_index + 6], ry)) {
+    return false;
+  }
+
+  joy_msg.header.stamp = this->now();
+  joy_msg.axes.assign(kJoyAxisCount, 0.0F);
+  joy_msg.buttons.assign(kJoyButtonCount, 0);
+
+  joy_msg.axes[0] = static_cast<float>(normalizeAxis(lx, false));
+  joy_msg.axes[1] = static_cast<float>(normalizeAxis(ly, true));
+  joy_msg.axes[3] = static_cast<float>(normalizeAxis(rx, false));
+  joy_msg.axes[4] = static_cast<float>(normalizeAxis(ry, true));
+  fillDpadAxes(dpad, joy_msg);
+
+  joy_msg.buttons[0] = (byte0 & 0x01) ? 1 : 0;   // A
+  joy_msg.buttons[1] = (byte0 & 0x02) ? 1 : 0;   // B
+  joy_msg.buttons[2] = (byte0 & 0x04) ? 1 : 0;   // X
+  joy_msg.buttons[3] = (byte0 & 0x08) ? 1 : 0;   // Y
+  joy_msg.buttons[4] = (byte0 & 0x10) ? 1 : 0;   // L
+  joy_msg.buttons[5] = (byte0 & 0x20) ? 1 : 0;   // R
+  joy_msg.buttons[6] = (byte0 & 0x40) ? 1 : 0;   // ZL
+  joy_msg.buttons[7] = (byte0 & 0x80) ? 1 : 0;   // ZR
+  joy_msg.buttons[8] = (byte1 & 0x01) ? 1 : 0;   // Minus
+  joy_msg.buttons[9] = (byte1 & 0x02) ? 1 : 0;   // Plus
+  joy_msg.buttons[10] = (byte1 & 0x04) ? 1 : 0;  // Home
+  joy_msg.buttons[11] = (byte1 & 0x08) ? 1 : 0;  // Capture
+  joy_msg.buttons[12] = (byte1 & 0x10) ? 1 : 0;  // LStick
+  joy_msg.buttons[13] = (byte1 & 0x20) ? 1 : 0;  // RStick
+
+  return true;
+}
+
+void UartJoyDriverComponent::applyDropoutFilter(sensor_msgs::msg::Joy& joy_msg) {
+  if (filtered_axes_.size() != joy_msg.axes.size()) {
+    filtered_axes_.assign(joy_msg.axes.size(), 0.0F);
+    axis_release_counts_.assign(joy_msg.axes.size(), 0);
+  }
+  if (filtered_buttons_.size() != joy_msg.buttons.size()) {
+    filtered_buttons_.assign(joy_msg.buttons.size(), 0);
+    button_release_counts_.assign(joy_msg.buttons.size(), 0);
+  }
+
+  const int axis_release_frames = std::max(1, axis_release_confirm_frames_);
+  const int button_release_frames = std::max(1, button_release_confirm_frames_);
+
+  for (size_t i = 0; i < joy_msg.axes.size(); ++i) {
+    const float raw_axis = joy_msg.axes[i];
+    if (std::abs(raw_axis) >= hold_axis_threshold_) {
+      filtered_axes_[i] = raw_axis;
+      axis_release_counts_[i] = 0;
+    } else if (std::abs(filtered_axes_[i]) >= hold_axis_threshold_) {
+      axis_release_counts_[i] += 1;
+      if (axis_release_counts_[i] >= axis_release_frames) {
+        filtered_axes_[i] = 0.0F;
+        axis_release_counts_[i] = 0;
+      }
+    } else {
+      filtered_axes_[i] = 0.0F;
+      axis_release_counts_[i] = 0;
+    }
+    joy_msg.axes[i] = filtered_axes_[i];
+  }
+
+  for (size_t i = 0; i < joy_msg.buttons.size(); ++i) {
+    const bool raw_pressed = joy_msg.buttons[i] == 1;
+    if (raw_pressed) {
+      filtered_buttons_[i] = 1;
+      button_release_counts_[i] = 0;
+    } else if (filtered_buttons_[i] == 1) {
+      button_release_counts_[i] += 1;
+      if (button_release_counts_[i] >= button_release_frames) {
+        filtered_buttons_[i] = 0;
+        button_release_counts_[i] = 0;
+      }
+    } else {
+      filtered_buttons_[i] = 0;
+      button_release_counts_[i] = 0;
+    }
+    joy_msg.buttons[i] = filtered_buttons_[i];
+  }
+}
+
+void UartJoyDriverComponent::applySemanticRemap(sensor_msgs::msg::Joy& joy_msg) const {
+  const auto is_pressed = [&joy_msg](int index) {
+    return index >= 0 && index < static_cast<int>(joy_msg.buttons.size()) &&
+           joy_msg.buttons[static_cast<size_t>(index)] == 1;
+  };
+
+  if (pan_output_axis_index_ >= 0 &&
+      pan_output_axis_index_ < static_cast<int>(joy_msg.axes.size()) &&
+      (pan_up_button_index_ >= 0 || pan_down_button_index_ >= 0)) {
+    float pan_axis_value = 0.0F;
+    if (is_pressed(pan_up_button_index_) && !is_pressed(pan_down_button_index_)) {
+      pan_axis_value = 1.0F;
+    } else if (is_pressed(pan_down_button_index_) && !is_pressed(pan_up_button_index_)) {
+      pan_axis_value = -1.0F;
+    }
+    joy_msg.axes[static_cast<size_t>(pan_output_axis_index_)] =
+        static_cast<float>(pan_axis_value * pan_output_axis_scale_);
+  }
+
+  if (fire_output_button_index_ >= 0 &&
+      fire_output_button_index_ < static_cast<int>(joy_msg.buttons.size()) &&
+      fire_input_button_index_ >= 0) {
+    joy_msg.buttons[static_cast<size_t>(fire_output_button_index_)] =
+        is_pressed(fire_input_button_index_) ? 1 : 0;
+  }
+
+  if (roller_output_button_index_ >= 0 &&
+      roller_output_button_index_ < static_cast<int>(joy_msg.buttons.size()) &&
+      roller_input_button_index_ >= 0) {
+    joy_msg.buttons[static_cast<size_t>(roller_output_button_index_)] =
+        is_pressed(roller_input_button_index_) ? 1 : 0;
+  }
+}
+
+bool UartJoyDriverComponent::parseHexByte(const std::string& token, uint8_t& value) const {
+  if (token.empty() || token.size() > 2) {
+    return false;
+  }
+
+  char* end_ptr = nullptr;
+  const unsigned long parsed = std::strtoul(token.c_str(), &end_ptr, 16);
+  if (end_ptr == nullptr || *end_ptr != '\0' || parsed > 0xFFUL) {
+    return false;
+  }
+
+  value = static_cast<uint8_t>(parsed);
+  return true;
+}
+
+double UartJoyDriverComponent::normalizeAxis(uint8_t value, bool invert) const {
+  double normalized = (static_cast<int>(value) - 128) / 127.0;
+  normalized = std::clamp(normalized, -1.0, 1.0);
+  if (invert) {
+    normalized = -normalized;
+  }
+  if (std::abs(normalized) < deadzone_) {
+    normalized = 0.0;
+  }
+  return normalized;
+}
+
+void UartJoyDriverComponent::fillDpadAxes(uint8_t dpad_value,
+                                          sensor_msgs::msg::Joy& joy_msg) const {
+  double horizontal = 0.0;
+  double vertical = 0.0;
+
+  switch (dpad_value) {
+    case 1:
+      vertical = 1.0;
+      break;
+    case 2:
+      horizontal = 1.0;
+      vertical = 1.0;
+      break;
+    case 3:
+      horizontal = 1.0;
+      break;
+    case 4:
+      horizontal = 1.0;
+      vertical = -1.0;
+      break;
+    case 5:
+      vertical = -1.0;
+      break;
+    case 6:
+      horizontal = -1.0;
+      vertical = -1.0;
+      break;
+    case 7:
+      horizontal = -1.0;
+      break;
+    case 8:
+      horizontal = -1.0;
+      vertical = 1.0;
+      break;
+    default:
+      break;
+  }
+
+  joy_msg.axes[6] = static_cast<float>(horizontal);
+  joy_msg.axes[7] = static_cast<float>(vertical);
+}
+
+void UartJoyDriverComponent::publishNeutralJoy() {
+  sensor_msgs::msg::Joy neutral_msg;
+  neutral_msg.header.stamp = this->now();
+  neutral_msg.axes.assign(kJoyAxisCount, 0.0F);
+  neutral_msg.buttons.assign(kJoyButtonCount, 0);
+  filtered_axes_.assign(kJoyAxisCount, 0.0F);
+  filtered_buttons_.assign(kJoyButtonCount, 0);
+  axis_release_counts_.assign(kJoyAxisCount, 0);
+  button_release_counts_.assign(kJoyButtonCount, 0);
+  last_valid_joy_msg_ = neutral_msg;
+  joy_pub_->publish(neutral_msg);
+
+  RCLCPP_WARN(this->get_logger(), "UART入力がタイムアウトしたため、ニュートラルJoyを送信しました");
 }
 
 }  // namespace uart_joy_driver


### PR DESCRIPTION
## Summary

- add `uart_joy_driver` to parse UART controller input on Raspberry Pi 5
- convert Switch2 raw input into DualShock-compatible `/joy`
- publish stable `/joy` at 50 Hz while keeping raw UART input on `/joy_raw_uart`
- fix control-path integration for roller, shot, tilt, turning, and driving
- separate drive and roller status topics to avoid topic collision
- update launch/config files for the current robot setup

## Why

The previous UART path was not stable enough for downstream ROS2 control nodes.

Main issues were:
- raw UART input arrived at about 5 Hz
- downstream nodes expected DualShock-style `/joy`
- some controls such as roller/fire did not map correctly from the UART controller

This PR makes the UART controller behave like the existing `/joy` input expected by the rest of the system.

## Changes

- implement ASCII UART frame parsing in `uart_joy_driver`
- add raw topic `/joy_raw_uart` for debugging
- add filtered/remapped `/joy` output at 50 Hz
- remap Switch2 controls to existing downstream expectations
  - `ZR -> buttons[3]` for roller
  - `R -> buttons[0]` for shot
  - `L/ZL -> axes[7]` for tilt
- adjust related configs and launch files
- split motor status topics into:
  - `/roller_motor_status`
  - `/drive_motor_status`

## Verification

### Build
- `colcon build --packages-select uart_joy_driver joy_controller esc_motor_control_cpp questix_launcher --symlink-install`

### Hardware / rosbag checks
Verified on Raspberry Pi 5 with UART controller input:
- `/joy` is published stably at 50 Hz
- roller control works from `ZR`
- shot trigger works from remapped button input
- tilt up/down commands are delivered correctly
- turning and forward/backward movement are stable
- rosbag analysis confirmed expected behavior on:
  - `/joy`
  - `/joy_raw_uart`
  - `/target_twist`
  - `/roller_motor_status`
  - `/drive_motor_status`
