### PR TITLE
ci: align ISO workflow with Ubuntu 24.04 and ROS 2 Jazzy

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -2,32 +2,6 @@ name: Build ROS2 Robotics Kit ISO
 
 on:
   workflow_dispatch:
-    inputs:
-      ros2_distro:
-        description: "ROS2 Distribution"
-        required: true
-        default: "jazzy"
-        type: choice
-        options:
-          - humble
-          - iron
-          - jazzy
-      ubuntu_version:
-        description: "Ubuntu Version"
-        required: true
-        default: "24.04"
-        type: choice
-        options:
-          - "22.04"
-          - "24.04"
-      architecture:
-        description: "Target Architecture"
-        required: true
-        default: "arm64"
-        type: choice
-        options:
-          - arm64
-          - amd64
 
 env:
   ISO_NAME: ros2-robotics-kit
@@ -39,11 +13,15 @@ jobs:
     name: Build Custom Ubuntu ISO
     runs-on: ubuntu-latest
     strategy:
+      # Current baseline: Ubuntu 24.04 + ROS 2 Jazzy for AMD64 and ARM64.
+      # Future baseline example: Ubuntu 26.04 + ROS 2 Lyrical.
+      # When upgrading, update this matrix, the test-iso artifact name,
+      # release notes, and README together.
       matrix:
         include:
           - architecture: amd64
-            ubuntu_version: "22.04"
-            ros2_distro: humble
+            ubuntu_version: "24.04"
+            ros2_distro: jazzy
           - architecture: arm64
             ubuntu_version: "24.04"
             ros2_distro: jazzy
@@ -134,7 +112,7 @@ jobs:
       - name: Download ISO artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ISO_NAME }}-${{ matrix.architecture }}-ubuntu22.04-ros2humble
+          name: ${{ env.ISO_NAME }}-${{ matrix.architecture }}-ubuntu24.04-ros2jazzy
 
       - name: Install QEMU
         run: |
@@ -169,11 +147,11 @@ jobs:
           This release contains custom Ubuntu ISO images pre-configured with ROS2 for robotics development.
 
           ## Images included:
-          - Ubuntu 22.04 ARM64 with ROS2 Humble (Raspberry Pi 5 optimized)
-          - Ubuntu 22.04 AMD64 with ROS2 Humble (Development machines)
+          - Ubuntu 24.04 ARM64 with ROS2 Jazzy (Raspberry Pi 5 optimized)
+          - Ubuntu 24.04 AMD64 with ROS2 Jazzy (Development machines)
 
           ## Features:
-          - Pre-installed ROS2 Humble Desktop
+          - Pre-installed ROS2 Jazzy Desktop
           - Robotics development tools
           - GPIO/I2C/SPI support (ARM64)
           - Pre-configured workspaces

--- a/README.md
+++ b/README.md
@@ -133,27 +133,31 @@ ros2_additional_packages:
 
 ### Automated Builds
 
-The GitHub Actions workflow automatically:
+The ISO build workflow is manual-only and runs when manually dispatched via GitHub Actions.
+When started, it:
 
-1. ✅ Validates Ansible playbooks
-2. 🏗️ Builds ISOs for both architectures
-3. 🧪 Tests ISO integrity
-4. 📦 Creates GitHub releases
-5. 🔐 Generates checksums
+1. 🏗️ Builds Ubuntu 24.04 + ROS 2 Jazzy ISOs for AMD64 and ARM64
+2. 🧪 Tests the AMD64 ISO boot path in QEMU
+3. 📦 Uploads ISO artifacts
+4. 🔐 Generates checksums
+
+Baseline upgrade note: the current workflow builds Ubuntu 24.04 + ROS 2 Jazzy
+for both AMD64 and ARM64. A future move to Ubuntu 26.04 + ROS 2 Lyrical should
+update the workflow matrix, ISO artifact names, release notes, dependency
+compatibility notes, and this README together. This PR does not change the
+baseline to Lyrical.
+
+The release job is present but disabled; manual dispatch does not publish GitHub releases.
 
 ### Triggers
 
-- **Push to main/develop**: Build and test
-- **Tags (v*)**: Build and create release
-- **Manual dispatch**: Custom parameters
-- **Pull requests**: Validation only
+- **Manual dispatch**: Build and test ISO artifacts
 
 ### Manual Trigger
 
 ```bash
 # Trigger manual build via GitHub CLI
-gh workflow run build-iso.yml \
-  --field architecture=arm64
+gh workflow run build-iso.yml
 ```
 
 ## 🧪 Testing
@@ -238,10 +242,9 @@ workspace. They are source/workspace dependencies, not apt packages:
 - `esc_motor_control`
 - `ddt_motor_control`
 
-`dependency.repos` currently references `ydlidar_ros2_driver` with `version: humble`.
-For Jazzy operation, confirm that the selected branch or tag is compatible with ROS 2
-Jazzy before using it. A successful `vcs import` only confirms that the repository was
-fetched; it does not guarantee runtime behavior.
+For Jazzy operation, confirm that each selected branch or tag in `dependency.repos`
+is compatible with ROS 2 Jazzy before using it. A successful `vcs import` only
+confirms that the repositories were fetched; it does not guarantee runtime behavior.
 
 ### Runtime (Generated ISOs)
 


### PR DESCRIPTION
## 概要

この PR では、ISO ビルド用の README 記述と GitHub Actions workflow を、現在の基準である **Ubuntu 24.04 + ROS 2 Jazzy** に合わせます。

主な変更点は次の通りです。

* ISO build matrix を AMD64 / ARM64 ともに Ubuntu 24.04 + ROS 2 Jazzy に統一
* 古い AMD64 向け Ubuntu 22.04 / ROS 2 Humble の artifact 名・release notes 記述を更新
* README の GitHub Actions 説明を、実際の workflow に合わせて manual-only として整理
* 将来 Ubuntu 26.04 + ROS 2 Lyrical へ baseline を上げる場合に、workflow matrix / artifact 名 / release notes / dependency compatibility notes / README をまとめて更新する必要があることを明記

## 変更ファイル

* `README.md`
* `.github/workflows/build-iso.yml`

## 検証

実施した確認:

* `git diff -- README.md .github/workflows/build-iso.yml`
* `git diff --check`
* README / workflow 内の古い Ubuntu 22.04 / ROS 2 Humble 参照の検索
* `yamllint .github/workflows/build-iso.yml`

結果:

* README / workflow 内の古い Ubuntu 22.04 / ROS 2 Humble 参照は解消済み
* `yamllint` は exit code 0
* 既存の warning として document start `---` 欠落と長い行の警告あり

## 実行していないこと

この PR では次を実行していません。

* ISO build
* QEMU test
* Ansible playbook 実行
* package install
* systemd 操作
