### PR TITLE
docs: add PR and Ansible validation guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,12 @@
 - Use C++17 unless an existing package explicitly specifies a different standard.
 - Keep AMD64 development and ARM64 Raspberry Pi 5 robotics-kit assumptions aligned unless the user explicitly requests otherwise.
 
+## Project naming
+
+- Use `QUESTiX` as the project name in prose and generated documentation.
+- Do not mechanically rename package names, paths, commands, URLs, environment variables, or code identifiers.
+- Preserve implementation identifiers such as `questix_launcher` unless explicitly asked to perform a code-level rename.
+
 ## Pull request titles
 
 - When creating or updating PRs, use Conventional Commits style titles.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,13 @@
 - Use C++17 unless an existing package explicitly specifies a different standard.
 - Keep AMD64 development and ARM64 Raspberry Pi 5 robotics-kit assumptions aligned unless the user explicitly requests otherwise.
 
+## Pull request titles
+
+- When creating or updating PRs, use Conventional Commits style titles.
+- Format: `<type>: <lowercase summary>`.
+- Prefer existing project types such as `fix`, `feat`, `docs`, `ci`, `chore`, `refactor`, and `test`.
+- Example: `fix: resolve recursive loop in setup_dev role vars`.
+
 ## C++ / ROS 2 completions
 
 - Follow `.clang-format`.
@@ -30,6 +37,13 @@
 - The ROS package name for `launcher/` is `questix_launcher`.
 - Verify `find-pkg-share`, package names, launch arguments, YAML parameters, and systemd / robot_manager references together when changing launch or package paths.
 - Treat `ENABLE_LIDAR`, `ENABLE_SHOT`, `ENABLE_DRIVE`, `ENABLE_GPIO_REF`, `ENABLE_RVIZ`, and `CONTROLLER_TYPE` as launch-flow and robot-startup related variables.
+
+## Ansible/setup completions
+
+- For Ansible or setup-script edits, preserve the execution boundary in `AGENTS.md`.
+- Do not weaken AMD64 `setup_dev.yaml` safeguards against `/root/ros2_ws` or `/root/.bashrc` unless explicitly requested.
+- Do not add `check_mode: false` to state-changing tasks such as package installation, downloads, systemd operations, or hardware-facing commands just to make check mode pass.
+- If touching `ansible.cfg`, preserve the distinction between repository-root config and copied chroot config.
 
 ## High-caution areas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,19 @@
 - Do not assume directory names always match ROS package names. For example, `launcher/` maps to the ROS package name `questix_launcher`.
 - Hardware-dependent code is likely impossible to validate fully without the physical robot or target hardware.
 
+## Pull request titles
+
+- Pull request titles must follow Conventional Commits because this repository runs a semantic pull request title check.
+- Use the format: `<type>: <lowercase summary>`.
+- Common types include `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, and `revert`.
+- Prefer concise summaries after the colon.
+- Examples:
+  - `fix: resolve recursive loop in setup_dev role vars`
+  - `ci: align ISO workflow with Ubuntu 24.04 and ROS 2 Jazzy`
+  - `docs: add AI agent guidance`
+  - `chore: sync upstream main through PR #56`
+- Before opening or updating a PR, ensure the title passes the semantic pull request check.
+
 ## C++ / ROS 2 implementation policy
 
 - Use C++17 unless an existing package explicitly specifies a different standard.
@@ -43,6 +56,47 @@
 - Do not run destructive commands such as `rm -rf`, broad `chmod`, or broad `chown`.
 - Explain the expected impact before changing Ansible, shell scripts, systemd units, UART/GPIO behavior, or ISO build behavior.
 - Treat `systemd/questix_robot*`, `scripts/build-iso.sh`, and `ansible/playbooks/*.yaml` with extra care because they can have significant effects on real hardware or the OS.
