### PR TITLE
docs: add AI agent guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# Copilot Instructions for QUESTiX
+
+## Precedence
+
+- Follow `AGENTS.md` first when it exists.
+- Use this file as lightweight Copilot completion guidance.
+- When instructions conflict, prefer the more specific file for the edited path.
+
+## Baseline
+
+- Target Ubuntu 24.04 LTS and ROS 2 Jazzy.
+- Use C++17 unless an existing package explicitly specifies a different standard.
+- Keep AMD64 development and ARM64 Raspberry Pi 5 robotics-kit assumptions aligned unless the user explicitly requests otherwise.
+
+## C++ / ROS 2 completions
+
+- Follow `.clang-format`.
+- Match existing `rclcpp` logging style, node names, topic names, parameter names, YAML, and launch conventions.
+- When changing ROS 2 packages, keep `package.xml`, `CMakeLists.txt`, component registration, launch files, config files, and runtime parameters consistent.
+
+## CMake / install guidance
+
+- Prefer the existing CMake style used by the package being edited.
+- For packages using `ament_cmake_auto`, confirm existing share-resource installation patterns such as `ament_auto_package(INSTALL_TO_SHARE launch config)` before changing them.
+- For packages not using that pattern, use the package's existing CMake style, such as `install(DIRECTORY launch config DESTINATION share/${PROJECT_NAME})`.
+
+## Launch and config completions
+
+- `launcher/launch/questix_core.launch.xml` is the integrated launch entry point.
+- The ROS package name for `launcher/` is `questix_launcher`.
+- Verify `find-pkg-share`, package names, launch arguments, YAML parameters, and systemd / robot_manager references together when changing launch or package paths.
+- Treat `ENABLE_LIDAR`, `ENABLE_SHOT`, `ENABLE_DRIVE`, `ENABLE_GPIO_REF`, `ENABLE_RVIZ`, and `CONTROLLER_TYPE` as launch-flow and robot-startup related variables.
+
+## High-caution areas
+
+- Do not generate broad edits to Ansible, shell scripts, systemd units, ISO build scripts, GPIO, UART, or robot startup behavior unless explicitly requested.
+- When completing code in these areas, preserve existing behavior and explain the expected validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Questix Agent Guide
+
+## Project overview
+
+- Questix is a repository for robot control and ISO image builds targeting ROS 2 Jazzy on Ubuntu 24.04.
+- The repository contains a mix of C++ ROS 2 packages, launch/config files, Ansible assets, systemd units, and the FastAPI-based `robot_manager`.
+
+## Environment baseline
+
+- AMD64 development environment: Ubuntu 24.04 + ROS 2 Jazzy.
+- ARM64 Raspberry Pi 5 robotics kit: Ubuntu 24.04 + ROS 2 Jazzy.
+- WSL and desktop environments are useful for reading, editing, static checks, and non-hardware tests.
+- Raspberry Pi 5 hardware validation is authoritative for GPIO, UART, I2C, SPI, systemd, robot startup, and controller integration.
+
+## Main directories
+
+- `motor_control_lib/`: Shared library for motor control.
+- `motor_control_app/`: ROS 2 nodes and components for drive, shot, single DDT, and related motor-control applications.
+- `joy_controller/`, `uart_joy_driver/`, `joy_gate/`, `gpio_reader/`: Input, gating, and GPIO-related packages.
+- `operation_manager/`: Operational state management.
+- `launcher/`: Integrated entry point for ROS launch files. The ROS package name is `questix_launcher`.
+- `description_launch/`: URDF, RViz, and xacro assets.
+- `ansible/`, `scripts/`, `systemd/`: OS setup, ISO build tooling, and resident services.
+- `scripts/robot_manager/`: FastAPI web management UI.
+
+## Pre-work checks
+
+- Always verify consistency across `package.xml`, `CMakeLists.txt`, `launch/`, and `config/` before and after changes.
+- Do not assume directory names always match ROS package names. For example, `launcher/` maps to the ROS package name `questix_launcher`.
+- Hardware-dependent code is likely impossible to validate fully without the physical robot or target hardware.
+
+## C++ / ROS 2 implementation policy
+
+- Use C++17 unless an existing package explicitly specifies a different standard.
+- Follow `.clang-format`.
+- Prefer `ament_cmake_auto` for ROS 2 packages.
+- For component implementations, keep `rclcpp_components_register_nodes` and `RCLCPP_COMPONENTS_REGISTER_NODE` entries consistent, including registration names and class names.
+- Update YAML parameters, launch arguments, and in-node `declare_parameter` / `get_parameter` usage together.
+
+## Command safety
+
+- Do not run ISO builds, QEMU tests, package installation, permission changes, systemd commands, or hardware-facing commands unless explicitly requested.
+- Do not run destructive commands such as `rm -rf`, broad `chmod`, or broad `chown`.
+- Explain the expected impact before changing Ansible, shell scripts, systemd units, UART/GPIO behavior, or ISO build behavior.
+- Treat `systemd/questix_robot*`, `scripts/build-iso.sh`, and `ansible/playbooks/*.yaml` with extra care because they can have significant effects on real hardware or the OS.
+
+## Validation commands
+
+The following commands are standard validation candidates. Whether they can run depends on the local environment, including ROS 2 availability, Ansible/lint tooling, hardware access, and OS permissions. Hardware-dependent behavior still requires real robot/Raspberry Pi validation.
+
+- `git diff --check`
+- `colcon build --symlink-install`
+- `colcon test`
+- For Ansible changes: `make test-ansible`
+- For Ansible/YAML changes: `yamllint ansible/`
+- For GitHub Actions changes: workflow YAML parse checks.
+
+## Cross-reference caution
+
+- When changing package names, launch-file references to `find-pkg-share`, or dependency package names, perform a cross-repository search and update all related references.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,12 @@
 The following commands are standard validation candidates. Whether they can run depends on the local environment, including ROS 2 availability, Ansible/lint tooling, hardware access, and OS permissions. Hardware-dependent behavior still requires real robot/Raspberry Pi validation.
 
 - `git diff --check`
