### PR TITLE
test: add feetech modbus protocol unit tests

### DIFF
--- a/motor_control_lib/CMakeLists.txt
+++ b/motor_control_lib/CMakeLists.txt
@@ -15,6 +15,7 @@ ament_auto_add_library(motor_control_lib SHARED
   src/ddt_motor_lib.cpp
   src/ddt_protocol.cpp
   src/differential_drive.cpp
+  src/feetech_protocol.cpp
   src/motor_manager.cpp
   src/servo_control.cpp
 )
@@ -28,6 +29,7 @@ if(BUILD_TESTING)
 
   ament_auto_add_gtest(test_ddt_protocol test/test_ddt_protocol.cpp)
   ament_auto_add_gtest(test_ddt_current_pi test/test_ddt_current_pi.cpp)
+  ament_auto_add_gtest(test_feetech_protocol test/test_feetech_protocol.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE)

--- a/motor_control_lib/include/motor_control_lib/feetech_protocol.hpp
+++ b/motor_control_lib/include/motor_control_lib/feetech_protocol.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#ifndef MOTOR_CONTROL_LIB__FEETECH_PROTOCOL_HPP_
+#define MOTOR_CONTROL_LIB__FEETECH_PROTOCOL_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace motor_control_lib::feetech_protocol {
+
+/**
+ * @brief Modbus CRC16計算
+ * @param data データ配列
+ * @param length データ長
+ * @return CRC16値
+ *
+ * CRC-16/MODBUS (init 0xFFFF, poly 0xA001)。
+ */
+uint16_t calculateCrc16(const uint8_t* data, size_t length);
+
+/**
+ * @brief Modbusコマンド作成
+ * @param slave_id スレーブID
+ * @param function_code ファンクションコード
+ * @param address アドレス
+ * @param value 値
+ * @param command 出力バッファ（8バイト以上）
+ * @return コマンド長（常に8）
+ *
+ * 8バイトを書き込む: [id][fc][addrH][addrL][valH][valL][crcL][crcH]。
+ * バイトオーダは混在: アドレスと値はビッグエンディアン、CRCはリトル
+ * エンディアン（Modbus-RTU）。
+ */
+size_t createModbusCommand(uint8_t slave_id, uint8_t function_code, uint16_t address,
+                           uint16_t value, uint8_t* command);
+
+/**
+ * @brief チェックサム検証
+ * @param data データ配列
+ * @param length データ長
+ * @return 検証成功時true
+ *
+ * length < 3 の場合は false。末尾2バイトをリトルエンディアンCRCとして
+ * 検証する（Modbus-RTU）。
+ */
+bool verifyChecksum(const uint8_t* data, size_t length);
+
+}  // namespace motor_control_lib::feetech_protocol
+
+#endif  // MOTOR_CONTROL_LIB__FEETECH_PROTOCOL_HPP_

