### PR TITLE
ci: fix ansible lint validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ UBUNTU_VERSION_AMD64 ?= 24.04
 UBUNTU_VERSION_ARM64 ?= 24.04
 ROS2_DISTRO_AMD64 ?= jazzy
 ROS2_DISTRO_ARM64 ?= jazzy
+export ANSIBLE_ROLES_PATH ?= $(CURDIR)/ansible/roles
 
 help: ## Show this help message
 	@echo "ROS2 Robotics Kit ISO Builder"
@@ -49,10 +50,10 @@ setup-deps: ## Install build dependencies
 test-ansible: ## Test and validate Ansible playbooks
 	@echo "🧪 Testing Ansible playbooks..."
 	yamllint ansible/
-	cd ansible && ansible-lint playbooks/setup_dev.yaml
-	cd ansible && ansible-lint playbooks/setup_kit.yaml
-	cd ansible && ansible-playbook --syntax-check playbooks/setup_dev.yaml
-	cd ansible && ansible-playbook --syntax-check playbooks/setup_kit.yaml
+	ansible-lint -c .ansible-lint.yml ansible/playbooks/setup_dev.yaml
+	ansible-lint -c .ansible-lint.yml ansible/playbooks/setup_kit.yaml
+	ansible-playbook --syntax-check -i localhost, ansible/playbooks/setup_dev.yaml
+	ansible-playbook --syntax-check -i localhost, ansible/playbooks/setup_kit.yaml
 	@echo "✅ Ansible playbooks validated"
 
 build-dev: test-ansible ## Build development ISO (AMD64)

--- a/ansible/roles/display_settings/meta/main.yaml
+++ b/ansible/roles/display_settings/meta/main.yaml
@@ -9,7 +9,8 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - jammy
-        - noble
+        # ansible-lint's bundled Galaxy schema does not yet include noble.
+        # The kit playbook still enforces Ubuntu 24.04 before applying this role.
+        - all
 
 dependencies: []

--- a/ansible/roles/hardware_interfaces/meta/main.yaml
+++ b/ansible/roles/hardware_interfaces/meta/main.yaml
@@ -9,7 +9,8 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - jammy
-        - noble
+        # ansible-lint's bundled Galaxy schema does not yet include noble.
+        # The kit playbook still enforces Ubuntu 24.04 before applying this role.
+        - all
 
 dependencies: []

--- a/ansible/roles/raspberry_pi_setup/meta/main.yaml
+++ b/ansible/roles/raspberry_pi_setup/meta/main.yaml
@@ -9,7 +9,8 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - jammy
-        - noble
+        # ansible-lint's bundled Galaxy schema does not yet include noble.
+        # The kit playbook still enforces Ubuntu 24.04 before applying this role.
+        - all
 
 dependencies: []

--- a/ansible/roles/robotics_workspace/meta/main.yaml
+++ b/ansible/roles/robotics_workspace/meta/main.yaml
@@ -9,7 +9,8 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - jammy
-        - noble
+        # ansible-lint's bundled Galaxy schema does not yet include noble.
+        # The kit playbook still enforces Ubuntu 24.04 before applying this role.
+        - all
 
 dependencies: []

--- a/ansible/roles/ros2_installation/meta/main.yaml
+++ b/ansible/roles/ros2_installation/meta/main.yaml
@@ -8,7 +8,9 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - noble # 24.04
+        # ansible-lint's bundled Galaxy schema does not yet include noble.
+        # The playbooks still enforce Ubuntu 24.04 before applying this role.
+        - all
   galaxy_tags:
     - robotics
     - ros2

--- a/ansible/roles/ros2_installation/tasks/main.yaml
+++ b/ansible/roles/ros2_installation/tasks/main.yaml
@@ -12,7 +12,7 @@
 
 # System setup - Set locale
 - name: Check current locale
-  ansible.builtin.shell: locale
+  ansible.builtin.command: locale
   register: current_locale
   changed_when: false
 
@@ -30,7 +30,7 @@
   changed_when: false
 
 - name: Verify locale setting
-  ansible.builtin.shell: locale
+  ansible.builtin.command: locale
   register: locale_verification
   changed_when: false
 
@@ -47,7 +47,7 @@
   become: true
 
 - name: Enable universe repository
-  ansible.builtin.shell: sudo add-apt-repository universe -y
+  ansible.builtin.command: add-apt-repository universe -y
   become: true
   changed_when: false
 
@@ -59,20 +59,33 @@
   become: true
 
 - name: Get latest ros2-apt-source version
-  ansible.builtin.shell: |
-    curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}'
-  register: ros_apt_source_version
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest
+    return_content: true
+  register: ros_apt_source_release
   changed_when: false
+
+- name: Set ros2-apt-source version
+  ansible.builtin.set_fact:
+    ros_apt_source_version: "{{ ros_apt_source_release.json.tag_name }}"
+
+- name: Set ros2-apt-source package metadata
+  ansible.builtin.set_fact:
+    ros_apt_source_package_name: >-
+      ros2-apt-source_{{ ros_apt_source_version }}.{{ ansible_distribution_release }}_all.deb
+    ros_apt_source_download_base_url: >-
+      https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros_apt_source_version }}
 
 - name: Download ros2-apt-source package
-  ansible.builtin.shell: |
-    curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros_apt_source_version.stdout }}/ros2-apt-source_{{ ros_apt_source_version.stdout }}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
-  changed_when: false
+  ansible.builtin.get_url:
+    url: "{{ ros_apt_source_download_base_url }}/{{ ros_apt_source_package_name }}"
+    dest: /tmp/ros2-apt-source.deb
+    mode: "0644"
 
 - name: Install ros2-apt-source package
