### PR TITLE
test: add ddt current-loop pi unit tests

### DIFF
--- a/motor_control_lib/CMakeLists.txt
+++ b/motor_control_lib/CMakeLists.txt
@@ -11,6 +11,7 @@ ament_auto_find_build_dependencies()
 
 # Create shared library with implementation
 ament_auto_add_library(motor_control_lib SHARED
+  src/ddt_current_pi.cpp
   src/ddt_motor_lib.cpp
   src/ddt_protocol.cpp
   src/differential_drive.cpp
@@ -26,6 +27,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_auto_add_gtest(test_ddt_protocol test/test_ddt_protocol.cpp)
+  ament_auto_add_gtest(test_ddt_current_pi test/test_ddt_current_pi.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE)

--- a/motor_control_lib/include/motor_control_lib/ddt_current_pi.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_current_pi.hpp
@@ -1,0 +1,74 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#ifndef MOTOR_CONTROL_LIB__DDT_CURRENT_PI_HPP_
+#define MOTOR_CONTROL_LIB__DDT_CURRENT_PI_HPP_
+
+#include <cstdint>
+
+namespace motor_control_lib::ddt_current_pi {
+
+/**
+ * @brief DDT モータ Current モードのソフトウェア PI 制御を提供する純粋関数群。
+ *
+ * ここに含まれる関数はシリアル I/O・rclcpp・時刻取得に一切依存せず、
+ * 目標 RPM と実測 RPM から電流指令 raw 値を計算するだけである（単体テスト可能）。
+ * dt サニタイズ・ゼロ近傍デッドバンド判定も同様に純粋関数として切り出す。
+ */
+
+/**
+ * @brief Current モード PI パラメータ（全モータ共通）。
+ */
+struct Params {
+  double kp;               // [A/rpm] 比例ゲイン
+  double ki;               // [A/(rpm·s)] 積分ゲイン
+  double max_current_amp;  // [A] 電流指令の絶対値上限（安全クランプ）
+  double integral_limit_amp;  // [A] 積分項寄与の絶対値上限（アンチワインドアップ）
+  bool invert_measured;  // measured RPM 符号反転（正帰還押さえ用）
+};
+
+/**
+ * @brief PI 積分器の状態（モータ毎に保持）。
+ */
+struct State {
+  double integral_amp{0.0};
+};
+
+/**
+ * @brief dt をサニタイズする。異常値（0 以下、または 0.2 を超える）は 0.01 に丸める。
+ *  0.2 ちょうどは正常値として保持する。
+ */
+double sanitizeDt(double dt_seconds);
+
+/**
+ * @brief ゼロ近傍デッドバンド判定。目標 RPM が 0 かつ実測 RPM の絶対値が
+ *  deadband_rpm 以下のとき true。実測 RPM は符号反転前の生値を渡すこと。
+ */
+bool inZeroDeadband(int rpm_ref, int measured_rpm, int deadband_rpm);
+
+/**
+ * @brief PI 1 ステップを実行し、電流指令 raw 値を返す純粋関数。
+ *
+ * 処理順は元実装 (DdtMotorLib::runCurrentLoopStep) と同一:
+ *   measured を必要なら符号反転 → error = ref - measured → 積分項更新
+ *   → アンチワインドアップ（積分項寄与 = Ki * integral を ±integral_limit_amp
+ *     にクランプ。Ki<=1e-9 のときは積分項を 0 にリセット）
+ *   → i_cmd = Kp*error + Ki*integral を ±max_current_amp にクランプ
+ *   → -8A..8A が -32767..32767 に対応（仕様書）ので A→raw 換算し ±32767 でクランプ。
+ *
+ * @param state           PI 積分器の状態（更新される）。
+ * @param params          PI パラメータ。
+ * @param rpm_ref         目標 RPM。
+ * @param measured_rpm    実測 RPM（符号反転前の生値）。
+ * @param dt              サニタイズ済み dt [s]。
+ * @param i_cmd_amp_out   非 null なら、クランプ後の電流指令 [A] を書き込む（ログ用）。
+ * @return 電流指令 raw 値（±32767）。
+ */
+int16_t stepToRaw(State& state, const Params& params, int rpm_ref, int measured_rpm, double dt,
+                  double* i_cmd_amp_out = nullptr);
+
+}  // namespace motor_control_lib::ddt_current_pi
+
+#endif  // MOTOR_CONTROL_LIB__DDT_CURRENT_PI_HPP_

--- a/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "motor_control_lib/base_motor_controller.hpp"
+#include "motor_control_lib/ddt_current_pi.hpp"
 
 namespace motor_control_lib {
 
@@ -131,7 +132,7 @@ private:
 
   // Current モード用 PI 状態（モータ毎）
   struct PiState {
-    double integral_amp{0.0};
+    ddt_current_pi::State pi;
     int16_t last_measured_rpm{0};
     std::chrono::steady_clock::time_point last_t{};
     bool has_last_t{false};

--- a/motor_control_lib/src/ddt_current_pi.cpp
+++ b/motor_control_lib/src/ddt_current_pi.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include "motor_control_lib/ddt_current_pi.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace motor_control_lib::ddt_current_pi {
+
+double sanitizeDt(double dt_seconds) {
+  if (dt_seconds <= 0.0 || dt_seconds > 0.2) {
+    return 0.01;  // 異常値クリップ（初回および異常時のフォールバック [s]）
+  }
+  return dt_seconds;
+}
+
+bool inZeroDeadband(int rpm_ref, int measured_rpm, int deadband_rpm) {
+  return rpm_ref == 0 && std::abs(measured_rpm) <= deadband_rpm;
+}
+
+int16_t stepToRaw(State& state, const Params& params, int rpm_ref, int measured_rpm, double dt,
+                  double* i_cmd_amp_out) {
+  int measured = params.invert_measured ? -measured_rpm : measured_rpm;
+
+  double error = static_cast<double>(rpm_ref - measured);
+
+  // 積分項更新 (アンチワインドアップ: 積分項寄与 = Ki * integral を ±integral_limit_amp
+  // にクランプ)
+  state.integral_amp += error * dt;
+  if (params.ki > 1e-9) {
+    double integ_clip = params.integral_limit_amp / params.ki;
+    state.integral_amp = std::clamp(state.integral_amp, -integ_clip, integ_clip);
+  } else {
+    state.integral_amp = 0.0;
+  }
+
+  double i_cmd_amp = params.kp * error + params.ki * state.integral_amp;
+  i_cmd_amp = std::clamp(i_cmd_amp, -params.max_current_amp, params.max_current_amp);
+  if (i_cmd_amp_out != nullptr) {
+    *i_cmd_amp_out = i_cmd_amp;
+  }
+
+  // -8A..8A が -32767..32767 に対応（仕様書）
+  double raw_d = (i_cmd_amp / 8.0) * 32767.0;
+  int raw = static_cast<int>(std::lround(raw_d));
+  raw = std::clamp(raw, -32767, 32767);
+  return static_cast<int16_t>(raw);
+}
+
+}  // namespace motor_control_lib::ddt_current_pi

--- a/motor_control_lib/src/ddt_motor_lib.cpp
+++ b/motor_control_lib/src/ddt_motor_lib.cpp
@@ -84,7 +84,7 @@ bool DdtMotorLib::isHealthy() const {
 
 void DdtMotorLib::resetCurrentPiStateForStop(int motor_id) {
   auto& pi_state = pi_states_[motor_id];
-  pi_state.integral_amp = 0.0;
+  pi_state.pi.integral_amp = 0.0;
   pi_state.has_last_t = false;
   pi_state.ref_rpm_filtered = 0.0;
   pi_state.last_ref_t = {};
@@ -176,10 +176,10 @@ bool DdtMotorLib::setMotorVelocity(int motor_id, int velocity_rpm) {
       if (fb_it != motor_feedbacks_.end()) {
         measured_rpm = static_cast<int>(fb_it->second.speed);
       }
-      if (std::abs(measured_rpm) <= current_zero_deadband_rpm_) {
+      if (ddt_current_pi::inZeroDeadband(rpm_ref, measured_rpm, current_zero_deadband_rpm_)) {
         auto pi_it = pi_states_.find(motor_id);
         if (pi_it != pi_states_.end()) {
-          pi_it->second.integral_amp = 0.0;
+          pi_it->second.pi.integral_amp = 0.0;
           pi_it->second.has_last_t = false;
         }
         return sendMotorCurrentRaw(motor_id, 0);
@@ -504,47 +504,32 @@ int16_t DdtMotorLib::runCurrentLoopStep(int motor_id, int rpm_ref) {
   double dt = 0.01;  // 初回および異常時のフォールバック [s]
   if (st.has_last_t) {
     dt = std::chrono::duration<double>(now - st.last_t).count();
-    if (dt <= 0.0 || dt > 0.2) {
-      dt = 0.01;  // 異常値クリップ
-    }
   }
   st.last_t = now;
   st.has_last_t = true;
+  dt = ddt_current_pi::sanitizeDt(dt);
 
-  // 実測 RPM: フィードバック未取得なら前回保持値（受信失敗時は最新フィードバックがそのまま残る）
+  // 実測 RPM: フィードバック未取得なら前回保持値（受信失敗時は最新フィードバックがそのまま残る）。
+  // 符号反転は stepToRaw 内で行うため、ここでは生値を渡す。
   int measured_rpm = 0;
   auto fb_it = motor_feedbacks_.find(motor_id);
   if (fb_it != motor_feedbacks_.end()) {
     measured_rpm = static_cast<int>(fb_it->second.speed);
   }
-  if (current_invert_measured_) {
-    measured_rpm = -measured_rpm;
-  }
 
-  double error = static_cast<double>(rpm_ref - measured_rpm);
+  ddt_current_pi::Params params{current_kp_, current_ki_, max_current_amp_, integral_limit_amp_,
+                                current_invert_measured_};
+  double i_cmd_amp = 0.0;
+  int16_t raw = ddt_current_pi::stepToRaw(st.pi, params, rpm_ref, measured_rpm, dt, &i_cmd_amp);
 
-  // 積分項更新 (アンチワインドアップ: 積分項寄与 = Ki * integral を ±integral_limit_amp_
-  // にクランプ)
-  st.integral_amp += error * dt;
-  if (current_ki_ > 1e-9) {
-    double integ_clip = integral_limit_amp_ / current_ki_;
-    st.integral_amp = std::clamp(st.integral_amp, -integ_clip, integ_clip);
-  } else {
-    st.integral_amp = 0.0;
-  }
-
-  double i_cmd_amp = current_kp_ * error + current_ki_ * st.integral_amp;
-  i_cmd_amp = std::clamp(i_cmd_amp, -max_current_amp_, max_current_amp_);
-
-  // -8A..8A が -32767..32767 に対応（仕様書）
-  double raw_d = (i_cmd_amp / 8.0) * 32767.0;
-  int raw = static_cast<int>(std::lround(raw_d));
-  raw = std::clamp(raw, -32767, 32767);
-
+  // ログは従来通り符号反転後の実測値と、それに基づく error を表示する。
+  int meas_logged = current_invert_measured_ ? -measured_rpm : measured_rpm;
+  double error = static_cast<double>(rpm_ref - meas_logged);
   RCLCPP_INFO_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 200,
                        "PI motor=%d ref=%d meas=%d err=%.1f integ=%.3fA i_cmd=%.3fA raw=%d dt=%.4f",
-                       motor_id, rpm_ref, measured_rpm, error, st.integral_amp, i_cmd_amp, raw, dt);
-  return static_cast<int16_t>(raw);
+                       motor_id, rpm_ref, meas_logged, error, st.pi.integral_amp, i_cmd_amp,
+                       static_cast<int>(raw), dt);
+  return raw;
 }
 
 bool DdtMotorLib::readFeedbackFrame(int expected_motor_id, std::vector<uint8_t>& out_frame,

--- a/motor_control_lib/test/test_ddt_current_pi.cpp
+++ b/motor_control_lib/test/test_ddt_current_pi.cpp
@@ -1,0 +1,130 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "motor_control_lib/ddt_current_pi.hpp"
+
+namespace pi = motor_control_lib::ddt_current_pi;
+
+namespace {
+
+// 参照パラメータ: kp=0.005, ki=0.02, max_current_amp=2.0, integral_limit_amp=1.5,
+// invert_measured=false（明記がない限り）。
+pi::Params refParams(double ki = 0.02, bool invert = false) {
+  return pi::Params{/*kp=*/0.005, /*ki=*/ki, /*max_current_amp=*/2.0,
+                    /*integral_limit_amp=*/1.5, /*invert_measured=*/invert};
+}
+
+}  // namespace
+
+TEST(StepToRaw, ProportionalTerm) {
+  // ki=0.0 → 積分項は 0 に強制される (ki<=1e-9 分岐)。
+  pi::State state;
+  pi::Params params = refParams(/*ki=*/0.0);
+  int16_t raw = pi::stepToRaw(state, params, /*rpm_ref=*/100, /*measured_rpm=*/0, /*dt=*/0.01);
+  EXPECT_EQ(state.integral_amp, 0.0);
+  // lround(0.005*100/8.0*32767) == lround(0.5/8*32767) == 2048
+  EXPECT_EQ(raw, 2048);
+}
+
+TEST(StepToRaw, IntegralAccumulates) {
+  pi::State state;
+  pi::Params params = refParams();
+  int16_t raw1 = pi::stepToRaw(state, params, /*rpm_ref=*/100, /*measured_rpm=*/0, /*dt=*/0.01);
+  int16_t raw2 = pi::stepToRaw(state, params, /*rpm_ref=*/100, /*measured_rpm=*/0, /*dt=*/0.01);
+  EXPECT_GT(raw2, raw1);
+  // クランプ未達なので integral == error*dt*2 == 100*0.01*2 == 2.0
+  EXPECT_NEAR(state.integral_amp, 2.0, 1e-9);
+}
+
+TEST(StepToRaw, AntiWindup) {
+  pi::State state;
+  pi::Params params = refParams();
+  int16_t raw = 0;
+  for (int i = 0; i < 100; ++i) {
+    raw = pi::stepToRaw(state, params, /*rpm_ref=*/1000, /*measured_rpm=*/0, /*dt=*/0.01);
+  }
+  // integral は integral_limit_amp/ki == 1.5/0.02 == 75.0 でクランプ。
+  EXPECT_DOUBLE_EQ(state.integral_amp, 75.0);
+  // 出力は max_current_amp=2.0 でクランプ: lround(2.0/8*32767) == 8192
+  EXPECT_EQ(raw, 8192);
+}
+
+TEST(StepToRaw, OutputClampNegative) {
+  pi::State state;
+  pi::Params params = refParams();
+  int16_t raw = 0;
+  for (int i = 0; i < 100; ++i) {
+    raw = pi::stepToRaw(state, params, /*rpm_ref=*/-1000, /*measured_rpm=*/0, /*dt=*/0.01);
+  }
+  EXPECT_DOUBLE_EQ(state.integral_amp, -75.0);
+  EXPECT_EQ(raw, -8192);
+}
+
+TEST(StepToRaw, InvertMeasured) {
+  // invert=false: ref=0, measured=100 → error<0 → raw 負。
+  pi::State state_no;
+  int16_t raw_no = pi::stepToRaw(state_no, refParams(/*ki=*/0.02, /*invert=*/false), 0, 100, 0.01);
+  EXPECT_LT(raw_no, 0);
+
+  // invert=true: measured を反転して error>0 → raw 正、大きさは同じ。
+  pi::State state_inv;
+  int16_t raw_inv = pi::stepToRaw(state_inv, refParams(/*ki=*/0.02, /*invert=*/true), 0, 100, 0.01);
+  EXPECT_GT(raw_inv, 0);
+  EXPECT_EQ(raw_inv, -raw_no);
+}
+
+TEST(SanitizeDt, ClipsAbnormalValues) {
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.0), 0.01);
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(-1.0), 0.01);
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.25), 0.01);
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.05), 0.05);
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.2), 0.2);  // 境界は保持
+}
+
+TEST(InZeroDeadband, Boundaries) {
+  EXPECT_TRUE(pi::inZeroDeadband(0, 3, 5));
+  EXPECT_TRUE(pi::inZeroDeadband(0, 5, 5));
+  EXPECT_FALSE(pi::inZeroDeadband(0, 6, 5));
+  EXPECT_FALSE(pi::inZeroDeadband(1, 0, 5));
+  EXPECT_TRUE(pi::inZeroDeadband(0, -5, 5));
+  EXPECT_TRUE(pi::inZeroDeadband(0, 0, 0));
+}
+
+TEST(StepToRaw, ResetClearsWindup) {
+  pi::State state;
+  pi::Params params = refParams();
+  for (int i = 0; i < 100; ++i) {
+    pi::stepToRaw(state, params, /*rpm_ref=*/1000, /*measured_rpm=*/0, /*dt=*/0.01);
+  }
+  ASSERT_DOUBLE_EQ(state.integral_amp, 75.0);
+
+  // リセット。
+  state = {};
+
+  int16_t raw_after =
+      pi::stepToRaw(state, params, /*rpm_ref=*/100, /*measured_rpm=*/0, /*dt=*/0.01);
+
+  pi::State fresh;
+  int16_t raw_fresh =
+      pi::stepToRaw(fresh, params, /*rpm_ref=*/100, /*measured_rpm=*/0, /*dt=*/0.01);
+
+  EXPECT_EQ(raw_after, raw_fresh);
+  EXPECT_DOUBLE_EQ(state.integral_amp, fresh.integral_amp);
+}
+
+TEST(StepToRaw, ICmdAmpOut) {
+  pi::State state;
+  pi::Params params = refParams();
+  double i_cmd_amp = 0.0;
+  for (int i = 0; i < 100; ++i) {
+    pi::stepToRaw(state, params, /*rpm_ref=*/1000, /*measured_rpm=*/0, /*dt=*/0.01, &i_cmd_amp);
+  }
+  // アンチワインドアップ飽和状態ではクランプ後の電流指令は max_current_amp=2.0。
+  EXPECT_DOUBLE_EQ(i_cmd_amp, 2.0);
+}


