### PR TITLE
fix: remove unnecessary dependency on servo_control_ros2 from package…

### DIFF
--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -22,7 +22,6 @@
     <exec_depend>ddt_motor_control</exec_depend>
     <exec_depend>esc_motor_control</exec_depend>
     <exec_depend>joy_controller</exec_depend>
-    <exec_depend>servo_control_ros2</exec_depend>
     <exec_depend>ydlidar_ros2_driver</exec_depend>
 
     <!-- Standard ROS2 packages -->


### PR DESCRIPTION
# description
https://github.com/scramble-robot/questix/issues/62
の対応PR
現在使っていない依存なら questix_launcher/package.xml やlaunch構成から外す
で削除

# test
rosdep install --from-paths . src --ignore-src -r -y
が通ること確認済み

colcon build --symlink-install:
が通るのを確認済み