### PR TITLE
fix: remove error suppression from rosdep install command in CI workflow

### DIFF
--- a/.github/workflows/ros2-build-test.yaml
+++ b/.github/workflows/ros2-build-test.yaml
@@ -113,7 +113,7 @@ jobs:
         run: |
           docker exec -i ros_build bash << 'EOF'
           apt-get -yqq update
-          rosdep install -yqq --from-paths . --ignore-src --rosdistro $ROS_DISTRO || true
+          rosdep install -yqq --from-paths . --ignore-src --rosdistro $ROS_DISTRO
           EOF
 
       - name: Setup colcon mixin


### PR DESCRIPTION
# description
ciの強化。
rosdep installに| true
が入ってたため、. rosdep install の失敗が握りつぶされてたため、除外