-- `colcon build --symlink-install`
-- `colcon test`
+- `colcon build --symlink-install` (run from the workspace root)
+- `colcon test` (run from the workspace root)
 - For Ansible changes: `make test-ansible`
 - For Ansible/YAML changes: `yamllint ansible/`
-- For GitHub Actions changes: workflow YAML parse checks.
+- For GitHub Actions changes: `yamllint .github/workflows/` and `actionlint` if available.
 
 ## Cross-reference caution
 
-- When changing package names, launch-file references to `find-pkg-share`, or dependency package names, perform a cross-repository search and update all related references.
+- When changing package names, launch-file references to `find-pkg-share`, or dependency package names, perform a cross-package search within this repository and update all related references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+## Claude Code
+
+- Treat `AGENTS.md` as the primary project guidance.
+- Keep this file as a Claude-specific adapter, not a duplicate manual.
+- Use a plan/review-oriented workflow before broad edits.
+- Prefer small, reviewable changes with clear validation notes.
+- Do not run ISO builds, QEMU tests, package installation, permission changes, systemd commands, or hardware-facing commands unless explicitly requested.
+- For GPIO, UART, I2C, SPI, systemd, robot startup, and controller integration, treat Raspberry Pi 5 hardware validation as authoritative.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,5 +6,6 @@
 - Keep this file as a Claude-specific adapter, not a duplicate manual.
 - Use a plan/review-oriented workflow before broad edits.
 - Prefer small, reviewable changes with clear validation notes.
+<!-- Claude-specific emphasis: repeated from AGENTS.md to ensure these constraints are applied by Claude Code -->
 - Do not run ISO builds, QEMU tests, package installation, permission changes, systemd commands, or hardware-facing commands unless explicitly requested.
 - For GPIO, UART, I2C, SPI, systemd, robot startup, and controller integration, treat Raspberry Pi 5 hardware validation as authoritative.


### PR DESCRIPTION
## 概要

この PR は、AI coding agent 向けのガイドとして以下の3ファイルを追加します。

- `AGENTS.md`
- `.github/copilot-instructions.md`
- `CLAUDE.md`

## 背景

このリポジトリでは、ROS 2 launch、controller parameter、Ansible、systemd、GPIO/UART、ISO build など、AIエージェントが広範囲に変更すると実機動作や検証負荷に影響しやすい領域があります。

AI支援による変更を小さく、検証可能で、レビューしやすい形に誘導するため、共通ガイドとツール別adapterを追加します。

## 役割分担

### `AGENTS.md`

AI coding agent向けの共通ガイドです。

主に以下を整理します。

- Ubuntu 24.04 / ROS 2 Jazzy baseline
- AMD64 development environment と ARM64 Raspberry Pi 5 robotics kit の役割
- C++17 方針
- WSL/desktopで可能な確認と、Raspberry Pi 5実機で確認すべき領域の分離
- ISO build、QEMU、package install、systemd、GPIO/UART、robot startup などの高注意領域
- `git diff --check`、`colcon build --symlink-install`、`colcon test`、`make test-ansible` などの検証候補

### `.github/copilot-instructions.md`

GitHub Copilot向けの軽量adapterです。

`AGENTS.md` を優先することを明記しつつ、Copilot補完時に壊しやすい CMake / launch / config / parameter の注意点を短く整理します。

### `CLAUDE.md`

Claude Code向けの軽量adapterです。

`@AGENTS.md` で共通ガイドを読み込み、Claude Code向けの最小限の運用注意だけを追記します。

## 変更していないこと

この PR では以下を追加・変更していません。

- `GEMINI.md`
- `.gemini/settings.json`
- Antigravity-specific configuration
- README
- LICENSE
- Ansible
- workflows
- ROS 2 application code
- launch files
- config YAML
- systemd files
- shell scripts

## Google / Gemini / Antigravity について

Google / Gemini / Antigravity 系の repository instruction file は、現時点では追加しません。

Gemini CLI から Antigravity CLI への移行が進んでいるため、Antigravity側の repository-level instruction file のベストプラクティスが固まった時点で別途検討します。

## 検証

- `git diff --check`
- `AGENTS.md` / `.github/copilot-instructions.md` / `CLAUDE.md` の存在と行数確認
- `GEMINI.md` / `.gemini/settings.json` が追加されていないことを確認

## 未実施

ドキュメント追加のみのため、以下は実行していません。

- ROS 2 build
- Ansible playbook
- ISO build
- QEMU test
- systemd 操作
- GPIO / UART / controller 実機操作