-  ansible.builtin.shell: sudo dpkg -i /tmp/ros2-apt-source.deb
+  ansible.builtin.apt:
+    deb: /tmp/ros2-apt-source.deb
   become: true
-  changed_when: false
 
 # Install ROS 2 packages
 - name: Update apt repository caches after setting up repositories
@@ -156,14 +169,15 @@
 
 # Initialize rosdep for workspace development
 - name: Initialize rosdep
-  ansible.builtin.shell: sudo rosdep init
+  ansible.builtin.command: rosdep init
   become: true
   register: rosdep_init_result
   failed_when: rosdep_init_result.rc != 0 and "already exists" not in rosdep_init_result.stderr
   changed_when: rosdep_init_result.rc == 0
 
 - name: Update rosdep
-  ansible.builtin.shell: rosdep update
+  ansible.builtin.command: rosdep update
+  become: false
   changed_when: false
 
 # Clean up temporary files


### PR DESCRIPTION
## 概要

この PR では、Ansible の検証コマンドが安定して実行できるようにし、既存の Ansible lint violation を最小限の変更で修正します。
PR #42 で Ubuntu 24.04 / ROS 2 Jazzy の baseline を README と ISO workflow に反映した後、その前提を変えずに Ansible validation 側を整備する変更です。

## 主な変更点

### `make test-ansible` の実行方法を整理

* `ANSIBLE_ROLES_PATH` を `Makefile` 側で export
* `ansible-lint` を repository root から実行
* root の `.ansible-lint.yml` を `-c .ansible-lint.yml` で明示
* `ansible-playbook --syntax-check` に `-i localhost,` を追加し、inventory 未指定 warning を抑制

これにより、`make test-ansible` が project-level の ansible-lint 設定を正しく読むようになります。

### Ansible role metadata の schema 対応

一部 role の `meta/main.yaml` で、ansible-lint の bundled Galaxy schema が Ubuntu `noble` をまだ受け付けないため、metadata 上は schema-valid な `versions: all` に変更しています。

ただし、実際の実行対象は playbook 側で Ubuntu 24.04 を assert するため、Ubuntu 24.04 / ROS 2 Jazzy baseline は変更していません。

### `ros2_installation` role の lint 修正

`ansible/roles/ros2_installation/tasks/main.yaml` で、shell/raw command に寄っていた処理を Ansible module 中心に整理しました。

主な変更は次の通りです。

* `shell: locale` を `command: locale` に変更
* GitHub API 取得を `curl | grep | awk` から `uri` + `set_fact` に変更
* `ros2-apt-source` のダウンロードを `get_url` に変更
* `.deb` のインストールを `dpkg -i` から `apt: deb:` に変更
* `rosdep init` を `command` 化
* `rosdep update` を `become: false` で実行

## 変更ファイル

* `Makefile`
* `ansible/roles/display_settings/meta/main.yaml`
* `ansible/roles/hardware_interfaces/meta/main.yaml`
* `ansible/roles/raspberry_pi_setup/meta/main.yaml`
* `ansible/roles/robotics_workspace/meta/main.yaml`
* `ansible/roles/ros2_installation/meta/main.yaml`
* `ansible/roles/ros2_installation/tasks/main.yaml`

## 検証

実施した確認:

* `git diff --check`
* `yamllint ansible/`
* sandbox-safe `make test-ansible`

結果:

* `git diff --check`: pass
* `yamllint ansible/`: exit 0

  * 既存の `ansible/roles/ros2_build/tasks/main.yaml` line-length warning 1件は残存
* 通常の `make test-ansible`: sandbox の `~/.ansible` 書き込み制限により失敗
* sandbox-safe `make test-ansible`: pass

  * dev / kit の `ansible-lint`: pass
  * dev / kit の `ansible-playbook --syntax-check`: pass

sandbox-safe 実行では、Ansible の home / cache / temp directory を workspace 内に向けて実行しました。

```bash
mkdir -p .ansible/tmp .cache
ANSIBLE_HOME="$PWD/.ansible" \
XDG_CACHE_HOME="$PWD/.cache" \
ANSIBLE_LOCAL_TEMP="$PWD/.ansible/tmp" \
ANSIBLE_REMOTE_TEMP="$PWD/.ansible/tmp" \
make test-ansible
```

ISO build、QEMU test、systemd 操作、hardware-facing command は実行していません。


補足:

* sandbox 環境では home directory への書き込み制限により通常の `make test-ansible` が失敗する場合があるため、必要に応じて `ANSIBLE_HOME` / `XDG_CACHE_HOME` / `ANSIBLE_LOCAL_TEMP` / `ANSIBLE_REMOTE_TEMP` を workspace 内に向けて実行しました。
* ISO build、QEMU test、systemd 操作、実機ハードウェア操作は実行していません。

## この PR で変更していないこと

この PR は Ansible validation 修正に限定しています。

以下は変更していません。

* README
* `.github/workflows/build-iso.yml`
* ROS 2 アプリケーションコード
* AGENTS.md / Copilot instructions
* ISO build 挙動
* release publishing
* systemd unit
* 実機ハードウェア設定

## 備考

この PR は Ubuntu 24.04 / ROS 2 Jazzy baseline を変更しません。
Ansible の lint / syntax-check を通しやすくし、今後の変更時に検証しやすくするための CI / validation 整備です。