--- a/motor_control_lib/include/motor_control_lib/servo_control.hpp
+++ b/motor_control_lib/include/motor_control_lib/servo_control.hpp
@@ -114,34 +114,6 @@ private:
   std::map<uint16_t, RegisterInfo> known_registers_;
 
   /**
-   * @brief Modbus CRC16計算
-   * @param data データ配列
-   * @param length データ長
-   * @return CRC16値
-   */
-  uint16_t calculateCRC16(const uint8_t* data, size_t length);
-
-  /**
-   * @brief Modbusコマンド作成
-   * @param slave_id スレーブID
-   * @param function_code ファンクションコード
-   * @param address アドレス
-   * @param value 値
-   * @param command 出力バッファ
-   * @return コマンド長
-   */
-  size_t createModbusCommand(uint8_t slave_id, uint8_t function_code, uint16_t address,
-                             uint16_t value, uint8_t* command);
-
-  /**
-   * @brief チェックサム検証
-   * @param data データ配列
-   * @param length データ長
-   * @return 検証成功時true
-   */
-  bool verifyChecksum(const uint8_t* data, size_t length);
-
-  /**
    * @brief コマンド送信
    * @param cmd_bytes コマンドバイト配列
    * @param cmd_length コマンド長

--- a/motor_control_lib/src/feetech_protocol.cpp
+++ b/motor_control_lib/src/feetech_protocol.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include "motor_control_lib/feetech_protocol.hpp"
+
+namespace motor_control_lib::feetech_protocol {
+
+uint16_t calculateCrc16(const uint8_t* data, size_t length) {
+  uint16_t crc = 0xFFFF;
+  for (size_t i = 0; i < length; i++) {
+    crc ^= data[i];
+    for (int j = 0; j < 8; j++) {
+      if (crc & 1) {
+        crc >>= 1;
+        crc ^= 0xA001;
+      } else {
+        crc >>= 1;
+      }
+    }
+  }
+  return crc;
+}
+
+size_t createModbusCommand(uint8_t slave_id, uint8_t function_code, uint16_t address,
+                           uint16_t value, uint8_t* command) {
+  command[0] = slave_id;
+  command[1] = function_code;
+  command[2] = (address >> 8) & 0xFF;  // アドレス上位
+  command[3] = address & 0xFF;         // アドレス下位
+  command[4] = (value >> 8) & 0xFF;    // 値上位
+  command[5] = value & 0xFF;           // 値下位
+
+  uint16_t crc = calculateCrc16(command, 6);
+  command[6] = crc & 0xFF;         // CRC下位
+  command[7] = (crc >> 8) & 0xFF;  // CRC上位
+
+  return 8;
+}
+
+bool verifyChecksum(const uint8_t* data, size_t length) {
+  if (length < 3) {
+    return false;
+  }
+
+  // データ部分（最後の2バイトを除く）
+  size_t data_length = length - 2;
+  // Modbus-RTUではCRCはリトルエンディアン
+  uint16_t received_crc = data[length - 2] | (data[length - 1] << 8);
+  uint16_t calculated_crc = calculateCrc16(data, data_length);
+
+  return received_crc == calculated_crc;
+}
+
+}  // namespace motor_control_lib::feetech_protocol

--- a/motor_control_lib/src/servo_control.cpp
+++ b/motor_control_lib/src/servo_control.cpp
@@ -5,6 +5,8 @@
 // https://opensource.org/licenses/MIT.
 #include "motor_control_lib/servo_control.hpp"
 
+#include "motor_control_lib/feetech_protocol.hpp"
+
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
@@ -149,53 +151,6 @@ void FeetechServoController::disconnect() {
 
 bool FeetechServoController::isConnected() const { return connected_; }
 
-uint16_t FeetechServoController::calculateCRC16(const uint8_t* data, size_t length) {
-  uint16_t crc = 0xFFFF;
-  for (size_t i = 0; i < length; i++) {
-    crc ^= data[i];
-    for (int j = 0; j < 8; j++) {
-      if (crc & 1) {
-        crc >>= 1;
-        crc ^= 0xA001;
-      } else {
-        crc >>= 1;
-      }
-    }
-  }
-  return crc;
-}
-
-size_t FeetechServoController::createModbusCommand(uint8_t slave_id, uint8_t function_code,
-                                                   uint16_t address, uint16_t value,
-                                                   uint8_t* command) {
-  command[0] = slave_id;
-  command[1] = function_code;
-  command[2] = (address >> 8) & 0xFF;  // アドレス上位
-  command[3] = address & 0xFF;         // アドレス下位
-  command[4] = (value >> 8) & 0xFF;    // 値上位
-  command[5] = value & 0xFF;           // 値下位
-
-  uint16_t crc = calculateCRC16(command, 6);
-  command[6] = crc & 0xFF;         // CRC下位
-  command[7] = (crc >> 8) & 0xFF;  // CRC上位
-
-  return 8;
-}
-
-bool FeetechServoController::verifyChecksum(const uint8_t* data, size_t length) {
-  if (length < 3) {
-    return false;
-  }
-
-  // データ部分（最後の2バイトを除く）
-  size_t data_length = length - 2;
-  // Modbus-RTUではCRCはリトルエンディアン
-  uint16_t received_crc = data[length - 2] | (data[length - 1] << 8);
-  uint16_t calculated_crc = calculateCRC16(data, data_length);
-
-  return received_crc == calculated_crc;
-}
-
 int FeetechServoController::sendCommand(const uint8_t* cmd_bytes, size_t cmd_length,
                                         uint8_t* response, size_t max_response_length,
                                         bool expect_response) {
@@ -288,7 +243,7 @@ int FeetechServoController::sendCommand(const uint8_t* cmd_bytes, size_t cmd_len
       }
 
       // チェックサム検証
-      if (verifyChecksum(response, bytes_read)) {
+      if (feetech_protocol::verifyChecksum(response, bytes_read)) {
         return bytes_read;
       } else {
         std::cerr << "Checksum verification failed" << std::endl;
@@ -315,7 +270,7 @@ int32_t FeetechServoController::readRegister(uint8_t servo_id, uint16_t address)
   }
 
   uint8_t cmd[8];
-  size_t cmd_length = createModbusCommand(servo_id, 3, address, 1, cmd);
+  size_t cmd_length = feetech_protocol::createModbusCommand(servo_id, 3, address, 1, cmd);
 
   uint8_t response[50];
   int response_length = sendCommand(cmd, cmd_length, response, sizeof(response));
@@ -344,7 +299,7 @@ bool FeetechServoController::writeRegister(uint8_t servo_id, uint16_t address, u
   }
 
   uint8_t cmd[8];
-  size_t cmd_length = createModbusCommand(servo_id, 6, address, value, cmd);
+  size_t cmd_length = feetech_protocol::createModbusCommand(servo_id, 6, address, value, cmd);
 
   uint8_t response[50];
   int response_length = sendCommand(cmd, cmd_length, response, sizeof(response));

--- a/motor_control_lib/src/servo_control.cpp
+++ b/motor_control_lib/src/servo_control.cpp
@@ -5,8 +5,6 @@
 // https://opensource.org/licenses/MIT.
 #include "motor_control_lib/servo_control.hpp"
 
-#include "motor_control_lib/feetech_protocol.hpp"
-
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
@@ -19,6 +17,8 @@
 #include <iostream>
 #include <thread>
 #include <vector>
+
+#include "motor_control_lib/feetech_protocol.hpp"
 
 namespace motor_control_lib {
 

--- a/motor_control_lib/test/test_feetech_protocol.cpp
+++ b/motor_control_lib/test/test_feetech_protocol.cpp
@@ -1,0 +1,103 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "motor_control_lib/feetech_protocol.hpp"
+
+namespace mp = motor_control_lib::feetech_protocol;
+
+TEST(FeetechProtocolTest, Crc16StandardCheckValue) {
+  // CRC-16/MODBUS standard check value: ASCII "123456789" -> 0x4B37.
+  const uint8_t data[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+  EXPECT_EQ(mp::calculateCrc16(data, sizeof(data)), 0x4B37u);
+}
+
+TEST(FeetechProtocolTest, CreateModbusCommandWrite) {
+  // slave=1, fc=6 (write), address=128 (Goal Position), value=2048.
+  uint8_t cmd[8] = {0};
+  size_t len = mp::createModbusCommand(1, 6, 128, 2048, cmd);
+
+  EXPECT_EQ(len, 8u);
+
+  // Header + big-endian address/value.
+  EXPECT_EQ(cmd[0], 0x01u);  // slave id
+  EXPECT_EQ(cmd[1], 0x06u);  // function code
+  EXPECT_EQ(cmd[2], 0x00u);  // address high (128 = 0x0080)
+  EXPECT_EQ(cmd[3], 0x80u);  // address low
+  EXPECT_EQ(cmd[4], 0x08u);  // value high (2048 = 0x0800)
+  EXPECT_EQ(cmd[5], 0x00u);  // value low
+
+  // CRC is little-endian (Modbus-RTU): [crcL][crcH] over the first 6 bytes.
+  uint16_t crc = mp::calculateCrc16(cmd, 6);
+  EXPECT_EQ(cmd[6], static_cast<uint8_t>(crc & 0xFF));
+  EXPECT_EQ(cmd[7], static_cast<uint8_t>((crc >> 8) & 0xFF));
+
+  // Fully hardcoded known-answer frame so that any CRC change is caught.
+  const uint8_t expected[8] = {0x01, 0x06, 0x00, 0x80, 0x08, 0x00, 0x8F, 0xE2};
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(cmd[i], expected[i]) << "byte mismatch at index " << i;
+  }
+}
+
+TEST(FeetechProtocolTest, CreateModbusCommandRead) {
+  // slave=1, fc=3 (read), address=257 (real hardware Present Position), value=1.
+  uint8_t cmd[8] = {0};
+  size_t len = mp::createModbusCommand(1, 3, 257, 1, cmd);
+
+  EXPECT_EQ(len, 8u);
+
+  EXPECT_EQ(cmd[0], 0x01u);  // slave id
+  EXPECT_EQ(cmd[1], 0x03u);  // function code
+  EXPECT_EQ(cmd[2], 0x01u);  // address high (257 = 0x0101)
+  EXPECT_EQ(cmd[3], 0x01u);  // address low
+  EXPECT_EQ(cmd[4], 0x00u);  // value high (1 = 0x0001)
+  EXPECT_EQ(cmd[5], 0x01u);  // value low
+
+  // Hardcoded known-answer frame including little-endian CRC.
+  const uint8_t expected[8] = {0x01, 0x03, 0x01, 0x01, 0x00, 0x01, 0xD4, 0x36};
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(cmd[i], expected[i]) << "byte mismatch at index " << i;
+  }
+}
+
+TEST(FeetechProtocolTest, VerifyChecksumRoundTrip) {
+  uint8_t cmd[8] = {0};
+  mp::createModbusCommand(1, 6, 128, 2048, cmd);
+
+  // A freshly created command verifies true.
+  EXPECT_TRUE(mp::verifyChecksum(cmd, 8));
+
+  // Corrupting each single byte in turn must fail verification.
+  for (size_t i = 0; i < 8; ++i) {
+    uint8_t corrupted[8];
+    for (size_t k = 0; k < 8; ++k) {
+      corrupted[k] = cmd[k];
+    }
+    corrupted[i] ^= 0xFF;
+    EXPECT_FALSE(mp::verifyChecksum(corrupted, 8))
+        << "corruption at index " << i << " not detected";
+  }
+}
+
+TEST(FeetechProtocolTest, VerifyChecksumLengthGuards) {
+  // length < 3 -> false.
+  const uint8_t two[2] = {0x01, 0x06};
+  EXPECT_FALSE(mp::verifyChecksum(two, 2));
+
+  // Minimal valid length-3 path: one data byte + 2-byte little-endian CRC.
+  uint8_t frame[3];
+  frame[0] = 0x11;
+  uint16_t crc = mp::calculateCrc16(frame, 1);
+  frame[1] = static_cast<uint8_t>(crc & 0xFF);
+  frame[2] = static_cast<uint8_t>((crc >> 8) & 0xFF);
+  EXPECT_TRUE(mp::verifyChecksum(frame, 3));
+
+  frame[2] ^= 0xFF;
+  EXPECT_FALSE(mp::verifyChecksum(frame, 3));
+}


### PR DESCRIPTION
## 概要

Issue #91 チェックリスト項目4: `FeetechServoController` の Modbus フレーム生成 / CRC16 / チェックサム検証のユニットテスト整備。

- Modbus-RTU の CRC16・8 バイトコマンド生成・チェックサム検証を `motor_control_lib::feetech_protocol` の純粋フリー関数へ抽出(`calculateCrc16` / `createModbusCommand` / `verifyChecksum`)
- 混在エンディアン(アドレス/値 = big-endian、CRC = little-endian)をヘッダに明記
- `FeetechServoController` は呼び出し置換のみ。シリアル I/O・RS485 RTS 制御・リトライは無変更
- CRC-16/MODBUS 既知解答値("123456789" → 0x4B37)、全バイト既知解答フレーム(`{01 06 00 80 08 00 8F E2}` / `{01 03 01 01 00 01 D4 36}`、レジスタ 257 = 実機 Present Position)、1 バイト破壊の全数検査を含む 5 テスト

**No wire-format change; frames verified byte-identical by known-answer tests.**

## 検証

- `colcon test-result`: 44 tests, 0 failures(新規 gtest 5/5 パス)
- fail 検知実証: CRC リテラル 0x8F→0x8E → exit 1 確認後、復元して green
- `ament_clang_format`: clean

## 注意

#102 と同じ `motor_control_lib/CMakeLists.txt` / `package.xml` に行を追加するため、後にマージする側で軽微な rebase が必要になる場合があります。

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)