### PR TITLE
fix(launcher): restore fire_button default and add per-controller YAML profiles

### DIFF
--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.dualshock.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.dualshock.yaml
@@ -1,0 +1,28 @@
+esc_motor_control:
+  ros__parameters:
+    use_sim_time: false
+    joy_topic: "/joy"
+
+    pwm_pin: 13
+
+    min_pulse_width: 0
+    max_pulse_width: 2000
+    neutral_pulse_width: 1000
+
+    max_speed: 1.0
+    min_speed: -1.0
+
+    # Roller spin button / ローラー回転ボタン
+    # DualShock standard mapping: R2 = 7
+    full_speed_button: 7
+    full_speed_value: 1.0
+
+    status_topic: "/roller_motor_status"
+    emergency_status_topic: "/roller_emergency_status"
+
+    enable_safety_stop: true
+    safety_timeout: 1.0
+
+    test_mode: false
+    pwm_backend: "auto"
+    gpio_chip_num: 4

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.uart.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.uart.yaml
@@ -1,0 +1,28 @@
+esc_motor_control:
+  ros__parameters:
+    use_sim_time: false
+    joy_topic: "/joy"
+
+    pwm_pin: 13
+
+    min_pulse_width: 0
+    max_pulse_width: 2000
+    neutral_pulse_width: 1000
+
+    max_speed: 1.0
+    min_speed: -1.0
+
+    # Roller spin button / ローラー回転ボタン
+    # Switch2 (uart_joy_driver) native index: ZR = 7
+    full_speed_button: 7
+    full_speed_value: 1.0
+
+    status_topic: "/roller_motor_status"
+    emergency_status_topic: "/roller_emergency_status"
+
+    enable_safety_stop: true
+    safety_timeout: 1.0
+
+    test_mode: false
+    pwm_backend: "auto"
+    gpio_chip_num: 4

--- a/launcher/launch/questix_core.launch.xml
+++ b/launcher/launch/questix_core.launch.xml
@@ -12,6 +12,7 @@
   <group if="$(var enable_shot)">
     <include file="$(find-pkg-share questix_launcher)/launch/shot_component.launch.xml">
       <arg name="enable_gpio_ref" value="$(var enable_gpio_ref)"/>
+      <arg name="controller_type" value="$(var controller_type)"/>
     </include>
   </group>
 

--- a/launcher/launch/shot_component.launch.xml
+++ b/launcher/launch/shot_component.launch.xml
@@ -1,9 +1,18 @@
 <launch>
   <!-- Launch Arguments -->
-
-  <arg name="shot_config_file" default="$(find-pkg-share motor_control_app)/config/shot_config.yaml" description="Configuration file path" />
+  <arg name="controller_type" default="dualshock" description="Controller type: dualshock or uart" />
   <arg name="enable_gpio_ref" default="false" description="Enable GPIO reference system (gpio_reader + joy_gate)" />
   <arg name="use_sim_time" default="false" description="Use simulation time" />
+
+  <!-- Per-controller YAML profiles (auto-selected from controller_type).
+       Override shot_config_file / esc_config_file to bypass selection. -->
+  <arg name="shot_config_file"
+       default="$(find-pkg-share motor_control_app)/config/shot_config.$(var controller_type).yaml"
+       description="Shot component YAML (defaults to controller-specific profile)" />
+  <arg name="esc_config_file"
+       default="$(find-pkg-share esc_motor_control_cpp)/config/esc_motor_control_cpp.$(var controller_type).yaml"
+       description="ESC motor control YAML (defaults to controller-specific profile)" />
+
   <!-- joy topic selection based on enable_gpio_ref -->
   <let name="joy_topic_name" value="/joy_gated" if="$(var enable_gpio_ref)" />
   <let name="joy_topic_name" value="/joy" unless="$(var enable_gpio_ref)" />
@@ -16,6 +25,7 @@
 
   <!-- ESC Motor Control (C++) -->
   <include file="$(find-pkg-share esc_motor_control_cpp)/launch/esc_motor_control_cpp.launch.xml">
