### PR TITLE
fix: initialize current tilt angle

### DIFF
--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -14,7 +14,8 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
       last_tilt_value_(0.0F),
       last_tilt_up_state_(false),
       last_tilt_down_state_(false),
-      current_tilt_position_(2048) {
+      current_tilt_position_(2048),
+      current_tilt_angle_(0.0) {
   // パラメーター宣言
   this->declare_parameter("port", "/dev/servo");
   this->declare_parameter("baudrate", 115200);


### PR DESCRIPTION
## 概要

`ShotComponent` のコンストラクタ初期化リストで `current_tilt_angle_` を初期化します。

この修正は、upstream PR #71 を fork 側に取り込んだ PR で Gemini Code Assist から指摘された内容への対応です。
本 PR では実行時の挙動は変更せず、コンストラクタが早期 return した場合でもメンバ変数が未初期化にならないようにします。

## 変更範囲

- `current_tilt_angle_` を初期化リストで `0.0` に初期化します。

## 検証

- fork 側 PR #14 で GitHub Actions `ROS2 Build and Test` が成功済みです。
- ローカル検証結果:
  - `git diff --check origin/main...HEAD`: OK
  - `colcon build --packages-select motor_control_lib motor_control_app --symlink-install`: 成功

関連:
- upstream PR #71
- fork 側 PR: Yuichiroh-Kobayashi/questix#14