### PR TITLE
fix: correct questix_launcher ESC dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,6 @@ On an x86_64 machine running Ubuntu 24.04, run Ansible against `localhost`.
    `package.xml` files. In the current tree, this includes packages such as
    `libgpiod-dev`, `joint_state_publisher`, and `xacro`.
 
-   Known issue: `rosdep install` may report `questix_launcher: Cannot locate
-   rosdep definition for [servo_control_ros2]`. This package is listed as a
-   source/workspace dependency of `questix_launcher`, but it is not currently
-   included in `dependency.repos`. This does not block the observed AMD64 build,
-   but the dependency should be clarified separately before relying on
-   servo-related launch paths.
-
 5. **Verify**
 
    ```bash
@@ -291,8 +284,7 @@ The launcher package expects the following packages to be available in the same 
 workspace. They are source/workspace dependencies, not apt packages:
 
 - `ydlidar_ros2_driver`
-- `servo_control_ros2`
-- `esc_motor_control`
+- `esc_motor_control_cpp`
 - `ddt_motor_control`
 
 For Jazzy operation, confirm that each selected branch or tag in `dependency.repos`

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -15,8 +15,7 @@ Questixシステムの各ノードを起動するためのlauncherファイル�
 ### 各パッケージ用launchファイル
 
 - `joy_controller/launch/joy_controller.launch.xml` - ジョイスティックコントローラ
-- `esc_motor_control/launch/esc_motor_control.launch.xml` - ESCモータコントローラ  
-- `servo_control_ros2/launch/servo_launch.xml` - サーボコントローラ
+- `esc_motor_control_cpp/launch/esc_motor_control_cpp.launch.xml` - ESCモータコントローラ
 - `ydlidar_ros2_driver/launch/ydlidar_launch.xml` - YDLiDAR
 - `ydlidar_ros2_driver/launch/ydlidar_launch_view.xml` - YDLiDAR + RViz
 
@@ -26,8 +25,7 @@ Questixシステムの各ノードを起動するためのlauncherファイル�
 これらはaptで入る依存ではなく、source/workspace依存です。
 
 - `ydlidar_ros2_driver`
-- `servo_control_ros2`
-- `esc_motor_control`
+- `esc_motor_control_cpp`
 - `ddt_motor_control`
 
 LiDARなど実機依存のパッケージは追加取得とJazzy互換性確認が必要です。取得できても、

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -20,7 +20,7 @@
 
     <!-- Package dependencies -->
     <exec_depend>ddt_motor_control</exec_depend>
-    <exec_depend>esc_motor_control</exec_depend>
+    <exec_depend>esc_motor_control_cpp</exec_depend>
     <exec_depend>joy_controller</exec_depend>
     <exec_depend>ydlidar_ros2_driver</exec_depend>
 


### PR DESCRIPTION
## 概要

`questix_launcher` に残っていた古いESC依存名を、実在するROSパッケージ名 `esc_motor_control_cpp` に合わせて修正します。

## 背景

Raspberry Pi 5 / Ubuntu 24.04 / ROS 2 Jazzy 環境で以下を実行したところ、`questix_launcher` の依存として `esc_motor_control` が未解決になりました。

```bash
rosdep install --from-paths . src --ignore-src -r -y
```

発生した未解決key:

```text
questix_launcher: Cannot locate rosdep definition for [esc_motor_control]
```

一方で、実在するパッケージ名は `esc_motor_control_cpp` であり、launch側もすでに `esc_motor_control_cpp` を参照しています。

## 変更内容

* `launcher/package.xml`

  * `esc_motor_control` 依存を `esc_motor_control_cpp` に修正
* `README.md`

  * `servo_control_ros2` に関する古い既知課題注記を削除
  * Runtime Source Dependencies のESC依存名を `esc_motor_control_cpp` に更新
* `launcher/README.md`

  * 古い `servo_control_ros2` 記述を削除
  * `esc_motor_control` を `esc_motor_control_cpp` に更新

## 変更していないこと

* `dependency.repos` は変更なし
* launch files / config YAML / ROS 2 source code は変更なし
* Ansible / setup scripts / workflows は変更なし
* systemd / GPIO / UART / 実機動作には変更なし

## 確認結果

Raspberry Pi 5 / Ubuntu 24.04 / ROS 2 Jazzy 環境でPR branchを追加確認しました。

* `grep` 確認

  * `servo_control_ros2` は対象ファイル内に残っていないことを確認
  * 古い `<exec_depend>esc_motor_control</exec_depend>` は残っていないことを確認
  * `esc_motor_control_cpp` は以下に整合して存在することを確認

    * `README.md`
    * `launcher/README.md`
    * `launcher/package.xml`
    * `launcher/launch/shot_component.launch.xml`
    * `esc_motor_control_cpp/package.xml`

* `rosdep install --from-paths . src --ignore-src -r -y`

  * PR#64で対象にした `esc_motor_control` 未解決keyは出なくなったことを確認
  * ただし、別件として `ddt_motor_control` の未解決keyが残っているため、rosdep全体は完全cleanではありません

* `colcon build --symlink-install`

  * `Summary: 13 packages finished [4.24s]`
  * `ydlidar_sdk_vendor` のjobserver warningのみ

* `ros2 topic list`

  * `/parameter_events`
  * `/rosout`

追加で、別件として `ddt_motor_control` の未解決を確認しました。
`rosdep install` で `questix_launcher: Cannot locate rosdep definition for [ddt_motor_control]` が残り、モータ未接続状態で `ros2 launch questix_launcher test.launch.xml` を実行すると `package 'ddt_motor_control' not found` で失敗しました。
これはPR#64の変更対象外として、別Issueに切り出します。
