### PR TITLE
ci: merge duplicate ansible check-mode jobs

### DIFF
--- a/.github/workflows/ansible-check.yaml
+++ b/.github/workflows/ansible-check.yaml
@@ -86,39 +86,6 @@ jobs:
             - name: Install required system packages
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y git
-
-            # check mode はインストーラ系タスクを完走できない既知の制約があるため
-            # 参考情報として実行する（AGENTS.md "Ansible check mode limits" を参照）
-            - name: Run ansible-playbook in check mode
-              run: |
-                  ansible-playbook ansible/playbooks/setup_kit.yaml \
-                    -i localhost, \
-                    --connection=local \
-                    --check \
-                    -e "ansible_become_password=dummy"
-              continue-on-error: true
-
-    ansible-test-setup:
-        name: Ansible Playbook Test (Minimal)
-        runs-on: ubuntu-24.04
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Set up Python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-
-            - name: Install Ansible
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install ansible
-
-            - name: Install required system packages
-              run: |
-                  sudo apt-get update
                   sudo apt-get install -y \
                     git \
                     software-properties-common \


### PR DESCRIPTION
## 概要

`ansible-check.yaml` の `ansible-dry-run` と `ansible-test-setup` はほぼ同一の重複ジョブでした。両者とも `setup_kit.yaml` を check モードで localhost に対して実行し、`continue-on-error: true` の advisory ジョブです。

`ansible-dry-run` は残した側（旧 `ansible-test-setup`）の純粋なサブセット（`--diff` なし・追加パッケージなし）だったため、より情報量の多い方に一本化しました。

## 変更点

- 重複していた 2 ジョブを 1 つの `ansible-dry-run`（表示名「Ansible Dry Run (Check Mode)」）に統合
- `.github/workflows/ansible-check.yaml` から 33 行削除

## 補足

- `setup_kit.yaml` は play レベルで `become: true` を宣言しているため、CLI `--become` フラグの有無に関わらず両ジョブとも特権昇格して実行されます。旧 `ansible-dry-run` に「非特権パス」の独自価値はなく、統合で失う検証はありません。
- AGENTS.md "Ansible check mode limits" の方針どおり、check モードの advisory 実行という位置付けは維持しています。

## 検証

- YAML パース: OK
- ジョブ数: 6 → 5、他ファイルからの当該ジョブ名参照なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)