### PR TITLE
ci: use native arm64 runner instead of qemu emulation

### DIFF
--- a/.github/workflows/ros2-build-test.yaml
+++ b/.github/workflows/ros2-build-test.yaml
@@ -26,16 +26,18 @@ defaults:
 jobs:
   build-and-test:
     name: build-and-test (${{ matrix.ros_distro }}, ${{ matrix.architecture }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
           - ros_distro: jazzy
             architecture: amd64
+            runner: ubuntu-24.04
             allow_failure: false
           - ros_distro: jazzy
             architecture: arm64
-            allow_failure: true
+            runner: ubuntu-24.04-arm
+            allow_failure: false
       fail-fast: false
     continue-on-error: ${{ matrix.allow_failure }}
 
@@ -46,17 +48,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup QEMU
-        if: matrix.architecture == 'arm64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Start ROS container
         run: |
-          docker pull --platform linux/${{ matrix.architecture }} ros:${{ matrix.ros_distro }}-ros-base
+          docker pull ros:${{ matrix.ros_distro }}-ros-base
           docker run -d --name ros_build \
-            --platform linux/${{ matrix.architecture }} \
             --init \
             -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
             -w "$GITHUB_WORKSPACE" \


### PR DESCRIPTION
## 背景

`build-and-test (jazzy, arm64)` が QEMU エミュレーション上で動作しており、約26分かかっていた（ネイティブ amd64 は約2.5分）。

## 変更

- questix は public リポジトリなので、GitHub 無料提供のネイティブ ARM64 ホストランナー `ubuntu-24.04-arm` に切り替え
- `docker/setup-qemu-action` ステップと `--platform linux/...` 指定を削除（ネイティブ実行で不要）
- `runs-on` を matrix の `runner` でパラメータ化
- ネイティブ化で高速・安定するため、arm64 を `allow_failure: false`（ブロッキングゲート）に格上げ

## 期待効果

arm64 ビルドが ~26分 → ~2-3分に短縮。実機（Raspberry Pi 5 / ARM64）向けビルド保証も強化。

## 確認事項

- arm64 ジョブが pending で止まらず、ネイティブランナー（aarch64）で実行されること
- 全チェックが pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)