### PR TITLE
fix: address PR75 and PR76 review follow-ups

### DIFF
--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -98,7 +98,7 @@ private:
   bool has_last_cmd_;
 
   // 停止時の電気ブレーキ（velocity モードのみ）
-  bool brake_on_stop_;
+  bool brake_on_stop_{true};
 
   // 状態フラグ
   bool motor_initialized_;

--- a/servo_checker.py
+++ b/servo_checker.py
@@ -224,8 +224,15 @@ def _transact(ser: serial.Serial, frame: bytes) -> bytes:
             data += ser.read(trailing)
         return data
 
-    # in_waiting が 0 のままでも、タイムアウトまでブロッキングで待ってみる
-    return ser.read(16)
+    # in_waiting が 0 のままでも、まず 1 バイトだけ待って応答開始を確認する。
+    first_byte = ser.read(1)
+    if first_byte:
+        time.sleep(0.01)
+        trailing = ser.in_waiting
+        if trailing:
+            return first_byte + ser.read(trailing)
+        return first_byte
+    return b""
 
 
 def _find_read_frame(data: bytes, servo_id: int):


### PR DESCRIPTION
## 概要

PR #75 / #76 取り込み後のレビューで見つかった小さな不備を修正します。

このPRは fork 側 PR #15 の Gemini Code Assist コメント対応から切り出した follow-up です。
upstream `main` はすでに PR #75 / #76 まで取り込み済みのため、本PRでは追加修正2点のみを扱います。

## 変更内容

### DriveComponent

- `brake_on_stop_` に in-class default `{true}` を追加
- `declare_parameter("brake_on_stop", true)` および YAML既定値と整合
- AGENTS.md の C++ member initialization 方針に合わせる

### servo_checker.py

- `_transact()` 末尾の固定長 `ser.read(16)` を削除
- `ser.read(1)` で応答開始を待ってから `in_waiting` 分を読む形に変更
- 正常応答時に不要な timeout 待ちで GUI が固まる問題を軽減

## 変更範囲

- `motor_control_app/include/motor_control_app/drive_component.hpp`
- `servo_checker.py`

## 確認

- [x] `git diff --check`
- [x] `python3 -m py_compile servo_checker.py`
- [x] `colcon build --packages-select motor_control_app motor_control_lib --symlink-install`

## 注意

実機確認は未実施です。
本PRは初期化漏れ防止とGUI応答性改善のみで、DDTモータ制御ロジックやサーボ制御プロトコル自体は変更していません。
