### PR TITLE
docs: add C++ format check guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,31 @@
 - For component implementations, keep `rclcpp_components_register_nodes` and `RCLCPP_COMPONENTS_REGISTER_NODE` entries consistent, including registration names and class names.
 - Update YAML parameters, launch arguments, and in-node `declare_parameter` / `get_parameter` usage together.
 
+## C++ formatting
+
+- C++ formatting is checked by CI with `ament_clang_format` and the repository `.clang-format`.
+- Before pushing C++ changes, run the CI-equivalent format check:
+
+  ```bash
+  source /opt/ros/jazzy/setup.bash
+  git ls-files -z -- '*.cpp' '*.hpp' | xargs -0 -r ament_clang_format --config .clang-format
+  ```
+
+- To reformat only the C++ files touched by a PR, run:
+
+  ```bash
+  source /opt/ros/jazzy/setup.bash
+  ament_clang_format --config .clang-format --reformat <changed-file-1> <changed-file-2>
+  ```
+
+- Do not reformat unrelated C++ files just to fix a PR unless the user explicitly asks for a repository-wide formatting change.
+- If `ament_clang_format` is missing on Ubuntu 24.04 / ROS 2 Jazzy, install it with:
+
+  ```bash
+  sudo apt update
+  sudo apt install -y ros-jazzy-ament-clang-format
+  ```
+
 ## Command safety
 
 - Do not run ISO builds, QEMU tests, package installation, permission changes, systemd commands, or hardware-facing commands unless explicitly requested.


### PR DESCRIPTION
## 概要

`AGENTS.md` に C++ format-check / reformat の標準コマンドを追記します。

## 背景

C++変更時に `.clang-format` への準拠が必要ですが、AGENTS.md には `ament_clang_format` を使った具体的な確認・整形コマンドがありませんでした。  
PRレビュー中に format-check の再現手順が必要になったため、AI agent / contributor 向けに標準手順を明記します。

## 変更内容

- CI相当の C++ format-check コマンドを追加
- PRで触ったC++ファイルだけを `--reformat` するコマンドを追加
- 無関係なC++ファイルを広範囲に整形しない注意を追加
- `ament_clang_format` が無い場合のインストールコマンドを追加

## 変更していないこと

- C++コード
- launch / YAML / Ansible / Robot Manager
- GitHub Actions workflow
- PR#66 の current mode 修正

## 確認

- [x] `git diff --check`
- [x] 変更ファイルが `AGENTS.md` のみであること