### PR TITLE
fix: update Python dependency installation to use pipx for pyserial

### DIFF
--- a/.github/workflows/ros2-build-test.yaml
+++ b/.github/workflows/ros2-build-test.yaml
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Install Python dependencies
-        run: pip3 install pyserial
+        run: pipx install pyserial
 
       - name: Setup colcon mixin
         run: |


### PR DESCRIPTION
ros2-buildのCIがfailするため、pipx に変更