### PR TITLE
ci: add no-op build-summary for PRs skipped by the build workflow

### DIFF
--- a/.github/workflows/ros2-build-test-skipped.yaml
+++ b/.github/workflows/ros2-build-test-skipped.yaml
@@ -1,0 +1,37 @@
+name: ROS2 Build and Test
+
+# Companion no-op for ros2-build-test.yaml.
+# Branch protection requires the "build-summary" check, but the real
+# workflow does not run for PRs that only touch the paths it ignores,
+# which would leave the required check pending forever. This workflow
+# triggers on exactly those paths and reports a passing "build-summary"
+# check instead.
+# Keep the paths list below identical to the paths-ignore list in
+# ros2-build-test.yaml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "**.md"
+      - "ansible/**"
+      - "docker/**"
+      - "scripts/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "**.md"
+      - "ansible/**"
+      - "docker/**"
+      - "scripts/**"
+
+jobs:
+  build-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report skipped build as passing
+        run: |
+          echo "Only paths ignored by the ROS 2 build workflow changed;" \
+               "reporting build-summary as passed."

--- a/.github/workflows/ros2-build-test.yaml
+++ b/.github/workflows/ros2-build-test.yaml
@@ -1,5 +1,8 @@
 name: ROS2 Build and Test
 
+# The paths-ignore lists below must stay identical to the paths lists in
+# ros2-build-test-skipped.yaml, which reports a passing "build-summary"
+# check for PRs this workflow skips (see that file for details).
 on:
   push:
     branches: [main]


### PR DESCRIPTION
PRs that only touch paths in the build workflow's paths-ignore list (.github, docs, ansible, docker, scripts) never start the workflow, so the required build-summary check stays pending and blocks the merge. Add a companion workflow that triggers on exactly those paths and reports a passing build-summary check, and cross-reference the two path lists so they stay in sync.