### PR TITLE
feat: update robot setup and enable UART interface support

### DIFF
--- a/ansible/playbooks/vars/setup_kit_vars.yaml
+++ b/ansible/playbooks/vars/setup_kit_vars.yaml
@@ -33,7 +33,7 @@ ros2_additional_packages:
 ros_domain_id: 42
 
 # Workspace path
-workspace_path: /home/{{ ansible_user | default(ansible_env.SUDO_USER) }}/robot_ws
+workspace_path: /home/{{ ansible_user | default(ansible_env.SUDO_USER) }}/questix
 
 # Hardware interface settings
 enable_i2c: true

--- a/ansible/roles/hardware_interfaces/defaults/main.yaml
+++ b/ansible/roles/hardware_interfaces/defaults/main.yaml
@@ -6,4 +6,5 @@ udev_rules_path: /etc/udev/rules.d/99-robot-hardware.rules
 
 enable_i2c: true
 enable_spi: true
+enable_uart: true
 configure_udev_rules: true

--- a/ansible/roles/hardware_interfaces/tasks/main.yaml
+++ b/ansible/roles/hardware_interfaces/tasks/main.yaml
@@ -19,6 +19,32 @@
   notify: reboot_required
   when: enable_spi | bool
 
+- name: Enable UART interface
+  ansible.builtin.lineinfile:
+    path: "{{ boot_config_path }}"
+    regexp: "^#?enable_uart="
+    line: "enable_uart=1"
+    state: present
+  notify: reboot_required
+  when: enable_uart | bool
+
+- name: Enable UART overlay for Raspberry Pi 5
+  ansible.builtin.lineinfile:
+    path: "{{ boot_config_path }}"
+    regexp: "^#?dtoverlay=uart0-pi5"
+    line: "dtoverlay=uart0-pi5"
+    state: present
+  notify: reboot_required
+  when: enable_uart | bool
+
+- name: Disable serial console on UART (remove console=serial0 from cmdline)
+  ansible.builtin.replace:
+    path: /boot/firmware/cmdline.txt
+    regexp: 'console=serial0,\d+ '
+    replace: ''
+  notify: reboot_required
+  when: enable_uart | bool
+
 - name: Create udev rules for common robotics hardware
   ansible.builtin.copy:
     content: |

--- a/ansible/roles/raspberry_pi_setup/tasks/main.yaml
+++ b/ansible/roles/raspberry_pi_setup/tasks/main.yaml
@@ -24,6 +24,10 @@
       - libraspberrypi-bin
       - libserial-dev
       - libgpiod-dev
+      - libpigpio-dev
+      - gpiod
+      - liblgpio-dev
+      - liblgpio1
     state: present
     update_cache: true
 

--- a/ansible/roles/robot_autostart/tasks/main.yaml
+++ b/ansible/roles/robot_autostart/tasks/main.yaml
@@ -58,15 +58,8 @@
     enabled: true
     daemon_reload: true
 
-- name: Deploy polkit rules for passwordless service management (legacy .pkla, Ubuntu 22.04)
-  ansible.builtin.copy:
-    src: 50-questix-robot.pkla
-    dest: /etc/polkit-1/localauthority/50-local.d/50-questix-robot.pkla
-    owner: root
-    group: root
-    mode: "0644"
-
-- name: Deploy polkit rules for passwordless service management (.rules, Ubuntu 24.04+)
+- name: Deploy polkit rules for passwordless service management (.rules, Ubuntu
+    24.04+)
   ansible.builtin.template:
     src: 50-questix-robot.rules.j2
     dest: /etc/polkit-1/rules.d/50-questix-robot.rules
@@ -77,4 +70,3 @@
 # Robot Manager Web UI (optional, skip by default)
 - name: Install robot-manager Web UI
   ansible.builtin.include_tasks: robot_manager.yaml
-  when: install_robot_manager | bool

--- a/ansible/roles/robot_autostart/tasks/robot_manager.yaml
+++ b/ansible/roles/robot_autostart/tasks/robot_manager.yaml
@@ -9,11 +9,41 @@
     state: present
     update_cache: true
 
