### PR TITLE
fix: harden ansible setup validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project provides a complete automation pipeline using Ansible and GitHub Ac
 - **Target**: Desktop/laptop development machines
 - **OS**: Ubuntu 24.04 LTS with ROS2 Jazzy
 - **Tools**: Full desktop environment, development tools, ROS2 Desktop
-- **Workspace**: Pre-configured `~/ros2_ws`
+- **Workspace**: Shell aliases pre-configured for `~/ros2_ws`
 
 ### 🍓 Robotics Kit (ARM64 - Raspberry Pi 5)
 
@@ -23,9 +23,8 @@ This project provides a complete automation pipeline using Ansible and GitHub Ac
 
 ## 🚀 Quick Start
 
-There are two setup paths: the AMD64 development machine is configured locally,
-while the Raspberry Pi 5 (ARM64) robot is provisioned remotely with Ansible
-from that development machine.
+There are two local setup paths: run the AMD64 playbook on the development
+machine and run the ARM64 kit playbook on the Raspberry Pi 5 itself.
 
 ### 1. AMD64 Development Machine (local provisioning)
 
@@ -51,14 +50,15 @@ On an x86_64 machine running Ubuntu 24.04, run Ansible against `localhost`.
    bash setup_dev.sh
    ```
 
-   This installs ROS 2 Jazzy Desktop, colcon, developer tooling, and creates
-   `~/ros2_ws`.
+   This installs ROS 2 Jazzy Desktop, colcon, developer tooling, and configures
+   shell aliases for `~/ros2_ws`.
 
 4. **Fetch workspace dependencies and build**
 
    ```bash
-   mkdir -p src
-   vcs import src < dependency.repos
+   mkdir -p ~/ros2_ws/src
+   vcs import ~/ros2_ws/src < dependency.repos
+   cd ~/ros2_ws
    source /opt/ros/jazzy/setup.bash
    colcon build --symlink-install
    source install/setup.bash

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+# Repository-root config for local setup scripts and CI commands.
 roles_path = ansible/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 inventory = ansible/inventory.ini
 host_key_checking = False

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+# Copied into /tmp/ansible for chroot provisioning.
+roles_path = roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+inventory = inventory.ini
+host_key_checking = False
+retry_files_enabled = False
+gathering = smart
+fact_caching = memory

--- a/ansible/playbooks/setup_dev.yaml
+++ b/ansible/playbooks/setup_dev.yaml
@@ -26,6 +26,7 @@
       ansible.builtin.command: whoami
       register: conn_user_whoami
       become: false
+      check_mode: false
       changed_when: false
 
     - name: Set connection user fact
@@ -107,6 +108,7 @@
         line: "{{ item }}"
         state: present
         create: true
+        mode: "0644"
       become: false
       loop:
         - "# ROS2 Development Environment"

--- a/ansible/roles/robot_autostart/tasks/robot_manager.yaml
+++ b/ansible/roles/robot_autostart/tasks/robot_manager.yaml
@@ -84,6 +84,7 @@
 - name: Mark desktop shortcut as trusted (GNOME)
   ansible.builtin.command:
     cmd: gio set "/home/{{ target_user }}/Desktop/questix_robot_manager.desktop" metadata::trusted true
-  become: false
+  become: true
+  become_user: "{{ target_user }}"
   failed_when: false
   changed_when: false

--- a/ansible/roles/ros2_installation/tasks/main.yaml
+++ b/ansible/roles/ros2_installation/tasks/main.yaml
@@ -63,6 +63,7 @@
     url: https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest
     return_content: true
   register: ros_apt_source_release
+  check_mode: false
   changed_when: false
 
 - name: Set ros2-apt-source version

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,5 @@
-cd "$(dirname "$0")/ansible"
-ansible-playbook playbooks/setup_kit.yaml -i localhost, --connection=local --ask-become-pass
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+ansible-playbook ansible/playbooks/setup_kit.yaml -i localhost, --connection=local --ask-become-pass

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -1,1 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
 ansible-playbook ansible/playbooks/setup_dev.yaml -i localhost, --connection=local --ask-become-pass


### PR DESCRIPTION
## 概要

この PR は、Ansible / setup 周辺の小さな品質改善を upstream に反映します。

fork 側で upstream main 同期と AMD64 setup_dev 実機検証を行った際に見つかった、setup / validation / chroot provisioning まわりの改善点だけを最小差分で抽出しています。

## 変更内容

- chroot provisioning 用の `ansible/ansible.cfg` を維持し、`/tmp/ansible` にコピーされた場合でも sibling `roles/` を解決できるようにする
- Robot Manager の GNOME trusted shortcut 設定を `target_user` として実行する
- `.bashrc` を `lineinfile create: true` で作成する場合の `mode: "0644"` を明示する
- check mode 中でも読み取り専用の実行ユーザー取得 / release metadata取得が成立するようにする

## 変更していないこと

- AMD64 `setup_dev.yaml` の root/chroot実行対応は追加しない
- `setup_dev.yaml` は一般ユーザーが sudo/become 付きで実行する開発体験用 playbook として維持
- package install、systemd、GPIO/UART、ISO/QEMU 関連の挙動変更なし
- ROS 2 application code の変更なし

## 検証

- `git diff --check`
- `yamllint ansible/`
- `ansible-playbook ansible/playbooks/setup_kit.yaml --syntax-check -i localhost,`
- `ansible-playbook ansible/playbooks/setup_dev.yaml --syntax-check -i localhost,`
- `bash -n setup.sh setup_dev.sh scripts/install-robot-manager.sh scripts/apply-ansible-config.sh`
- sandbox-safe `make test-ansible`

## 未実施

- `setup.sh` / `setup_dev.sh` の本実行
- package installation
- systemd 操作
- GPIO / UART / 実機操作
- ISO build
- QEMU test

## check mode 対応について

`check_mode: false` は、読み取り専用の task に限定して追加しています。
- `whoami`: 実行ユーザー名を取得するだけで、対象環境を変更しません。
- GitHub API の `uri`: `ros2-apt-source` の release metadata を取得するだけで、対象環境を変更しません。

`get_url`、`apt`、package install など、ファイル作成やパッケージ導入を伴う task には `check_mode: false` を追加していません。そのため、check mode の安全境界は維持しています。

## 備考

fork側では AMD64 development environment に対して `setup_dev.sh` の実機実行検証を行い、一般ユーザー + sudo 実行経路が通ることを確認済みです。本PRでは upstream に必要な最小の修正のみを抽出しています。
