### PR TITLE
Replace libpigpio-dev with libpigpio-if-dev

### DIFF
--- a/ansible/roles/raspberry_pi_setup/tasks/main.yaml
+++ b/ansible/roles/raspberry_pi_setup/tasks/main.yaml
@@ -24,7 +24,7 @@
       - libraspberrypi-bin
       - libserial-dev
       - libgpiod-dev
-      - libpigpio-dev
+      - libpigpio-if-dev
       - gpiod
       - liblgpio-dev
       - liblgpio1


### PR DESCRIPTION
# description
library名ミスを修正。
# test
installできることを確認済み