### PR TITLE
fix: harden robot manager file handling

### DIFF
--- a/scripts/robot_manager/logs.py
+++ b/scripts/robot_manager/logs.py
@@ -131,6 +131,14 @@ def _copy_tail(src: Path, dest: Path, max_bytes: int) -> bool:
         truncated = size > max_bytes
         if truncated:
             fsrc.seek(size - max_bytes)
+            if max_bytes > 0:
+                while True:
+                    byte = fsrc.read(1)
+                    if not byte:
+                        break
+                    if (byte[0] & 0xC0) != 0x80:
+                        fsrc.seek(-1, 1)
+                        break
             fdst.write("# ... (先頭を切り捨て / older entries omitted) ...\n".encode("utf-8"))
         else:
             fsrc.seek(0)

--- a/scripts/robot_manager/logs.py
+++ b/scripts/robot_manager/logs.py
@@ -124,12 +124,16 @@ def _copy_tail(src: Path, dest: Path, max_bytes: int) -> bool:
 
     Returns True if the file was truncated (tail only).
     """
-    size = src.stat().st_size
+    max_bytes = max(0, max_bytes)
     with src.open("rb") as fsrc, dest.open("wb") as fdst:
+        fsrc.seek(0, 2)
+        size = fsrc.tell()
         truncated = size > max_bytes
         if truncated:
             fsrc.seek(size - max_bytes)
             fdst.write("# ... (先頭を切り捨て / older entries omitted) ...\n".encode("utf-8"))
+        else:
+            fsrc.seek(0)
         shutil.copyfileobj(fsrc, fdst)
     return truncated
 

--- a/scripts/robot_manager/recorder.py
+++ b/scripts/robot_manager/recorder.py
@@ -71,7 +71,7 @@ def _read_env_file(path: Path) -> dict[str, str]:
     """Parse a shell-style KEY=value file, skipping comments and blanks."""
     result: dict[str, str] = {}
     try:
-        for line in path.read_text().splitlines():
+        for line in path.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
@@ -80,6 +80,8 @@ def _read_env_file(path: Path) -> dict[str, str]:
                 result[m.group(1)] = m.group(2)
     except FileNotFoundError:
         pass
+    except UnicodeError as exc:
+        raise OSError(f"failed to decode environment file {path}: {exc}") from exc
     except OSError as exc:
         raise OSError(f"failed to read environment file {path}: {exc}") from exc
     return result

--- a/scripts/robot_manager/recorder.py
+++ b/scripts/robot_manager/recorder.py
@@ -80,6 +80,8 @@ def _read_env_file(path: Path) -> dict[str, str]:
                 result[m.group(1)] = m.group(2)
     except FileNotFoundError:
         pass
+    except OSError as exc:
+        raise OSError(f"failed to read environment file {path}: {exc}") from exc
     return result
 
 
@@ -88,6 +90,14 @@ def _read_config() -> dict[str, str]:
     config = dict(_DEFAULT_CONFIG)
     config.update(_read_env_file(ROSBAG_ENV_FILE))
     return config
+
+
+def _read_config_for_api() -> dict[str, str]:
+    """Read recorder config, mapping filesystem failures to a safe API error."""
+    try:
+        return _read_config()
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail="録画設定を読み込めません") from exc
 
 
 def _write_config(config: dict[str, str]) -> None:
@@ -314,7 +324,7 @@ def _watch_disk(output_dir: Path, min_free: int) -> None:
 # ---------------------------------------------------------------------------
 
 def _status_payload() -> dict:
-    config = _read_config()
+    config = _read_config_for_api()
     output_dir = Path(config["OUTPUT_DIR"])
     free, total = _disk_usage(output_dir)
     recording = _proc is not None and _proc.poll() is None
@@ -352,7 +362,7 @@ def start_recording():
         if _proc is not None and _proc.poll() is None:
             raise HTTPException(status_code=409, detail="録画中です")
 
-        config = _read_config()
+        config = _read_config_for_api()
         vehicle = config["VEHICLE_NAME"]
         if not _VEHICLE_RE.match(vehicle):
             raise HTTPException(status_code=400, detail="VEHICLE_NAME が不正です")
@@ -375,7 +385,10 @@ def start_recording():
 
         bag_name = f"{vehicle}_{datetime.now():%Y%m%d_%H%M%S}"
         bag_path = output_dir / bag_name
-        script = _build_record_command(config, bag_path)
+        try:
+            script = _build_record_command(config, bag_path)
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail="録画設定を読み込めません") from exc
 
         try:
             proc = subprocess.Popen(
@@ -428,13 +441,13 @@ def stop_recording():
 @router.get("/config")
 def get_config():
     """Return the recorder configuration."""
-    return _read_config()
+    return _read_config_for_api()
 
 
 @router.put("/config")
 def set_config(config: RecorderConfig):
     """Update recorder configuration (rosbag.env)."""
-    current = _read_config()
+    current = _read_config_for_api()
     update = {k: v for k, v in config.model_dump().items() if v is not None}
     current.update(update)
     try:
@@ -447,7 +460,7 @@ def set_config(config: RecorderConfig):
 @router.get("/list")
 def list_bags():
     """List recorded bags in OUTPUT_DIR with size / mtime / mcap presence."""
-    config = _read_config()
+    config = _read_config_for_api()
     output_dir = Path(config["OUTPUT_DIR"])
     bags = []
     total_used = 0
@@ -486,7 +499,7 @@ def delete_bag(ref: BagRef):
     name = ref.bag_name
     if not name or "/" in name or name.startswith(".") or name in ("", ".", ".."):
         raise HTTPException(status_code=400, detail="バッグ名が不正です")
-    config = _read_config()
+    config = _read_config_for_api()
     output_dir = Path(config["OUTPUT_DIR"]).resolve()
     target = (output_dir / name).resolve()
     if target.parent != output_dir or not target.is_dir():
@@ -507,7 +520,7 @@ def delete_bag(ref: BagRef):
 
 def _browse_start_path() -> Path:
     """Return the default starting directory for the folder browser."""
-    output_dir = Path(_read_config()["OUTPUT_DIR"])
+    output_dir = Path(_read_config_for_api()["OUTPUT_DIR"])
     if output_dir.is_dir():
         return output_dir
     ancestor = _existing_ancestor(output_dir)
@@ -530,7 +543,7 @@ def get_locations():
 
     add("ホーム", Path.home(), "home")
     add("既定", Path(_DEFAULT_CONFIG["OUTPUT_DIR"]), "default")
-    add("現在の設定", Path(_read_config()["OUTPUT_DIR"]), "current")
+    add("現在の設定", Path(_read_config_for_api()["OUTPUT_DIR"]), "current")
 
     # Removable media: real mount points under the usual automount roots.
     candidates: list[Path] = []

--- a/scripts/robot_manager/static/app.js
+++ b/scripts/robot_manager/static/app.js
@@ -123,14 +123,43 @@ async function collectLogs() {
 
 function renderLogResult(data) {
   const box = document.getElementById("log-result");
-  const rows = (data.notes || [])
-    .map((n) => `<div class="log-note"><span class="log-note-label">${n.label}</span><span class="log-note-text">${n.note}</span></div>`)
-    .join("");
-  box.innerHTML = `
-    <div class="log-result-head">保存しました</div>
-    <div class="log-result-path">${data.path}</div>
-    <div class="log-result-size">サイズ: ${fmtBytes(data.size_bytes)}</div>
-    <div class="log-notes">${rows}</div>`;
+  while (box.firstChild) box.removeChild(box.firstChild);
+
+  const head = document.createElement("div");
+  head.className = "log-result-head";
+  head.textContent = "保存しました";
+
+  const path = document.createElement("div");
+  path.className = "log-result-path";
+  path.textContent = data.path;
+
+  const size = document.createElement("div");
+  size.className = "log-result-size";
+  size.textContent = `サイズ: ${fmtBytes(data.size_bytes)}`;
+
+  const notes = document.createElement("div");
+  notes.className = "log-notes";
+  for (const n of data.notes || []) {
+    const row = document.createElement("div");
+    row.className = "log-note";
+
+    const label = document.createElement("span");
+    label.className = "log-note-label";
+    label.textContent = n.label;
+
+    const note = document.createElement("span");
+    note.className = "log-note-text";
+    note.textContent = n.note;
+
+    row.appendChild(label);
+    row.appendChild(note);
+    notes.appendChild(row);
+  }
+
+  box.appendChild(head);
+  box.appendChild(path);
+  box.appendChild(size);
+  box.appendChild(notes);
   box.classList.remove("hidden");
 }
 
@@ -227,22 +256,46 @@ async function refreshBagList() {
   }
   document.getElementById("disk-used-text").textContent = fmtBytes(data.total_used_bytes);
   const list = document.getElementById("rec-bag-list");
-  list.innerHTML = "";
+  while (list.firstChild) list.removeChild(list.firstChild);
   if (!data.bags.length) {
-    list.innerHTML = '<li class="rec-bag-empty">バッグはまだありません</li>';
+    const empty = document.createElement("li");
+    empty.className = "rec-bag-empty";
+    empty.textContent = "バッグはまだありません";
+    list.appendChild(empty);
     return;
   }
   for (const bag of data.bags) {
     const li = document.createElement("li");
     li.className = "rec-bag-item" + (bag.recording ? " recording" : "");
     const date = bag.mtime ? new Date(bag.mtime * 1000).toLocaleString("ja-JP") : "";
-    li.innerHTML = `
-      <div class="rec-bag-main">
-        <span class="rec-bag-name">${bag.name}${bag.recording ? " ●REC" : ""}</span>
-        <span class="rec-bag-meta">${fmtBytes(bag.size_bytes)} · ${date}</span>
-        <span class="rec-bag-path">${bag.path}</span>
-      </div>
-      <button class="btn btn-small btn-del" data-bag="${bag.name}" ${bag.recording ? "disabled" : ""}>削除</button>`;
+
+    const main = document.createElement("div");
+    main.className = "rec-bag-main";
+
+    const name = document.createElement("span");
+    name.className = "rec-bag-name";
+    name.textContent = bag.name + (bag.recording ? " ●REC" : "");
+
+    const meta = document.createElement("span");
+    meta.className = "rec-bag-meta";
+    meta.textContent = `${fmtBytes(bag.size_bytes)} · ${date}`;
+
+    const path = document.createElement("span");
+    path.className = "rec-bag-path";
+    path.textContent = bag.path;
+
+    main.appendChild(name);
+    main.appendChild(meta);
+    main.appendChild(path);
+
+    const btn = document.createElement("button");
+    btn.className = "btn btn-small btn-del";
+    btn.dataset.bag = bag.name;
+    btn.textContent = "削除";
+    btn.disabled = Boolean(bag.recording);
+
+    li.appendChild(main);
+    li.appendChild(btn);
     list.appendChild(li);
   }
 }

--- a/scripts/robot_manager/test_file_helpers.py
+++ b/scripts/robot_manager/test_file_helpers.py
@@ -1,0 +1,133 @@
+"""Regression tests for Robot Manager file helpers."""
+
+import tempfile
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+try:
+    from fastapi import HTTPException
+except ModuleNotFoundError:
+    fastapi = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        """Minimal FastAPI HTTPException substitute for helper tests."""
+
+        def __init__(self, status_code, detail):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class APIRouter:
+        """Minimal route decorator substitute for importing helper modules."""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def _route(self, *args, **kwargs):
+            return lambda function: function
+
+        get = post = put = delete = _route
+
+    fastapi.APIRouter = APIRouter
+    fastapi.HTTPException = HTTPException
+    sys.modules["fastapi"] = fastapi
+
+try:
+    import pydantic  # noqa: F401
+except ModuleNotFoundError:
+    pydantic = types.ModuleType("pydantic")
+
+    class BaseModel:
+        """Minimal Pydantic model substitute for importing helper modules."""
+
+    def field_validator(*args, **kwargs):
+        return lambda function: function
+
+    pydantic.BaseModel = BaseModel
+    pydantic.field_validator = field_validator
+    sys.modules["pydantic"] = pydantic
+
+from robot_manager import logs, recorder
+
+
+class ReadEnvFileTests(unittest.TestCase):
+    """Cover missing, readable, and unreadable environment files."""
+
+    def test_missing_file_returns_empty_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(recorder._read_env_file(Path(tmp) / "missing.env"), {})
+
+    def test_valid_file_is_parsed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "robot.env"
+            path.write_text("# comment\nROBOT_WS=/home/robot/ws\nINVALID-LINE\nENABLED=true\n")
+
+            self.assertEqual(
+                recorder._read_env_file(path),
+                {"ROBOT_WS": "/home/robot/ws", "ENABLED": "true"},
+            )
+
+    def test_permission_error_is_not_silenced(self):
+        path = Path("/private/robot.env")
+        with patch.object(Path, "read_text", side_effect=PermissionError("denied")):
+            with self.assertRaises(OSError) as raised:
+                recorder._read_env_file(path)
+
+        self.assertIn("failed to read environment file", str(raised.exception))
+        self.assertIsInstance(raised.exception.__cause__, PermissionError)
+
+    def test_api_error_does_not_expose_config_path(self):
+        with patch.object(
+            recorder,
+            "_read_config",
+            side_effect=OSError("failed to read /private/rosbag.env"),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                recorder._read_config_for_api()
+
+        self.assertEqual(raised.exception.status_code, 500)
+        self.assertEqual(raised.exception.detail, "録画設定を読み込めません")
+        self.assertNotIn("/private", raised.exception.detail)
+
+
+class CopyTailTests(unittest.TestCase):
+    """Cover full copies and bounded tail copies."""
+
+    def test_small_file_is_copied_in_full(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "source.log"
+            dest = Path(tmp) / "dest.log"
+            src.write_bytes(b"small log\n")
+
+            self.assertFalse(logs._copy_tail(src, dest, 100))
+            self.assertEqual(dest.read_bytes(), b"small log\n")
+
+    def test_large_file_keeps_marker_and_tail(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "source.log"
+            dest = Path(tmp) / "dest.log"
+            src.write_bytes(b"0123456789")
+
+            self.assertTrue(logs._copy_tail(src, dest, 4))
+            output = dest.read_bytes()
+            self.assertIn(b"older entries omitted", output)
+            self.assertTrue(output.endswith(b"6789"))
+
+    def test_zero_limit_writes_only_truncation_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "source.log"
+            dest = Path(tmp) / "dest.log"
+            src.write_bytes(b"content")
+
+            self.assertTrue(logs._copy_tail(src, dest, 0))
+            output = dest.read_bytes()
+            self.assertIn(b"older entries omitted", output)
+            self.assertNotIn(b"content", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/robot_manager/test_file_helpers.py
+++ b/scripts/robot_manager/test_file_helpers.py
@@ -71,6 +71,30 @@ class ReadEnvFileTests(unittest.TestCase):
                 {"ROBOT_WS": "/home/robot/ws", "ENABLED": "true"},
             )
 
+    def test_utf8_comment_file_is_parsed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "robot.env"
+            path.write_text(
+                "# 録画設定\nROBOT_WS=/home/robot/ws\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                recorder._read_env_file(path),
+                {"ROBOT_WS": "/home/robot/ws"},
+            )
+
+    def test_invalid_utf8_is_reported_as_decode_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "robot.env"
+            path.write_bytes(b"ROBOT_WS=/home/robot/\xff\n")
+
+            with self.assertRaises(OSError) as raised:
+                recorder._read_env_file(path)
+
+        self.assertIn("failed to decode environment file", str(raised.exception))
+        self.assertIsInstance(raised.exception.__cause__, UnicodeError)
+
     def test_permission_error_is_not_silenced(self):
         path = Path("/private/robot.env")
         with patch.object(Path, "read_text", side_effect=PermissionError("denied")):
@@ -116,6 +140,22 @@ class CopyTailTests(unittest.TestCase):
             output = dest.read_bytes()
             self.assertIn(b"older entries omitted", output)
             self.assertTrue(output.endswith(b"6789"))
+
+    def test_utf8_tail_starts_at_character_boundary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "source.log"
+            dest = Path(tmp) / "dest.log"
+            src.write_text("甲乙丙丁", encoding="utf-8")
+
+            self.assertTrue(logs._copy_tail(src, dest, 8))
+            output = dest.read_bytes()
+            decoded = output.decode("utf-8")
+            marker, tail = output.split(b"\n", 1)
+
+            self.assertIn(b"older entries omitted", marker)
+            self.assertTrue(decoded.endswith("丙丁"))
+            self.assertEqual(tail.decode("utf-8"), "丙丁")
+            self.assertLessEqual(len(tail), 8)
 
     def test_zero_limit_writes_only_truncation_marker(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 概要

fork側の統合レビューPR
`Yuichiroh-Kobayashi/questix#16`
でGemini Code Assistから指摘された、Robot Managerの安全性・堅牢性問題を修正します。

その後、upstream PR #101相当の変更をfork側PR #17で追加レビューし、UTF-8ファイル処理に関する2件の指摘も反映しました。

対象は次の4領域です。

1. rosbag一覧・ログ回収結果のDOM-based XSS対策
2. recorder設定ファイルの「不存在」「読取不能」「文字コード不正」の区別
3. syslog tailコピー時のstat/open競合の回避
4. UTF-8 multibyte文字の途中でtailを切らない処理

これらの修正による挙動退行を防ぐため、ファイル操作helperに対する標準`unittest`も追加しています。

## 変更内容

### 1. rosbag一覧のXSS対策

従来の`refreshBagList()`では、APIから返された以下の値をtemplate literal経由で`innerHTML`へ挿入していました。

- `bag.name`
- `bag.path`
- `bag.size_bytes`
- `bag.mtime`
- `bag.recording`

bag名やpathはファイルシステム由来であり、USBメディアなどから意図しないHTML文字列が持ち込まれた場合、ブラウザがHTMLとして解釈する可能性がありました。

修正後は次のDOM APIを使用しています。

- `document.createElement()`
- `textContent`
- `dataset`
- `appendChild()`

削除ボタンのbag名も、HTML属性文字列へ埋め込まず`button.dataset.bag`へ設定します。

### 2. ログ回収結果のXSS対策

Geminiの直接指摘箇所以外にも、`renderLogResult()`で以下のAPI由来値を`innerHTML`へ挿入していました。

- `data.path`
- `data.size_bytes`
- `note.label`
- `note.note`

こちらも同じ方針で、DOM要素を個別に生成し、可変値はすべて`textContent`へ設定するよう変更しました。

### 3. recorder設定ファイルの読取エラー処理

従来の`_read_env_file()`は`FileNotFoundError`のみを扱い、その他のI/Oエラーや文字コード不正が、呼出経路によって未整理の例外となる可能性がありました。

修正後は以下を明確に区別します。

- `FileNotFoundError`
  - 設定ファイルがまだ作成されていない正常ケース
  - 空の設定として扱う
- `UnicodeError`
  - UTF-8としてdecodeできない設定ファイル
  - 文脈付き`OSError`へ変換する
- その他の`OSError`
  - PermissionError、I/O error等
  - 文脈付きで再送出する
- API境界
  - 内部pathやOS例外を露出しないHTTP 500へ変換する

環境設定ファイルは、システムlocaleに依存しないよう`encoding="utf-8"`を明示して読み込みます。

対象経路は以下です。

- status取得
- 録画開始
- 設定取得・更新
- bag一覧・削除
- folder browser
- record command生成

設定ファイルはmodule import時には読まれないため、設定ファイルの権限エラーや文字コード不正だけでFastAPIアプリ全体がimport不能になる構造にはしていません。

### 4. syslog tailコピーのstat/open競合修正

従来の`_copy_tail()`は、

1. `src.stat()`でsize取得
2. その後にfileをopen

という順序でした。

この間にsyslogのrotationやtruncateが起こると、取得したsizeと実際にopenしたfileの内容が一致しない可能性があります。

修正後はfileをopenしてから、そのfile descriptor上で

- `seek(0, 2)`
- `tell()`

によりsizeを取得します。

これにより、pathが差し替わっても、open済みの同一file descriptorを一貫して読み取ります。

あわせて以下も明示しました。

- truncateしない場合は先頭へseekする
- `max_bytes < 0`は0として扱う
- `max_bytes == 0`でも負のseekを行わない
- 大きいfileは末尾だけをコピーする
- truncation markerを出力する

### 5. UTF-8文字境界を考慮したtailコピー

fork側PR #17の追加レビューで、byte単位のtail切り出しがUTF-8 multibyte文字の途中から始まる可能性を指摘されました。

開始位置がUTF-8 continuation byte（`0x80`〜`0xBF`）の場合は、次の文字境界まで進めてからコピーします。

これにより、日本語ログ等を末尾切り出しした際に、出力ファイル先頭へ不正なUTF-8列が残る問題を防ぎます。

既存仕様は維持しています。

- ASCIIログの末尾コピー
- `max_bytes == 0`ではtruncation markerのみ
- markerはbyte上限の対象外
- 非truncate時はファイル全体をコピー
- 切り出す実データ部分は`max_bytes`以下

## `test_file_helpers.py`を追加した理由

今回の修正は、見た目上は小さいものの、設定ファイルの例外分類、文字コード、syslogの切り出し位置など、将来の変更で退行しやすいファイル操作ロジックを含みます。

特に以下は静的lintやsyntax checkだけでは確認できません。

- 設定ファイルが存在しない場合に空dictを返すこと
- 正常な設定ファイルを正しくparseすること
- 日本語コメントを含むUTF-8設定ファイルを読めること
- 不正UTF-8をdecode失敗として検出すること
- PermissionError等を黙って無視しないこと
- API errorへ内部pathを露出しないこと
- 小さいsyslogを全体コピーすること
- 大きいsyslogを末尾だけコピーすること
- truncation markerが付くこと
- `max_bytes == 0`でも安全に動作すること
- UTF-8 multibyte文字の途中からtailを開始しないこと

このため、`scripts/robot_manager/test_file_helpers.py`を新規追加し、`_read_env_file()`と`_copy_tail()`の契約を回帰テストとして固定しました。

テストには標準ライブラリの`unittest`を使用しています。

理由は以下です。

- 新しいpytest/npm等の依存を追加しない
- Robot Manager単体の最小環境でも実行しやすい
- ROS 2 package buildから独立してhelperだけを検証できる
- 今回の変更範囲に対して十分な粒度である

FastAPIまたはPydanticが存在しない最小環境でもhelperをimportできるよう、テスト内では必要最小限のstubを条件付きで使用しています。

実環境にFastAPI/Pydanticが存在する場合は実パッケージを使用します。

## 変更ファイル

- `scripts/robot_manager/static/app.js`
- `scripts/robot_manager/recorder.py`
- `scripts/robot_manager/logs.py`
- `scripts/robot_manager/test_file_helpers.py`

## 確認

- [x] `git diff --check`
- [x] JavaScript syntax check
- [x] API由来値が対象関数内の`innerHTML`へ残っていないこと
- [x] Python syntax
- [x] Robot Manager flake8
- [x] Robot Manager pydocstyle
- [x] Robot Manager scripts全体lint
- [x] 標準`unittest` 10件
- [x] GitHub Actions
  - ROS2 Build and Test
  - Robot Manager Lint
  - Ansible Playbook Check
  - その他required checks

## 追加レビュー

upstream PR #101相当の変更について、fork側レビュー専用PRでGemini Code Assistの追加レビューを実施しました。

- `Yuichiroh-Kobayashi/questix#17`

追加レビューで指摘された以下を修正済みです。

- syslog tailのUTF-8文字境界
- env fileのUTF-8 decode error処理

対応commit:

- `405c1c3 fix: handle UTF-8 file boundaries`

## ROS buildについて

ローカルの`colcon build`は実行していません。

今回の変更はすべて
`scripts/robot_manager/COLCON_IGNORE`
配下のJavaScript/Pythonであり、ROS 2 packageのbuild対象外です。

ただし、GitHub Actions上の`ROS2 Build and Test`は成功しています。

## 未確認

- Raspberry Pi 5実機でのRobot Manager操作
- USBメディアへの実ログ回収
- 実rosbagディレクトリを用いた一覧・削除操作
- 実syslog rotation中のログ回収
- 不正UTF-8を含む実設定ファイルでのUI表示

## 出典

fork review PR:

- `Yuichiroh-Kobayashi/questix#16`
- `Yuichiroh-Kobayashi/questix#17`