### PR DESCRIPTION
## 概要

Issue #91 チェックリスト項目2: `runCurrentLoopStep` の PI 制御(アンチワインドアップ、デッドバンド、リセット)のユニットテスト整備。

**#102(DDT protocol 抽出)に積み上げたスタック PR です。#102 マージ後に base が main に切り替わります。**

- 電流ループの PI ステップ・dt サニタイズ・静止デッドバンド判定を `motor_control_lib::ddt_current_pi` の純粋関数へ抽出(`stepToRaw` / `sanitizeDt` / `inZeroDeadband`、`Params`/`State` 構造体)
- dt をパラメータ化したことでテストが決定的に(steady_clock 依存はラッパ側に残置)
- 符号反転(`invert_measured`)は `stepToRaw` 内へ移動。デッドバンド判定が反転前の生実測値を使う従来挙動、および RCLCPP_INFO_THROTTLE のログ内容(反転後 meas / err / integ / i_cmd / raw / dt)は完全維持
- 積分リセット(integral=0 + `has_last_t=false`)は従来どおりラッパ側(AGENTS.md の制御状態リセット則)
- アンチワインドアップ(積分が `integral_limit/ki` に張り付き・出力固定)、クランプ、符号反転、dt 境界、デッドバンド境界、リセット回帰の 9 テスト

**Numerical behavior unchanged.**

## 検証

- `colcon test-result`: 68 tests, 0 failures(新規 gtest 9/9、#102 の test_ddt_protocol も継続パス)
- fail 検知実証: 期待値を改変 → exit 1 確認後、復元して green
- `ament_clang_format`: clean

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)