### PR TITLE
docs: add rosdep install step to AMD64 build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,33 @@ On an x86_64 machine running Ubuntu 24.04, run Ansible against `localhost`.
    mkdir -p src
    vcs import src < dependency.repos
    source /opt/ros/jazzy/setup.bash
+   rosdep update
+   rosdep install --from-paths . src --ignore-src -r -y
    colcon build --symlink-install
    source install/setup.bash
    ```
 
+   `rosdep install` resolves workspace package dependencies declared in
+   `package.xml` files. In the current tree, this includes packages such as
+   `libgpiod-dev`, `joint_state_publisher`, and `xacro`.
+
+   Known issue: `rosdep install` may report `questix_launcher: Cannot locate
+   rosdep definition for [servo_control_ros2]`. This package is listed as a
+   source/workspace dependency of `questix_launcher`, but it is not currently
+   included in `dependency.repos`. This does not block the observed AMD64 build,
+   but the dependency should be clarified separately before relying on
+   servo-related launch paths.
+
 5. **Verify**
 
    ```bash
-   ros2 --version
+   ros2 -h
+   printenv ROS_DISTRO
    ros2 topic list
    ```
+
+   `ros2 --version` is not used here because the ROS 2 CLI does not accept that
+   option in this environment.
 
 ### 2. Raspberry Pi 5 (ARM64) Setup (run on the Pi itself)
 


### PR DESCRIPTION
## 概要

この PR は、AMD64 development machine 向け README 手順に、workspace依存を解決する `rosdep install` 手順を追加します。

## 背景

Ubuntu 24.04 + ROS 2 Jazzy 環境で README 手順を検証したところ、`bash setup_dev.sh` は成功しましたが、その後の `colcon build --symlink-install` で `gpio_reader` が `gpiod.h` 不足により失敗しました。

`colcon build` 前に以下を追加すると、`libgpiod-dev` などの依存が導入され、最終的に `13 packages finished` でビルド成功しました。

```bash
rosdep update
rosdep install --from-paths . src --ignore-src -r -y
```

## 変更内容

* AMD64 build手順に `rosdep update` と `rosdep install --from-paths . src --ignore-src -r -y` を追加
* Verify手順の `ros2 --version` を削除し、以下に置き換え

  * `ros2 -h`
  * `printenv ROS_DISTRO`
  * `ros2 topic list`
* `servo_control_ros2` が `rosdep install` で未解決になる既知課題を注記

## 変更していないこと

* `dependency.repos` は変更なし
* `launcher/package.xml` は変更なし
* Ansible / setup scripts / workflows / ROS 2 source / launch / config YAML は変更なし
* `servo_control_ros2` の依存設計はこのPRでは解決しない

## 検証

実機検証済み:

* Ubuntu 24.04 / x86_64
* ROS 2 Jazzy
* `bash setup_dev.sh`: pass
* `rosdep install --from-paths . src --ignore-src -r -y`: resolvable dependencies installed
* `colcon build --symlink-install`: pass
* `Summary: 13 packages finished`
* `ros2 topic list`: `/parameter_events`, `/rosout`

ローカルPR検証:

* `git diff --check`

## 未実施

* `setup.sh` / `setup_dev.sh` の再実行
* package installationの再実行
* GPIO / UART / 実機ロボット操作
* systemd 操作
* ISO build
* QEMU test

## 備考

`servo_control_ros2` は `questix_launcher` のsource/workspace依存として残っていますが、現在の `dependency.repos` には含まれていません。この扱いは別Issueで確認します。
