### PR TITLE
test: add ddt protocol pack/parse unit tests

### DIFF
--- a/motor_control_lib/CMakeLists.txt
+++ b/motor_control_lib/CMakeLists.txt
@@ -12,6 +12,7 @@ ament_auto_find_build_dependencies()
 # Create shared library with implementation
 ament_auto_add_library(motor_control_lib SHARED
   src/ddt_motor_lib.cpp
+  src/ddt_protocol.cpp
   src/differential_drive.cpp
   src/motor_manager.cpp
   src/servo_control.cpp
@@ -23,6 +24,8 @@ if(BUILD_TESTING)
     ament_cmake_cpplint
     ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_ddt_protocol test/test_ddt_protocol.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE)

--- a/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
@@ -183,8 +183,7 @@ private:
   bool readFeedbackFrame(int expected_motor_id, std::vector<uint8_t>& out_frame, int timeout_ms);
   bool parseFeedback(int expected_motor_id, const std::vector<uint8_t>& frame);
 
-  // Utility methods (M15 datasheet compliant)
-  uint8_t crc8Maxim(const std::vector<uint8_t>& data);
+  // Utility methods
   bool sendCommand(const std::vector<uint8_t>& command, int retry_count = 3);
   ssize_t writeSerial(const void* data, size_t size);
   ssize_t readSerial(void* data, size_t size);

--- a/motor_control_lib/include/motor_control_lib/ddt_protocol.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_protocol.hpp
@@ -1,0 +1,112 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#ifndef MOTOR_CONTROL_LIB__DDT_PROTOCOL_HPP_
+#define MOTOR_CONTROL_LIB__DDT_PROTOCOL_HPP_
+
+#include <cstdint>
+#include <vector>
+
+namespace motor_control_lib::ddt_protocol {
+
+/**
+ * @brief DDT モータ (M0602C) の通信フレーム pack/parse を提供する純粋関数群。
+ *
+ * ここに含まれる関数はシリアル I/O や rclcpp に一切依存せず、
+ * バイト列の組み立て・分解と CRC 計算のみを行う（単体テスト可能）。
+ *
+ * マルチバイトフィールドは全て big-endian (high, low) で並ぶ。
+ * 各 pack 関数は 9 バイトのペイロード + 末尾 CRC8 = 全 10 バイトの完全なフレームを返す。
+ */
+
+/**
+ * @brief CRC8/MAXIM (poly 0x8C reflected, init 0x00) を計算する。
+ */
+uint8_t crc8Maxim(const std::vector<uint8_t>& data);
+
+/**
+ * @brief モード切替フレーム (Protocol 3) を組み立てる。
+ *
+ * 仕様書: {ID, 0xA0, 0,0,0,0,0,0, 0, mode_value} （DATA[9] が mode_value で CRC 無し）
+ * 既存実装互換: DATA[8] に mode_value を入れ DATA[9] を CRC8(data[0..8]) とする独自レイアウト。
+ *   既存 velocity 切替 (mode_value=0) はこの形で実機動作実績がある。
+ *   電流モードで意図通り切替できない場合は仕様書通りの形 (DATA[9]=mode_value, CRC無し) に
+ *   フォールバックすること。
+ *
+ * @param motor_id   モータ ID (DATA[0])
+ * @param mode_value モード値 (DATA[8] に格納する。0x01=電流ループ, 0x02=速度ループ)
+ * @return 全 10 バイトのフレーム
+ */
+std::vector<uint8_t> packModeFrame(uint8_t motor_id, uint8_t mode_value);
+
+/**
+ * @brief 速度指令フレーム (Protocol 1, 0x64) を組み立てる。
+ *
+ * 仕様 (M0602C プロトコル1): DATA[2]=指令上位8bit, DATA[3]=指令下位8bit。
+ * マルチバイトは big-endian (high, low)。packCurrentFrame と同じ並び。
+ * DATA[6]=加速時間, DATA[7]=ブレーキ（0xFF でブレーキ、速度ループモードのみ有効）。
+ *
+ * @param motor_id     モータ ID
+ * @param velocity_rpm 目標 RPM（int16 として big-endian で格納）
+ * @param accel_time   加速時間 (DATA[6])
+ * @param brake        true で DATA[7]=0xFF（電気ブレーキ）
+ * @return 全 10 バイトのフレーム
+ */
+std::vector<uint8_t> packVelocityFrame(uint8_t motor_id, int16_t velocity_rpm, uint8_t accel_time,
+                                       bool brake);
+
+/**
+ * @brief 電流指令フレーム (Protocol 1, 0x64) を組み立てる。
+ *
+ * 仕様: DATA[2]=指令上位, DATA[3]=指令下位（電流モードでは -32767..32767 が -8A..8A）。
+ * 電流モードでは acceleration / brake バイトは無効。
+ * マルチバイトは big-endian (high, low)。
+ *
+ * @param motor_id    モータ ID
+ * @param current_raw 電流指令の生値（int16 として big-endian で格納）
+ * @return 全 10 バイトのフレーム
+ */
+std::vector<uint8_t> packCurrentFrame(uint8_t motor_id, int16_t current_raw);
+
+/**
+ * @brief Protocol 1 応答フレームのデコード結果。
+ */
+struct Feedback {
+  uint8_t mode;
+  uint16_t current;
+  int16_t speed;
+  uint8_t fault_code;
+};
+
+/**
+ * @brief parseFeedbackFrame の結果コード。
+ */
+enum class ParseResult {
+  kOk,
+  kBadLength,
+  kIdMismatch,
+  kCrcMismatch,
+};
+
+/**
+ * @brief Protocol 1 応答フレーム (DDT M0602C 仕様) をデコードする。
+ *
+ *  DATA[1]=mode, DATA[2..3]=torque current, DATA[4..5]=speed (signed),
+ *  DATA[6..7]=position, DATA[8]=fault code。
+ * マルチバイトは big-endian (high, low)。
+ *
+ * 検証順: 長さ==10 → 先頭 ID 一致 → CRC8(先頭9バイト)==frame[9]。
+ *
+ * @param expected_motor_id 期待するモータ ID (frame[0] と照合)
+ * @param frame             受信フレーム（10 バイトを期待）
+ * @param out               デコード結果（kOk のときのみ更新される）
+ * @return ParseResult
+ */
+ParseResult parseFeedbackFrame(uint8_t expected_motor_id, const std::vector<uint8_t>& frame,
+                               Feedback& out);
+
+}  // namespace motor_control_lib::ddt_protocol
+
+#endif  // MOTOR_CONTROL_LIB__DDT_PROTOCOL_HPP_