+    <arg name="config_file" value="$(var esc_config_file)"/>
     <arg name="joy_topic" value="$(var joy_topic_name)"/>
   </include>
 </launch>

--- a/motor_control_app/config/shot_config.dualshock.yaml
+++ b/motor_control_app/config/shot_config.dualshock.yaml
@@ -1,0 +1,22 @@
+shot_component:
+  ros__parameters:
+    # Joy input topic
+    joy_topic: "/joy"
+
+    port: "/dev/servo"
+    baudrate: 115200
+    pan_servo_id: 11
+    trigger_servo_id: 10
+    # Disc fire button / ディスク射出ボタン
+    # DualShock standard mapping: R1 = 5
+    fire_button: 5
+    fire_duration_ms: 300
+    # Pan input mode
+    # DualShock: D-pad vertical = axis 7 (joy_node)
+    pan_axis: 7
+    # DualShock: L1 = 4, L2 = 6
+    pan_up_button_index: 4
+    pan_down_button_index: 6
+    fire_angle: 145.0
+    home_angle: 245.0
+    pan_max_angle: 120.0

--- a/motor_control_app/config/shot_config.uart.yaml
+++ b/motor_control_app/config/shot_config.uart.yaml
@@ -1,0 +1,22 @@
+shot_component:
+  ros__parameters:
+    # Joy input topic
+    joy_topic: "/joy"
+
+    port: "/dev/servo"
+    baudrate: 115200
+    pan_servo_id: 11
+    trigger_servo_id: 10
+    # Disc fire button / ディスク射出ボタン
+    # Switch2 (uart_joy_driver) native index: R = 5
+    fire_button: 5
+    fire_duration_ms: 300
+    # Pan input mode
+    # Switch2: D-pad vertical = axis 7
+    pan_axis: 7
+    # Switch2 native indices: L = 4 (up), ZL = 6 (down)
+    pan_up_button_index: 4
+    pan_down_button_index: 6
+    fire_angle: 145.0
+    home_angle: 245.0
+    pan_max_angle: 120.0

--- a/motor_control_app/config/shot_config.yaml
+++ b/motor_control_app/config/shot_config.yaml
@@ -8,8 +8,8 @@ shot_component:
     pan_servo_id: 11
     trigger_servo_id: 10
     # Disc fire button / ディスク射出ボタン
-    # Switch2 native index: R button = 5
-    fire_button: 0
+    # Switch2 (uart) native index: R = 5 / DualShock: R1 = 5
+    fire_button: 5
     fire_duration_ms: 300 # 射撃持続時間（ミリ秒）
     # Pan input mode / パン入力モード
     # - pan_axis >= 0 : use that analog axis (e.g. D-pad vertical = 7).


### PR DESCRIPTION
## Problem

`shot_config.yaml` had `fire_button: 0` but the value was historically overridden by `shot_component.launch.py` argument default of 5. After the parameter-unification refactor (#45) removed that override, the YAML's `0` became the effective binding (DualShock X / Switch2 B) — pressing A triggered shot, R did not.

## Fix
- Restore `fire_button: 5` in `shot_config.yaml` (Switch2 R / DualShock R1).
- Add per-controller profiles:
  - `motor_control_app/config/shot_config.{dualshock,uart}.yaml`
  - `esc_motor_control_cpp/config/esc_motor_control_cpp.{dualshock,uart}.yaml`
- `launcher/launch/shot_component.launch.xml`: accept `controller_type` and auto-select `shot_config_file` / `esc_config_file` per controller. Both can still be overridden manually.
- `launcher/launch/questix_core.launch.xml`: forward `controller_type` to shot include.

## Verification
- colcon build OK for motor_control_app / esc_motor_control_cpp / questix_launcher.
- YAML structure check OK (all 6 files validate).
- Both `*.dualshock.yaml` and `*.uart.yaml` installed to `install/share`.