+
+## Ansible and setup validation
+
+- Treat Ansible, setup scripts, ISO provisioning, and robot startup as OS-impacting areas.
+- Separate static validation from state-changing validation.
+- Safe default validation candidates:
+  - `git diff --check`
+  - `yamllint ansible/`
+  - `ansible-playbook ansible/playbooks/setup_kit.yaml --syntax-check -i localhost,`
+  - `ansible-playbook ansible/playbooks/setup_dev.yaml --syntax-check -i localhost,`
+  - `bash -n setup.sh setup_dev.sh scripts/install-robot-manager.sh scripts/apply-ansible-config.sh`
+  - sandbox-safe `make test-ansible`
+- Do not run `setup.sh`, `setup_dev.sh`, package installation, systemd commands, GPIO/UART commands, ISO build, or QEMU unless explicitly requested.
+- If a real setup run is explicitly requested, record:
+  - branch and commit
+  - host OS and architecture
+  - execution user
+  - whether `/root/ros2_ws` or `/root/.bashrc` was accidentally touched
+  - ROS 2, colcon, rosdep, and vcs post-checks
+  - skipped hardware/system checks
+
+## Ansible check mode limits
+
+- Do not assume `ansible-playbook --check --diff` fully validates installer playbooks.
+- Check mode can skip modules that do not support it, and later tasks may fail if they depend on registered variables from skipped tasks.
+- `check_mode: false` is acceptable only for read-only discovery tasks that must run to provide registered variables, such as:
+  - `whoami`
+  - HTTP GET metadata lookups
+- Do not add `check_mode: false` to package installation, `get_url` downloads, file writes, systemd operations, GPIO/UART access, or other state-changing tasks just to make check mode pass.
+- `get_url` may validate the URL in check mode without downloading the file body; do not treat a later missing downloaded file as proof that the real run will fail.
+- When check mode reaches this kind of installer limitation, report it clearly and ask before proceeding to a real setup run.
+
+## AMD64 setup_dev execution boundary
+
+- `ansible/playbooks/setup_dev.yaml` is intended for an AMD64 development machine where a regular user runs the playbook with sudo/become.
+- Keep safeguards that prevent accidental `/root/ros2_ws` or `/root/.bashrc` configuration.
+- Do not weaken `/home/...` assertions to support root-driven local or chroot execution unless explicitly requested.
+- Treat AMD64 root/chroot provisioning as a separate ISO workflow design issue.
+- Keep repository-root `ansible.cfg` and copied-subtree `ansible/ansible.cfg` roles distinct:
+  - root `ansible.cfg`: repository-root local setup and CI commands
+  - `ansible/ansible.cfg`: copied into `/tmp/ansible` for chroot provisioning and should resolve sibling `roles/`
 
 ## Validation commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,16 @@
-# Questix Agent Guide
+# QUESTiX Agent Guide
 
 ## Project overview
 
-- Questix is a repository for robot control and ISO image builds targeting ROS 2 Jazzy on Ubuntu 24.04.
+- QUESTiX is a repository for robot control and ISO image builds targeting ROS 2 Jazzy on Ubuntu 24.04.
 - The repository contains a mix of C++ ROS 2 packages, launch/config files, Ansible assets, systemd units, and the FastAPI-based `robot_manager`.
+
+## Project naming and documentation style
+
+- Use `QUESTiX` as the project name in prose, headings, summaries, PR bodies, and generated documentation.
+- Do not mechanically rename repository names, package names, file paths, URLs, commands, service names, launch arguments, environment variables, or code identifiers.
+- Preserve existing lowercase identifiers such as `questix_launcher`, `questix_robot`, and repository/path names unless the user explicitly requests a code-level rename.
+- When generating documentation, distinguish between the product/project name `QUESTiX` and implementation identifiers such as package names or file paths.
 
 ## Environment baseline
 


### PR DESCRIPTION
## 概要

この PR は、AI agent 向け文書に PR title rule と Ansible/setup 検証時の注意点を追加します。

## 背景

このリポジトリでは `semantic-pull-request` check が有効であり、PR title が Conventional Commits 形式でない場合にCIが失敗します。

また、Ansible/setup 周辺の変更では、`setup_dev.yaml` の実行前提、`ansible.cfg` の役割分担、`--check --diff` の限界をAI agentが誤解すると、不要なroot/chroot対応や危険な `check_mode: false` を追加するおそれがあります。

## 変更内容

- `AGENTS.md`
  - PR title は Conventional Commits 形式にすることを明記
  - Ansible/setup 変更時の検証候補を整理
  - `--check --diff` はinstaller playbookの完全検証ではないことを明記
  - `check_mode: false` を許容できる範囲を読み取り専用taskに限定
  - AMD64 `setup_dev.yaml` は一般ユーザー + sudo/become 前提であることを明記
  - root用 `ansible.cfg` と chrootコピー用 `ansible/ansible.cfg` の役割分担を明記
  - `QUESTiX` を文書上の正式表記とし、package/path/code identifier は機械的に変更しない方針を追加
- `.github/copilot-instructions.md`
  - Copilot向けにPR titleとAnsible/setup補完時の短い注意を追加

## Skillsについて

今回の内容は、PR作成やAnsible/setup編集時に常時参照されるべきガードレールのため、まずは `AGENTS.md` と `.github/copilot-instructions.md` に入れます。

長い手順書になりやすい以下は、必要に応じて別PRでClaude project skills等として切り出す候補です。

- AMD64 setup_dev real-run validation
- Ansible check-mode failure triage
- upstream PR review checklist

## 変更していないこと

- `CLAUDE.md` は変更なし
  - `@AGENTS.md` を読み込むため、共通ルールは `AGENTS.md` 側で扱う
- `.claude/skills/` は追加なし
- README / Ansible / workflows / ROS 2 source / launch / config YAML / setup scripts は変更なし

## 検証

- `git diff --check`
- 対象Markdownファイルの存在と行数確認