-- name: Install robot-manager from private repository
+- name: Copy robot-manager source to target
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../scripts/robot_manager/"
+    dest: /tmp/robot_manager_pkg/robot_manager/
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Create pyproject.toml for robot-manager
+  ansible.builtin.copy:
+    content: |
+      [build-system]
+      requires = ["setuptools"]
+      build-backend = "setuptools.build_meta"
+
+      [project]
+      name = "robot_manager"
+      version = "0.1.0"
+      dependencies = ["fastapi", "uvicorn[standard]"]
+
+      [tool.setuptools.packages.find]
+      where = ["."]
+
+      [tool.setuptools.package-data]
+      robot_manager = ["static/*", "static/**/*"]
+    dest: /tmp/robot_manager_pkg/pyproject.toml
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Install robot-manager from local scripts directory
   ansible.builtin.pip:
-    name: "{{ robot_manager_repo }}@{{ robot_manager_version }}"
-    state: present
-    extra_args: "--break-system-packages"
+    name: /tmp/robot_manager_pkg
+    extra_args: "--break-system-packages --ignore-installed"
+    executable: pip3
 
 - name: Deploy questix_robot_manager systemd service
   ansible.builtin.template:

--- a/scripts/install-robot-manager.sh
+++ b/scripts/install-robot-manager.sh
@@ -107,10 +107,11 @@ if [ "${INSTALL_GUI}" = true ]; then
   # Install dependencies
   apt-get install -y -qq python3-pip > /dev/null 2>&1 || true
 
-  # Copy source and pip install
+  # Copy source and pip install (force non-editable to override any prior editable installs)
   cp -r "${REPO_DIR}/scripts/robot_manager" /opt/questix_robot/robot_manager
   cp "${REPO_DIR}/scripts/setup.py" /opt/questix_robot/setup.py
-  pip3 install /opt/questix_robot --break-system-packages --ignore-installed -q
+  pip3 uninstall robot-manager -y -q 2>/dev/null || true
+  pip3 install /opt/questix_robot --break-system-packages -q
 
   # Install manager service
   sed \


### PR DESCRIPTION
# description
This pull request introduces several improvements and updates to the Ansible playbooks and related scripts for robot setup, focusing on enhanced hardware interface support, improved installation methods for the robot-manager, and some configuration cleanups. The most significant changes are grouped below by theme.

**Hardware Interface Enhancements:**

* Added UART support: The UART interface is now enabled by default (`enable_uart: true`), with tasks to configure UART in the boot config, apply the Raspberry Pi 5 UART overlay, and disable the serial console on UART. This ensures UART is correctly set up for supported hardware. [[1]](diffhunk://#diff-bb1d25aa625fe4576c2819a0552d49f1fc53cd6f856c9c010f1f0f5dbe7286f2R9) [[2]](diffhunk://#diff-6ef5bb6a814c55aea2bf86d37410bee2129288c4375a2b88ff44cb03a4c4a3c9R22-R47)
* Expanded hardware-related package installation: Additional GPIO and pigpio-related libraries (`libpigpio-dev`, `gpiod`, `liblgpio-dev`, `liblgpio1`) are now installed, improving hardware compatibility.

**Robot Manager Installation Improvements:**

* Switched robot-manager installation to use a local source copy: Instead of installing from a private repository, the playbook now copies the `robot_manager` source from the scripts directory, generates a `pyproject.toml`, and installs via pip. This makes the installation process more robust and independent of external repositories.
* Updated the shell script install to force a non-editable pip install and ensure any previous editable installs are removed, preventing conflicts and ensuring a clean installation.

**Configuration and Cleanup:**

* Changed the default `workspace_path` to `/home/<user>/questix` to better reflect the project structure.
* Removed legacy `.pkla` polkit rule deployment, standardizing on the `.rules` format for Ubuntu 24.04+ and simplifying service management permissions.
* The robot-manager Web UI installation task is now always included, regardless of the `install_robot_manager` variable, ensuring consistent deployment behavior.

# test
real robot setting finished and ros2 launch questix_core.launch.xml

