### PR TITLE
fix: mark desktop shortcut as trusted for GNOME to allow launching without manual permission

### DIFF
--- a/ansible/roles/robot_autostart/tasks/robot_manager.yaml
+++ b/ansible/roles/robot_autostart/tasks/robot_manager.yaml
@@ -80,3 +80,10 @@
     mode: "0755"
   become: false
   failed_when: false
+
+- name: Mark desktop shortcut as trusted (GNOME)
+  ansible.builtin.command:
+    cmd: gio set "/home/{{ target_user }}/Desktop/questix_robot_manager.desktop" metadata::trusted true
+  become: false
+  failed_when: false
+  changed_when: false

--- a/scripts/install-robot-manager.sh
+++ b/scripts/install-robot-manager.sh
@@ -130,6 +130,13 @@ if [ "${INSTALL_GUI}" = true ]; then
     install -o "${TARGET_USER}" -g "${TARGET_USER}" -m 0755 \
       "${REPO_DIR}/systemd/questix_robot_manager.desktop" "${DESKTOP_DIR}/"
     echo "  -> Desktop shortcut created"
+    # Mark as trusted so GNOME allows launching without manual permission grant
+    if command -v gio &>/dev/null; then
+      su -s /bin/bash -c \
+        "gio set '${DESKTOP_DIR}/questix_robot_manager.desktop' metadata::trusted true" \
+        "${TARGET_USER}" 2>/dev/null || true
+      echo "  -> Desktop shortcut marked as trusted"
+    fi
   fi
 else
   echo "[5/5] Skipping Robot Manager Web UI (use --with-gui to install)"


### PR DESCRIPTION
questix_robotmangerの実行権限を初回付与が手間なのでinstall.shするときに自動付与するように変更