--- a/motor_control_lib/package.xml
+++ b/motor_control_lib/package.xml
@@ -15,6 +15,7 @@
     <depend>sensor_msgs</depend>
     <depend>joy</depend>
 
+    <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
 

--- a/motor_control_lib/src/ddt_motor_lib.cpp
+++ b/motor_control_lib/src/ddt_motor_lib.cpp
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <thread>
 
+#include "motor_control_lib/ddt_protocol.hpp"
+
 using namespace std::chrono_literals;
 
 namespace motor_control_lib {
@@ -381,21 +383,14 @@ bool DdtMotorLib::setModeVelocity(int motor_id) {
 
 bool DdtMotorLib::setControlMode(int motor_id, ControlMode mode) {
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
-  // Protocol 3 (モード切替)
-  // 仕様書: {ID, 0xA0, 0,0,0,0,0,0, 0, mode_value} （DATA[9] が mode_value で CRC 無し）
-  // 既存実装互換: DATA[8] に mode_value を入れ DATA[9] を CRC8(data[0..8]) とする独自レイアウト。
-  //   既存 velocity 切替 (mode_value=0) はこの形で実機動作実績がある。
-  //   電流モードで意図通り切替できない場合は仕様書通りの形 (DATA[9]=mode_value, CRC無し) に
-  //   フォールバックすること。
+  // フレーム組み立ては ddt_protocol::packModeFrame に集約（バイト列レイアウトは同関数を参照）。
   uint8_t mode_value = 0x02;  // 速度ループ
   if (mode == ControlMode::Current) {
     mode_value = 0x01;  // 電流ループ
   }
 
-  std::vector<uint8_t> data_fields = {
-      static_cast<uint8_t>(motor_id), 0xA0, 0, 0, 0, 0, 0, 0, mode_value};
-  uint8_t crc = crc8Maxim(data_fields);
-  data_fields.push_back(crc);
+  std::vector<uint8_t> data_fields =
+      ddt_protocol::packModeFrame(static_cast<uint8_t>(motor_id), mode_value);
 
   bool success = sendCommand(data_fields);
   if (success) {
@@ -450,18 +445,9 @@ void DdtMotorLib::setBrakeOnStop(bool enable) {
 bool DdtMotorLib::sendMotorVelocity(int motor_id, int velocity_rpm, bool brake) {
   int velocity_int = std::clamp(velocity_rpm, -max_motor_rpm_, max_motor_rpm_);
 
-  // 仕様 (M0602C プロトコル1): DATA[2]=指令上位8bit, DATA[3]=指令下位8bit。
-  // マルチバイトは big-endian (high, low)。sendMotorCurrentRaw と同じ並び。
-  uint8_t vel_high = static_cast<uint8_t>((velocity_int >> 8) & 0xFF);
-  uint8_t vel_low = static_cast<uint8_t>(velocity_int & 0xFF);
-
-  // DATA[6]=加速時間, DATA[7]=ブレーキ（0xFF でブレーキ、速度ループモードのみ有効）。
-  uint8_t brake_byte = brake ? 0xFF : 0x00;
-  std::vector<uint8_t> data_fields = {
-      static_cast<uint8_t>(motor_id), 0x64, vel_high, vel_low, 0, 0, 10, brake_byte, 0};
-
-  uint8_t crc = crc8Maxim(data_fields);
-  data_fields.push_back(crc);
+  // フレーム組み立ては ddt_protocol::packVelocityFrame に集約。加速時間は従来通り 10 固定。
+  std::vector<uint8_t> data_fields = ddt_protocol::packVelocityFrame(
+      static_cast<uint8_t>(motor_id), static_cast<int16_t>(velocity_int), /*accel_time=*/10, brake);
 
   bool success = sendCommand(data_fields);
   if (success) {
@@ -475,17 +461,9 @@ bool DdtMotorLib::sendMotorVelocity(int motor_id, int velocity_rpm, bool brake) 
 }
 
 bool DdtMotorLib::sendMotorCurrentRaw(int motor_id, int16_t current_raw) {
-  // Protocol 1 (0x64) を電流指令として送信。
-  // 仕様: DATA[2]=指令上位, DATA[3]=指令下位（電流モードでは -32767..32767 が -8A..8A）
-  // 電流モードでは acceleration / brake バイトは無効。
-  // マルチバイトは big-endian (high, low)。
-  uint8_t cur_high = static_cast<uint8_t>((current_raw >> 8) & 0xFF);
-  uint8_t cur_low = static_cast<uint8_t>(current_raw & 0xFF);
-
-  std::vector<uint8_t> data_fields = {
-      static_cast<uint8_t>(motor_id), 0x64, cur_high, cur_low, 0, 0, 0, 0, 0};
-  uint8_t crc = crc8Maxim(data_fields);
-  data_fields.push_back(crc);
+  // フレーム組み立ては ddt_protocol::packCurrentFrame に集約（バイト列レイアウトは同関数を参照）。
+  std::vector<uint8_t> data_fields =
+      ddt_protocol::packCurrentFrame(static_cast<uint8_t>(motor_id), current_raw);
 
   if (serial_fd_ < 0) {
     return false;
@@ -615,7 +593,7 @@ bool DdtMotorLib::readFeedbackFrame(int expected_motor_id, std::vector<uint8_t>&
         // 10バイト揃った段階で CRC を検証し、失敗なら先頭 1バイトを捨てて
         // 残りを保持したまま再同期を試みる（スライド同期）。
         std::vector<uint8_t> payload(out_frame.begin(), out_frame.begin() + 9);
-        if (crc8Maxim(payload) == out_frame[9]) {
+        if (ddt_protocol::crc8Maxim(payload) == out_frame[9]) {
           return true;
         }
         out_frame.erase(out_frame.begin());
@@ -631,19 +609,20 @@ bool DdtMotorLib::readFeedbackFrame(int expected_motor_id, std::vector<uint8_t>&
 }
 
 bool DdtMotorLib::parseFeedback(int expected_motor_id, const std::vector<uint8_t>& frame) {
-  if (frame.size() != 10) {
-    return false;
-  }
-  if (frame[0] != static_cast<uint8_t>(expected_motor_id)) {
-    return false;
-  }
-  // CRC8 検証（readFeedbackFrame 側でも検証済みだが、二重ガード）
-  std::vector<uint8_t> payload(frame.begin(), frame.begin() + 9);
-  uint8_t expected_crc = crc8Maxim(payload);
-  if (expected_crc != frame[9]) {
-    RCLCPP_WARN_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 1000,
-                         "CRC不一致 motor=%d expected=0x%02X got=0x%02X", expected_motor_id,
-                         expected_crc, frame[9]);
+  // フレーム分解・検証は ddt_protocol::parseFeedbackFrame に集約（readFeedbackFrame 側でも
+  // 検証済みだが、二重ガード）。
+  ddt_protocol::Feedback decoded{};
+  ddt_protocol::ParseResult result =
+      ddt_protocol::parseFeedbackFrame(static_cast<uint8_t>(expected_motor_id), frame, decoded);
+  if (result != ddt_protocol::ParseResult::kOk) {
+    if (result == ddt_protocol::ParseResult::kCrcMismatch) {
+      // ログ用に payload の期待 CRC を再計算する。
+      std::vector<uint8_t> payload(frame.begin(), frame.begin() + 9);
+      uint8_t expected_crc = ddt_protocol::crc8Maxim(payload);
+      RCLCPP_WARN_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 1000,
+                           "CRC不一致 motor=%d expected=0x%02X got=0x%02X", expected_motor_id,
+                           expected_crc, frame[9]);
+    }
     return false;
   }
 
@@ -652,12 +631,12 @@ bool DdtMotorLib::parseFeedback(int expected_motor_id, const std::vector<uint8_t
   //  DATA[6..7]=position, DATA[8]=fault code
   // マルチバイトは big-endian (high, low)。
   MotorFeedback& fb = motor_feedbacks_[expected_motor_id];
-  fb.mode = frame[1];
-  fb.current = static_cast<uint16_t>((frame[2] << 8) | frame[3]);
-  fb.speed = static_cast<int16_t>((frame[4] << 8) | frame[5]);
+  fb.mode = decoded.mode;
+  fb.current = decoded.current;
+  fb.speed = decoded.speed;
   // 位置はここでは使わないが、temperature 取得は Protocol 2 (0x74) が必要。
   // 暫定で前回値保持（既存挙動）。
-  fb.fault_code = frame[8];
+  fb.fault_code = decoded.fault_code;
 
   // PI 状態側にも保存（受信失敗時のフォールバック用）
   auto pi_it = pi_states_.find(expected_motor_id);
@@ -665,21 +644,6 @@ bool DdtMotorLib::parseFeedback(int expected_motor_id, const std::vector<uint8_t
     pi_it->second.last_measured_rpm = fb.speed;
   }
   return true;
-}
-
-uint8_t DdtMotorLib::crc8Maxim(const std::vector<uint8_t>& data) {
-  uint8_t crc = 0x00;
-  for (uint8_t byte : data) {
-    crc ^= byte;
-    for (int i = 0; i < 8; i++) {
-      if (crc & 0x01) {
-        crc = (crc >> 1) ^ 0x8C;
-      } else {
-        crc >>= 1;
-      }
-    }
-  }
-  return crc;
 }
 
 bool DdtMotorLib::sendCommand(const std::vector<uint8_t>& command, int retry_count) {

--- a/motor_control_lib/src/ddt_protocol.cpp
+++ b/motor_control_lib/src/ddt_protocol.cpp
@@ -1,0 +1,95 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include "motor_control_lib/ddt_protocol.hpp"
+
+namespace motor_control_lib::ddt_protocol {
+
+uint8_t crc8Maxim(const std::vector<uint8_t>& data) {
+  uint8_t crc = 0x00;
+  for (uint8_t byte : data) {
+    crc ^= byte;
+    for (int i = 0; i < 8; i++) {
+      if (crc & 0x01) {
+        crc = (crc >> 1) ^ 0x8C;
+      } else {
+        crc >>= 1;
+      }
+    }
+  }
+  return crc;
+}
+
+std::vector<uint8_t> packModeFrame(uint8_t motor_id, uint8_t mode_value) {
+  // Protocol 3 (モード切替)
+  // 仕様書: {ID, 0xA0, 0,0,0,0,0,0, 0, mode_value} （DATA[9] が mode_value で CRC 無し）
+  // 既存実装互換: DATA[8] に mode_value を入れ DATA[9] を CRC8(data[0..8]) とする独自レイアウト。
+  //   既存 velocity 切替 (mode_value=0) はこの形で実機動作実績がある。
+  //   電流モードで意図通り切替できない場合は仕様書通りの形 (DATA[9]=mode_value, CRC無し) に
+  //   フォールバックすること。
+  std::vector<uint8_t> data_fields = {motor_id, 0xA0, 0, 0, 0, 0, 0, 0, mode_value};
+  uint8_t crc = crc8Maxim(data_fields);
+  data_fields.push_back(crc);
+  return data_fields;
+}
+
+std::vector<uint8_t> packVelocityFrame(uint8_t motor_id, int16_t velocity_rpm, uint8_t accel_time,
+                                       bool brake) {
+  // 仕様 (M0602C プロトコル1): DATA[2]=指令上位8bit, DATA[3]=指令下位8bit。
+  // マルチバイトは big-endian (high, low)。packCurrentFrame と同じ並び。
+  uint8_t vel_high = static_cast<uint8_t>((velocity_rpm >> 8) & 0xFF);
+  uint8_t vel_low = static_cast<uint8_t>(velocity_rpm & 0xFF);
+
+  // DATA[6]=加速時間, DATA[7]=ブレーキ（0xFF でブレーキ、速度ループモードのみ有効）。
+  uint8_t brake_byte = brake ? 0xFF : 0x00;
+  std::vector<uint8_t> data_fields = {motor_id, 0x64,       vel_high,   vel_low, 0,
+                                      0,        accel_time, brake_byte, 0};
+
+  uint8_t crc = crc8Maxim(data_fields);
+  data_fields.push_back(crc);
+  return data_fields;
+}
+
+std::vector<uint8_t> packCurrentFrame(uint8_t motor_id, int16_t current_raw) {
+  // Protocol 1 (0x64) を電流指令として送信。
+  // 仕様: DATA[2]=指令上位, DATA[3]=指令下位（電流モードでは -32767..32767 が -8A..8A）
+  // 電流モードでは acceleration / brake バイトは無効。
+  // マルチバイトは big-endian (high, low)。
+  uint8_t cur_high = static_cast<uint8_t>((current_raw >> 8) & 0xFF);
+  uint8_t cur_low = static_cast<uint8_t>(current_raw & 0xFF);
+
+  std::vector<uint8_t> data_fields = {motor_id, 0x64, cur_high, cur_low, 0, 0, 0, 0, 0};
+  uint8_t crc = crc8Maxim(data_fields);
+  data_fields.push_back(crc);
+  return data_fields;
+}
+
+ParseResult parseFeedbackFrame(uint8_t expected_motor_id, const std::vector<uint8_t>& frame,
+                               Feedback& out) {
+  if (frame.size() != 10) {
+    return ParseResult::kBadLength;
+  }
+  if (frame[0] != expected_motor_id) {
+    return ParseResult::kIdMismatch;
+  }
+  // CRC8 検証（readFeedbackFrame 側でも検証済みだが、二重ガード）
+  std::vector<uint8_t> payload(frame.begin(), frame.begin() + 9);
+  uint8_t expected_crc = crc8Maxim(payload);
+  if (expected_crc != frame[9]) {
+    return ParseResult::kCrcMismatch;
+  }
+
+  // Protocol 1 応答フォーマット (DDT M0602C 仕様):
+  //  DATA[1]=mode, DATA[2..3]=torque current, DATA[4..5]=speed (signed),
+  //  DATA[6..7]=position, DATA[8]=fault code
+  // マルチバイトは big-endian (high, low)。
+  out.mode = frame[1];
+  out.current = static_cast<uint16_t>((frame[2] << 8) | frame[3]);
+  out.speed = static_cast<int16_t>((frame[4] << 8) | frame[5]);
+  out.fault_code = frame[8];
+  return ParseResult::kOk;
+}
+
+}  // namespace motor_control_lib::ddt_protocol

--- a/motor_control_lib/test/test_ddt_protocol.cpp
+++ b/motor_control_lib/test/test_ddt_protocol.cpp
@@ -1,0 +1,146 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "motor_control_lib/ddt_protocol.hpp"
+
+namespace ddt = motor_control_lib::ddt_protocol;
+
+namespace {
+
+std::vector<uint8_t> payloadOf(const std::vector<uint8_t>& frame) {
+  return std::vector<uint8_t>(frame.begin(), frame.begin() + 9);
+}
+
+}  // namespace
+
+TEST(Crc8Maxim, KnownAnswerAscii123456789) {
+  // CRC-8/MAXIM 標準チェック値: "123456789" -> 0xA1
+  std::vector<uint8_t> data = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+  EXPECT_EQ(ddt::crc8Maxim(data), 0xA1);
+}
+
+TEST(Crc8Maxim, EmptyVectorIsZero) { EXPECT_EQ(ddt::crc8Maxim(std::vector<uint8_t>{}), 0x00); }
+
+TEST(PackVelocityFrame, ByteOrderPositiveRpm) {
+  auto frame = ddt::packVelocityFrame(1, 100, 10, false);
+  ASSERT_EQ(frame.size(), 10u);
+  // 全10バイトの既知解 (CRC 0x25 は独立実装で事前計算した値)。
+  // CRC 実装が変わればこのテストで検出される。
+  const std::vector<uint8_t> expected = {0x01, 0x64, 0x00, 0x64, 0x00,
+                                         0x00, 0x0A, 0x00, 0x00, 0x25};
+  EXPECT_EQ(frame, expected);
+  EXPECT_EQ(frame[9], ddt::crc8Maxim(payloadOf(frame)));
+}
+
+TEST(PackVelocityFrame, NegativeRpmIsBigEndian) {
+  // -100 = 0xFF9C: DATA[2]=上位 0xFF, DATA[3]=下位 0x9C (big-endian 符号回帰テスト)
+  auto frame = ddt::packVelocityFrame(1, -100, 10, false);
+  ASSERT_EQ(frame.size(), 10u);
+  EXPECT_EQ(frame[2], 0xFF);
+  EXPECT_EQ(frame[3], 0x9C);
+  EXPECT_EQ(frame[9], ddt::crc8Maxim(payloadOf(frame)));
+}
+
+TEST(PackVelocityFrame, BrakeSetsByte7) {
+  auto frame = ddt::packVelocityFrame(1, 100, 10, true);
+  ASSERT_EQ(frame.size(), 10u);
+  EXPECT_EQ(frame[7], 0xFF);
+  EXPECT_EQ(frame[9], ddt::crc8Maxim(payloadOf(frame)));
+}
+
+TEST(PackCurrentFrame, NegativeRawIsBigEndian) {
+  auto frame = ddt::packCurrentFrame(1, -100);
+  ASSERT_EQ(frame.size(), 10u);
+  const std::vector<uint8_t> expected_payload = {0x01, 0x64, 0xFF, 0x9C, 0x00,
+                                                 0x00, 0x00, 0x00, 0x00};
+  EXPECT_EQ(payloadOf(frame), expected_payload);
+  EXPECT_EQ(frame[9], ddt::crc8Maxim(payloadOf(frame)));
+}
+
+TEST(PackCurrentFrame, MaxRawAndZeroTailBytes) {
+  auto frame = ddt::packCurrentFrame(1, 32767);
+  ASSERT_EQ(frame.size(), 10u);
+  EXPECT_EQ(frame[2], 0x7F);
+  EXPECT_EQ(frame[3], 0xFF);
+  // 電流モードでは acceleration / brake バイトは無効（常に 0）
+  EXPECT_EQ(frame[6], 0x00);
+  EXPECT_EQ(frame[7], 0x00);
+  EXPECT_EQ(frame[9], ddt::crc8Maxim(payloadOf(frame)));
+}
+
+TEST(PackModeFrame, ModeValueLandsInByte8) {
+  // 既存実装互換の独自レイアウト: mode_value は DATA[8]
+  auto current_frame = ddt::packModeFrame(1, 0x01);
+  ASSERT_EQ(current_frame.size(), 10u);
+  EXPECT_EQ(current_frame[1], 0xA0);
+  EXPECT_EQ(current_frame[8], 0x01);
+  EXPECT_EQ(current_frame[9], ddt::crc8Maxim(payloadOf(current_frame)));
+
+  auto velocity_frame = ddt::packModeFrame(1, 0x02);
+  ASSERT_EQ(velocity_frame.size(), 10u);
+  EXPECT_EQ(velocity_frame[1], 0xA0);
+  EXPECT_EQ(velocity_frame[8], 0x02);
+  EXPECT_EQ(velocity_frame[9], ddt::crc8Maxim(payloadOf(velocity_frame)));
+}
+
+TEST(ParseFeedbackFrame, ValidFrame) {
+  // speed = 0xFF9C = -100 (int16 符号拡張回帰テスト), current = 0x0102
+  std::vector<uint8_t> frame = {0x01, 0x01, 0x01, 0x02, 0xFF, 0x9C, 0x00, 0x00, 0x00};
+  frame.push_back(ddt::crc8Maxim(frame));
+  // 独立実装で事前計算した CRC の既知解
+  EXPECT_EQ(frame[9], 0x8E);
+
+  ddt::Feedback fb{};
+  EXPECT_EQ(ddt::parseFeedbackFrame(0x01, frame, fb), ddt::ParseResult::kOk);
+  EXPECT_EQ(fb.mode, 0x01);
+  EXPECT_EQ(fb.current, 0x0102);
+  EXPECT_EQ(fb.speed, -100);
+  EXPECT_EQ(fb.fault_code, 0x00);
+}
+
+TEST(ParseFeedbackFrame, BadLength) {
+  ddt::Feedback fb{};
+  std::vector<uint8_t> short_frame(9, 0x00);
+  short_frame[0] = 0x01;
+  EXPECT_EQ(ddt::parseFeedbackFrame(0x01, short_frame, fb), ddt::ParseResult::kBadLength);
+
+  std::vector<uint8_t> long_frame(11, 0x00);
+  long_frame[0] = 0x01;
+  EXPECT_EQ(ddt::parseFeedbackFrame(0x01, long_frame, fb), ddt::ParseResult::kBadLength);
+}
+
+TEST(ParseFeedbackFrame, IdMismatch) {
+  std::vector<uint8_t> frame = {0x01, 0x01, 0x01, 0x02, 0xFF, 0x9C, 0x00, 0x00, 0x00};
+  frame.push_back(ddt::crc8Maxim(frame));
+
+  ddt::Feedback fb{};
+  EXPECT_EQ(ddt::parseFeedbackFrame(0x02, frame, fb), ddt::ParseResult::kIdMismatch);
+}
+
+TEST(ParseFeedbackFrame, CrcMismatch) {
+  std::vector<uint8_t> frame = {0x01, 0x01, 0x01, 0x02, 0xFF, 0x9C, 0x00, 0x00, 0x00};
+  frame.push_back(static_cast<uint8_t>(ddt::crc8Maxim(frame) ^ 0xFF));
+
+  ddt::Feedback fb{};
+  EXPECT_EQ(ddt::parseFeedbackFrame(0x01, frame, fb), ddt::ParseResult::kCrcMismatch);
+}
+
+TEST(PackVelocityFrame, RoundTripCrcMatches) {
+  for (int16_t rpm : {int16_t{-330}, int16_t{-1}, int16_t{0}, int16_t{1}, int16_t{330}}) {
+    auto frame = ddt::packVelocityFrame(1, rpm, 10, false);
+    ASSERT_EQ(frame.size(), 10u);
+    EXPECT_EQ(frame[9], ddt::crc8Maxim(payloadOf(frame))) << "rpm=" << rpm;
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## 概要

Issue #91 チェックリスト項目1: `DdtMotorLib::crc8Maxim` と送信フレームのパック/フィードバックフレームのアンパックのユニットテスト整備。

- DDT M0602C のフレーム組み立て・分解・CRC8 を `motor_control_lib::ddt_protocol` の純粋フリー関数へ抽出(`packModeFrame` / `packVelocityFrame` / `packCurrentFrame` / `parseFeedbackFrame` / `crc8Maxim`)
- `DdtMotorLib` は薄い委譲ラッパに変更。シリアル I/O、リトライ、ロック、ログ、`motor_feedbacks_`/`pi_states_` 更新はすべて従来どおりラッパ側
- `motor_control_lib` に初の gtest 基盤を追加(`ament_auto_add_gtest` + `<test_depend>ament_cmake_gtest</test_depend>`)
- byte order(big-endian)回帰テスト、int16 符号拡張回帰、CRC 既知解答値(CRC-8/MAXIM "123456789" → 0xA1)、フレーム全バイトの既知解答リテラルを含む 13 テスト

**No wire-format change; frames verified byte-identical by known-answer tests.**

## 検証

- `colcon build` / `colcon test` / `colcon test-result`: 52 tests, 0 failures(新規 gtest 13/13 パス)
- fail 検知実証: 既知解答 CRC リテラルを 1 バイト反転 → `colcon test-result` exit 1 を確認後、復元して green
- `ament_clang_format --config .clang-format`: clean

## 注意

- Feetech Modbus テストの PR と同じ `motor_control_lib/CMakeLists.txt` / `package.xml` を触るため、後にマージする側で軽微な rebase が必要になる場合があります
- 後続のスタック PR(PI 抽出)がこのブランチを基点にしています

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)