### PR TITLE
test: add uart joy parser and dropout filter unit tests

### DIFF
--- a/uart_joy_driver/CMakeLists.txt
+++ b/uart_joy_driver/CMakeLists.txt
@@ -11,6 +11,8 @@ ament_auto_find_build_dependencies()
 
 # Create the component library
 ament_auto_add_library(uart_joy_driver_component SHARED
+  src/dropout_filter.cpp
+  src/joy_line_parser.cpp
   src/uart_joy_driver_component.cpp
 )
 
@@ -32,6 +34,9 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_cpplint ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_joy_line_parser test/test_joy_line_parser.cpp)
+  ament_auto_add_gtest(test_dropout_filter test/test_dropout_filter.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/uart_joy_driver/include/uart_joy_driver/dropout_filter.hpp
+++ b/uart_joy_driver/include/uart_joy_driver/dropout_filter.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Questix Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UART_JOY_DRIVER__DROPOUT_FILTER_HPP_
+#define UART_JOY_DRIVER__DROPOUT_FILTER_HPP_
+
+#include <cstddef>
+#include <sensor_msgs/msg/joy.hpp>
+#include <vector>
+
+namespace uart_joy_driver {
+
+// Debounces momentary UART dropouts by holding the last active axis/button
+// value until a configurable number of consecutive neutral frames confirms the
+// release. State is retained between apply() calls.
+class DropoutFilter {
+public:
+  struct Config {
+    double hold_axis_threshold{0.1};
+    int axis_release_confirm_frames{2};
+    int button_release_confirm_frames{2};
+  };
+
+  DropoutFilter() = default;
+
+  void configure(const Config& config);
+  void apply(sensor_msgs::msg::Joy& joy_msg);
+  void reset(size_t axis_count, size_t button_count);
+
+private:
+  Config config_;
+  std::vector<float> filtered_axes_;
+  std::vector<int> filtered_buttons_;
+  std::vector<int> axis_release_counts_;
+  std::vector<int> button_release_counts_;
+};
+
+}  // namespace uart_joy_driver
+
+#endif  // UART_JOY_DRIVER__DROPOUT_FILTER_HPP_

--- a/uart_joy_driver/include/uart_joy_driver/joy_line_parser.hpp
+++ b/uart_joy_driver/include/uart_joy_driver/joy_line_parser.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Questix Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UART_JOY_DRIVER__JOY_LINE_PARSER_HPP_
+#define UART_JOY_DRIVER__JOY_LINE_PARSER_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <sensor_msgs/msg/joy.hpp>
+#include <string>
+
+namespace uart_joy_driver {
+
+constexpr size_t kJoyAxisCount = 8;
+constexpr size_t kJoyButtonCount = 16;
+constexpr int kExpectedFunctionId = 0x01;
+
+// Parse a 1- or 2-character hex token into a byte. Returns false on empty,
+// over-length, malformed, or out-of-range (> 0xFF) input.
+bool parseHexByte(const std::string& token, uint8_t& value);
+
+// Map a raw 0..255 stick value to a normalized [-1, 1] axis. 0x80 is neutral.
+// When invert is true the sign is flipped. Values whose magnitude falls below
+// deadzone are snapped to 0.
+double normalizeAxis(uint8_t value, bool invert, double deadzone);
+
+// Fill joy_msg.axes[6] (horizontal) and axes[7] (vertical) from a D-pad code.
+void fillDpadAxes(uint8_t dpad_value, sensor_msgs::msg::Joy& joy_msg);
+
+// Convert one ASCII line from the receiver module into a Joy message. Accepts an
+// optional "key:" prefix before the payload, and either a 7-token data frame or
+// an 8-token frame led by the expected function id. Returns false on any
+// malformed frame. Does not set joy_msg.header.stamp.
+bool parseControllerLine(const std::string& line, double deadzone, sensor_msgs::msg::Joy& joy_msg);
+
+}  // namespace uart_joy_driver
+
+#endif  // UART_JOY_DRIVER__JOY_LINE_PARSER_HPP_

--- a/uart_joy_driver/include/uart_joy_driver/uart_joy_driver_component.hpp
+++ b/uart_joy_driver/include/uart_joy_driver/uart_joy_driver_component.hpp
@@ -55,7 +55,8 @@ extern "C" {
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <string>
-#include <vector>
+#include <uart_joy_driver/dropout_filter.hpp>
+#include <uart_joy_driver/joy_line_parser.hpp>
 
 namespace uart_joy_driver {
 
@@ -76,12 +77,6 @@ private:
   // Read a complete line from serial buffer
   bool readLine(std::string& line);
 
-  // Convert one ASCII line from the receiver module into a Joy message.
-  bool parseControllerLine(const std::string& line, sensor_msgs::msg::Joy& joy_msg);
-  bool parseHexByte(const std::string& token, uint8_t& value) const;
-  double normalizeAxis(uint8_t value, bool invert) const;
-  void fillDpadAxes(uint8_t dpad_value, sensor_msgs::msg::Joy& joy_msg) const;
-  void applyDropoutFilter(sensor_msgs::msg::Joy& joy_msg);
   void publishNeutralJoy();
 
   // Parameters
@@ -108,10 +103,7 @@ private:
   bool have_received_frame_;
   bool neutral_published_;
   sensor_msgs::msg::Joy last_valid_joy_msg_;
-  std::vector<float> filtered_axes_;
-  std::vector<int> filtered_buttons_;
-  std::vector<int> axis_release_counts_;
-  std::vector<int> button_release_counts_;
+  DropoutFilter dropout_filter_;
 };
 
 }  // namespace uart_joy_driver

--- a/uart_joy_driver/package.xml
+++ b/uart_joy_driver/package.xml
@@ -14,6 +14,7 @@
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
 
+    <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
 

--- a/uart_joy_driver/src/dropout_filter.cpp
+++ b/uart_joy_driver/src/dropout_filter.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Questix Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <uart_joy_driver/dropout_filter.hpp>
+
+namespace uart_joy_driver {
+
+void DropoutFilter::configure(const Config& config) { config_ = config; }
+
+void DropoutFilter::apply(sensor_msgs::msg::Joy& joy_msg) {
+  if (filtered_axes_.size() != joy_msg.axes.size()) {
+    filtered_axes_.assign(joy_msg.axes.size(), 0.0F);
+    axis_release_counts_.assign(joy_msg.axes.size(), 0);
+  }
+  if (filtered_buttons_.size() != joy_msg.buttons.size()) {
+    filtered_buttons_.assign(joy_msg.buttons.size(), 0);
+    button_release_counts_.assign(joy_msg.buttons.size(), 0);
+  }
+
+  const int axis_release_frames = std::max(1, config_.axis_release_confirm_frames);
+  const int button_release_frames = std::max(1, config_.button_release_confirm_frames);
+
+  for (size_t i = 0; i < joy_msg.axes.size(); ++i) {
+    const float raw_axis = joy_msg.axes[i];
+    if (std::abs(raw_axis) >= config_.hold_axis_threshold) {
+      filtered_axes_[i] = raw_axis;
+      axis_release_counts_[i] = 0;
+    } else if (std::abs(filtered_axes_[i]) >= config_.hold_axis_threshold) {
+      axis_release_counts_[i] += 1;
+      if (axis_release_counts_[i] >= axis_release_frames) {
+        filtered_axes_[i] = 0.0F;
+        axis_release_counts_[i] = 0;
+      }
+    } else {
+      filtered_axes_[i] = 0.0F;
+      axis_release_counts_[i] = 0;
+    }
+    joy_msg.axes[i] = filtered_axes_[i];
+  }
+
+  for (size_t i = 0; i < joy_msg.buttons.size(); ++i) {
+    const bool raw_pressed = joy_msg.buttons[i] == 1;
+    if (raw_pressed) {
+      filtered_buttons_[i] = 1;
+      button_release_counts_[i] = 0;
+    } else if (filtered_buttons_[i] == 1) {
+      button_release_counts_[i] += 1;
+      if (button_release_counts_[i] >= button_release_frames) {
+        filtered_buttons_[i] = 0;
+        button_release_counts_[i] = 0;
+      }
+    } else {
+      filtered_buttons_[i] = 0;
+      button_release_counts_[i] = 0;
+    }
+    joy_msg.buttons[i] = filtered_buttons_[i];
+  }
+}
+
+void DropoutFilter::reset(size_t axis_count, size_t button_count) {
+  filtered_axes_.assign(axis_count, 0.0F);
+  filtered_buttons_.assign(button_count, 0);
+  axis_release_counts_.assign(axis_count, 0);
+  button_release_counts_.assign(button_count, 0);
+}
+
+}  // namespace uart_joy_driver

--- a/uart_joy_driver/src/joy_line_parser.cpp
+++ b/uart_joy_driver/src/joy_line_parser.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Questix Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <uart_joy_driver/joy_line_parser.hpp>
+#include <vector>
+
+namespace uart_joy_driver {
+
+namespace {
+
+std::vector<std::string> splitString(const std::string& input, char delimiter) {
+  std::vector<std::string> tokens;
+  std::stringstream ss(input);
+  std::string token;
+
+  while (std::getline(ss, token, delimiter)) {
+    tokens.push_back(token);
+  }
+
+  return tokens;
+}
+
+}  // namespace
+
+bool parseHexByte(const std::string& token, uint8_t& value) {
+  if (token.empty() || token.size() > 2) {
+    return false;
+  }
+
+  char* end_ptr = nullptr;
+  const uint64_t parsed = static_cast<uint64_t>(std::strtoul(token.c_str(), &end_ptr, 16));
+  if (end_ptr == nullptr || *end_ptr != '\0' || parsed > 0xFFUL) {
+    return false;
+  }
+
+  value = static_cast<uint8_t>(parsed);
+  return true;
+}
+
+double normalizeAxis(uint8_t value, bool invert, double deadzone) {
+  double normalized = (static_cast<int>(value) - 128) / 127.0;
+  normalized = std::clamp(normalized, -1.0, 1.0);
+  if (invert) {
+    normalized = -normalized;
+  }
+  if (std::abs(normalized) < deadzone) {
+    normalized = 0.0;
+  }
+  return normalized;
+}
+
+void fillDpadAxes(uint8_t dpad_value, sensor_msgs::msg::Joy& joy_msg) {
+  // Right-hand coordinate frame: D-pad left = +1, right = -1.
+  // 右手座標系: 十字キー左を +1、右を -1 として出力します。
+  double horizontal = 0.0;
+  double vertical = 0.0;
+
+  switch (dpad_value) {
+    case 1:
+      vertical = 1.0;
+      break;
+    case 2:
+      horizontal = -1.0;
+      vertical = 1.0;
+      break;
+    case 3:
+      horizontal = -1.0;
+      break;
+    case 4:
+      horizontal = -1.0;
+      vertical = -1.0;
+      break;
+    case 5:
+      vertical = -1.0;
+      break;
+    case 6:
+      horizontal = 1.0;
+      vertical = -1.0;
+      break;
+    case 7:
+      horizontal = 1.0;
+      break;
+    case 8:
+      horizontal = 1.0;
+      vertical = 1.0;
+      break;
+    default:
+      break;
+  }
+
+  joy_msg.axes[6] = static_cast<float>(horizontal);
+  joy_msg.axes[7] = static_cast<float>(vertical);
+}
+
+bool parseControllerLine(const std::string& line, double deadzone, sensor_msgs::msg::Joy& joy_msg) {
+  std::string payload = line;
+  const auto separator_pos = payload.find(':');
+  if (separator_pos != std::string::npos) {
+    payload = payload.substr(separator_pos + 1);
+  }
+
+  const auto tokens = splitString(payload, ',');
+  size_t data_start_index = 0;
+  if (tokens.size() == 8) {
+    uint8_t function_id = 0;
+    if (!parseHexByte(tokens[0], function_id) || function_id != kExpectedFunctionId) {
+      return false;
+    }
+    data_start_index = 1;
+  } else if (tokens.size() != 7) {
+    return false;
+  }
+
+  uint8_t byte0 = 0;
+  uint8_t byte1 = 0;
+  uint8_t dpad = 0;
+  uint8_t lx = 0x80;
+  uint8_t ly = 0x80;
+  uint8_t rx = 0x80;
+  uint8_t ry = 0x80;
+
+  if (!parseHexByte(tokens[data_start_index + 0], byte0) ||
+      !parseHexByte(tokens[data_start_index + 1], byte1) ||
+      !parseHexByte(tokens[data_start_index + 2], dpad) ||
+      !parseHexByte(tokens[data_start_index + 3], lx) ||
+      !parseHexByte(tokens[data_start_index + 4], ly) ||
+      !parseHexByte(tokens[data_start_index + 5], rx) ||
+      !parseHexByte(tokens[data_start_index + 6], ry)) {
+    return false;
+  }
+
+  joy_msg.axes.assign(kJoyAxisCount, 0.0F);
+  joy_msg.buttons.assign(kJoyButtonCount, 0);
+
+  // Right-hand coordinate frame: stick left = +1, stick right = -1.
+  // 右手座標系: スティック左を +1、右を -1 として出力します。
+  joy_msg.axes[0] = static_cast<float>(normalizeAxis(lx, true, deadzone));
+  joy_msg.axes[1] = static_cast<float>(normalizeAxis(ly, true, deadzone));
+  joy_msg.axes[3] = static_cast<float>(normalizeAxis(rx, true, deadzone));
+  joy_msg.axes[4] = static_cast<float>(normalizeAxis(ry, true, deadzone));
+  fillDpadAxes(dpad, joy_msg);
+
+  joy_msg.buttons[0] = (byte0 & 0x01) ? 1 : 0;   // A
+  joy_msg.buttons[1] = (byte0 & 0x02) ? 1 : 0;   // B
+  joy_msg.buttons[2] = (byte0 & 0x04) ? 1 : 0;   // X
+  joy_msg.buttons[3] = (byte0 & 0x08) ? 1 : 0;   // Y
+  joy_msg.buttons[4] = (byte0 & 0x10) ? 1 : 0;   // L
+  joy_msg.buttons[5] = (byte0 & 0x20) ? 1 : 0;   // R
+  joy_msg.buttons[6] = (byte0 & 0x40) ? 1 : 0;   // ZL
+  joy_msg.buttons[7] = (byte0 & 0x80) ? 1 : 0;   // ZR
+  joy_msg.buttons[8] = (byte1 & 0x01) ? 1 : 0;   // Minus
+  joy_msg.buttons[9] = (byte1 & 0x02) ? 1 : 0;   // Plus
+  joy_msg.buttons[10] = (byte1 & 0x04) ? 1 : 0;  // Home
+  joy_msg.buttons[11] = (byte1 & 0x08) ? 1 : 0;  // Capture
+  joy_msg.buttons[12] = (byte1 & 0x10) ? 1 : 0;  // LStick
+  joy_msg.buttons[13] = (byte1 & 0x20) ? 1 : 0;  // RStick
+
+  return true;
+}
+
+}  // namespace uart_joy_driver

--- a/uart_joy_driver/src/uart_joy_driver_component.cpp
+++ b/uart_joy_driver/src/uart_joy_driver_component.cpp
@@ -19,37 +19,12 @@
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
-#include <cmath>
-#include <cstdint>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
-#include <sstream>
 #include <string>
 #include <uart_joy_driver/uart_joy_driver_component.hpp>
-#include <vector>
 
 namespace uart_joy_driver {
-
-namespace {
-
-constexpr size_t kJoyAxisCount = 8;
-constexpr size_t kJoyButtonCount = 16;
-constexpr int kExpectedFunctionId = 0x01;
-
-std::vector<std::string> splitString(const std::string& input, char delimiter) {
-  std::vector<std::string> tokens;
-  std::stringstream ss(input);
-  std::string token;
-
-  while (std::getline(ss, token, delimiter)) {
-    tokens.push_back(token);
-  }
-
-  return tokens;
-}
-
-}  // namespace
 
 UartJoyDriverComponent::UartJoyDriverComponent(const rclcpp::NodeOptions& options)
     : Node("uart_joy_driver", options),
@@ -81,10 +56,12 @@ UartJoyDriverComponent::UartJoyDriverComponent(const rclcpp::NodeOptions& option
 
   joy_pub_ = this->create_publisher<sensor_msgs::msg::Joy>("/joy", 1);
   joy_raw_pub_ = this->create_publisher<sensor_msgs::msg::Joy>("/joy_raw_uart", 1);
-  filtered_axes_.assign(kJoyAxisCount, 0.0F);
-  filtered_buttons_.assign(kJoyButtonCount, 0);
-  axis_release_counts_.assign(kJoyAxisCount, 0);
-  button_release_counts_.assign(kJoyButtonCount, 0);
+  DropoutFilter::Config filter_config;
+  filter_config.hold_axis_threshold = hold_axis_threshold_;
+  filter_config.axis_release_confirm_frames = axis_release_confirm_frames_;
+  filter_config.button_release_confirm_frames = button_release_confirm_frames_;
+  dropout_filter_.configure(filter_config);
+  dropout_filter_.reset(kJoyAxisCount, kJoyButtonCount);
   last_valid_joy_msg_.axes.assign(kJoyAxisCount, 0.0F);
   last_valid_joy_msg_.buttons.assign(kJoyButtonCount, 0);
   last_frame_time_ = this->now();
@@ -217,7 +194,7 @@ void UartJoyDriverComponent::readTimerCallback() {
   std::string line;
   while (readLine(line)) {
     sensor_msgs::msg::Joy raw_joy_msg;
-    if (!parseControllerLine(line, raw_joy_msg)) {
+    if (!parseControllerLine(line, deadzone_, raw_joy_msg)) {
       RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
                            "Failed to parse UART controller line: %s", line.c_str());
       continue;
@@ -228,7 +205,7 @@ void UartJoyDriverComponent::readTimerCallback() {
     joy_raw_pub_->publish(raw_joy_msg);
 
     auto joy_msg = raw_joy_msg;
-    applyDropoutFilter(joy_msg);
+    dropout_filter_.apply(joy_msg);
     joy_msg.header.stamp = now;
     last_valid_joy_msg_ = joy_msg;
     last_frame_time_ = now;
@@ -282,204 +259,12 @@ bool UartJoyDriverComponent::readLine(std::string& line) {
   return !line.empty();
 }
 
-bool UartJoyDriverComponent::parseControllerLine(const std::string& line,
-                                                 sensor_msgs::msg::Joy& joy_msg) {
-  std::string payload = line;
-  const auto separator_pos = payload.find(':');
-  if (separator_pos != std::string::npos) {
-    payload = payload.substr(separator_pos + 1);
-  }
-
-  const auto tokens = splitString(payload, ',');
-  size_t data_start_index = 0;
-  if (tokens.size() == 8) {
-    uint8_t function_id = 0;
-    if (!parseHexByte(tokens[0], function_id) || function_id != kExpectedFunctionId) {
-      return false;
-    }
-    data_start_index = 1;
-  } else if (tokens.size() != 7) {
-    return false;
-  }
-
-  uint8_t byte0 = 0;
-  uint8_t byte1 = 0;
-  uint8_t dpad = 0;
-  uint8_t lx = 0x80;
-  uint8_t ly = 0x80;
-  uint8_t rx = 0x80;
-  uint8_t ry = 0x80;
-
-  if (!parseHexByte(tokens[data_start_index + 0], byte0) ||
-      !parseHexByte(tokens[data_start_index + 1], byte1) ||
-      !parseHexByte(tokens[data_start_index + 2], dpad) ||
-      !parseHexByte(tokens[data_start_index + 3], lx) ||
-      !parseHexByte(tokens[data_start_index + 4], ly) ||
-      !parseHexByte(tokens[data_start_index + 5], rx) ||
-      !parseHexByte(tokens[data_start_index + 6], ry)) {
-    return false;
-  }
-
-  joy_msg.header.stamp = this->now();
-  joy_msg.axes.assign(kJoyAxisCount, 0.0F);
-  joy_msg.buttons.assign(kJoyButtonCount, 0);
-
-  // Right-hand coordinate frame: stick left = +1, stick right = -1.
-  // 右手座標系: スティック左を +1、右を -1 として出力します。
-  joy_msg.axes[0] = static_cast<float>(normalizeAxis(lx, true));
-  joy_msg.axes[1] = static_cast<float>(normalizeAxis(ly, true));
-  joy_msg.axes[3] = static_cast<float>(normalizeAxis(rx, true));
-  joy_msg.axes[4] = static_cast<float>(normalizeAxis(ry, true));
-  fillDpadAxes(dpad, joy_msg);
-
-  joy_msg.buttons[0] = (byte0 & 0x01) ? 1 : 0;   // A
-  joy_msg.buttons[1] = (byte0 & 0x02) ? 1 : 0;   // B
-  joy_msg.buttons[2] = (byte0 & 0x04) ? 1 : 0;   // X
-  joy_msg.buttons[3] = (byte0 & 0x08) ? 1 : 0;   // Y
-  joy_msg.buttons[4] = (byte0 & 0x10) ? 1 : 0;   // L
-  joy_msg.buttons[5] = (byte0 & 0x20) ? 1 : 0;   // R
-  joy_msg.buttons[6] = (byte0 & 0x40) ? 1 : 0;   // ZL
-  joy_msg.buttons[7] = (byte0 & 0x80) ? 1 : 0;   // ZR
-  joy_msg.buttons[8] = (byte1 & 0x01) ? 1 : 0;   // Minus
-  joy_msg.buttons[9] = (byte1 & 0x02) ? 1 : 0;   // Plus
-  joy_msg.buttons[10] = (byte1 & 0x04) ? 1 : 0;  // Home
-  joy_msg.buttons[11] = (byte1 & 0x08) ? 1 : 0;  // Capture
-  joy_msg.buttons[12] = (byte1 & 0x10) ? 1 : 0;  // LStick
-  joy_msg.buttons[13] = (byte1 & 0x20) ? 1 : 0;  // RStick
-
-  return true;
-}
-
-void UartJoyDriverComponent::applyDropoutFilter(sensor_msgs::msg::Joy& joy_msg) {
-  if (filtered_axes_.size() != joy_msg.axes.size()) {
-    filtered_axes_.assign(joy_msg.axes.size(), 0.0F);
-    axis_release_counts_.assign(joy_msg.axes.size(), 0);
-  }
-  if (filtered_buttons_.size() != joy_msg.buttons.size()) {
-    filtered_buttons_.assign(joy_msg.buttons.size(), 0);
-    button_release_counts_.assign(joy_msg.buttons.size(), 0);
-  }
-
-  const int axis_release_frames = std::max(1, axis_release_confirm_frames_);
-  const int button_release_frames = std::max(1, button_release_confirm_frames_);
-
-  for (size_t i = 0; i < joy_msg.axes.size(); ++i) {
-    const float raw_axis = joy_msg.axes[i];
-    if (std::abs(raw_axis) >= hold_axis_threshold_) {
-      filtered_axes_[i] = raw_axis;
-      axis_release_counts_[i] = 0;
-    } else if (std::abs(filtered_axes_[i]) >= hold_axis_threshold_) {
-      axis_release_counts_[i] += 1;
-      if (axis_release_counts_[i] >= axis_release_frames) {
-        filtered_axes_[i] = 0.0F;
-        axis_release_counts_[i] = 0;
-      }
-    } else {
-      filtered_axes_[i] = 0.0F;
-      axis_release_counts_[i] = 0;
-    }
-    joy_msg.axes[i] = filtered_axes_[i];
-  }
-
-  for (size_t i = 0; i < joy_msg.buttons.size(); ++i) {
-    const bool raw_pressed = joy_msg.buttons[i] == 1;
-    if (raw_pressed) {
-      filtered_buttons_[i] = 1;
-      button_release_counts_[i] = 0;
-    } else if (filtered_buttons_[i] == 1) {
-      button_release_counts_[i] += 1;
-      if (button_release_counts_[i] >= button_release_frames) {
-        filtered_buttons_[i] = 0;
-        button_release_counts_[i] = 0;
-      }
-    } else {
-      filtered_buttons_[i] = 0;
-      button_release_counts_[i] = 0;
-    }
-    joy_msg.buttons[i] = filtered_buttons_[i];
-  }
-}
-
-bool UartJoyDriverComponent::parseHexByte(const std::string& token, uint8_t& value) const {
-  if (token.empty() || token.size() > 2) {
-    return false;
-  }
-
-  char* end_ptr = nullptr;
-  const uint64_t parsed = static_cast<uint64_t>(std::strtoul(token.c_str(), &end_ptr, 16));
-  if (end_ptr == nullptr || *end_ptr != '\0' || parsed > 0xFFUL) {
-    return false;
-  }
-
-  value = static_cast<uint8_t>(parsed);
-  return true;
-}
-
-double UartJoyDriverComponent::normalizeAxis(uint8_t value, bool invert) const {
-  double normalized = (static_cast<int>(value) - 128) / 127.0;
-  normalized = std::clamp(normalized, -1.0, 1.0);
-  if (invert) {
-    normalized = -normalized;
-  }
-  if (std::abs(normalized) < deadzone_) {
-    normalized = 0.0;
-  }
-  return normalized;
-}
-
-void UartJoyDriverComponent::fillDpadAxes(uint8_t dpad_value,
-                                          sensor_msgs::msg::Joy& joy_msg) const {
-  // Right-hand coordinate frame: D-pad left = +1, right = -1.
-  // 右手座標系: 十字キー左を +1、右を -1 として出力します。
-  double horizontal = 0.0;
-  double vertical = 0.0;
-
-  switch (dpad_value) {
-    case 1:
-      vertical = 1.0;
-      break;
-    case 2:
-      horizontal = -1.0;
-      vertical = 1.0;
-      break;
-    case 3:
-      horizontal = -1.0;
-      break;
-    case 4:
-      horizontal = -1.0;
-      vertical = -1.0;
-      break;
-    case 5:
-      vertical = -1.0;
-      break;
-    case 6:
-      horizontal = 1.0;
-      vertical = -1.0;
-      break;
-    case 7:
-      horizontal = 1.0;
-      break;
-    case 8:
-      horizontal = 1.0;
-      vertical = 1.0;
-      break;
-    default:
-      break;
-  }
-
-  joy_msg.axes[6] = static_cast<float>(horizontal);
-  joy_msg.axes[7] = static_cast<float>(vertical);
-}
-
 void UartJoyDriverComponent::publishNeutralJoy() {
   sensor_msgs::msg::Joy neutral_msg;
   neutral_msg.header.stamp = this->now();
   neutral_msg.axes.assign(kJoyAxisCount, 0.0F);
   neutral_msg.buttons.assign(kJoyButtonCount, 0);
-  filtered_axes_.assign(kJoyAxisCount, 0.0F);
-  filtered_buttons_.assign(kJoyButtonCount, 0);
-  axis_release_counts_.assign(kJoyAxisCount, 0);
-  button_release_counts_.assign(kJoyButtonCount, 0);
+  dropout_filter_.reset(kJoyAxisCount, kJoyButtonCount);
   last_valid_joy_msg_ = neutral_msg;
   joy_pub_->publish(neutral_msg);
 

--- a/uart_joy_driver/test/test_dropout_filter.cpp
+++ b/uart_joy_driver/test/test_dropout_filter.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Questix Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <sensor_msgs/msg/joy.hpp>
+#include <uart_joy_driver/dropout_filter.hpp>
+#include <vector>
+
+namespace {
+
+constexpr size_t kAxisCount = 8;
+constexpr size_t kButtonCount = 16;
+
+uart_joy_driver::DropoutFilter makeFilter(int axis_frames = 2, int button_frames = 2) {
+  uart_joy_driver::DropoutFilter filter;
+  uart_joy_driver::DropoutFilter::Config config;
+  config.hold_axis_threshold = 0.1;
+  config.axis_release_confirm_frames = axis_frames;
+  config.button_release_confirm_frames = button_frames;
+  filter.configure(config);
+  return filter;
+}
+
+sensor_msgs::msg::Joy makeJoy(float axis0 = 0.0F, int button0 = 0) {
+  sensor_msgs::msg::Joy joy_msg;
+  joy_msg.axes.assign(kAxisCount, 0.0F);
+  joy_msg.buttons.assign(kButtonCount, 0);
+  joy_msg.axes[0] = axis0;
+  joy_msg.buttons[0] = button0;
+  return joy_msg;
+}
+
+float applyAxis(uart_joy_driver::DropoutFilter& filter, float axis0) {
+  auto joy_msg = makeJoy(axis0);
+  filter.apply(joy_msg);
+  return joy_msg.axes[0];
+}
+
+int applyButton(uart_joy_driver::DropoutFilter& filter, int button0) {
+  auto joy_msg = makeJoy(0.0F, button0);
+  filter.apply(joy_msg);
+  return joy_msg.buttons[0];
+}
+
+TEST(DropoutFilterTest, ActiveAxisPassesThrough) {
+  auto filter = makeFilter();
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.8F), 0.8F);
+}
+
+TEST(DropoutFilterTest, AxisDropoutHeldUntilConfirmed) {
+  auto filter = makeFilter();
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.8F), 0.8F);
+  // First zero frame: held (release count 1 of 2).
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.0F), 0.8F);
+  // Second zero frame: release confirmed.
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.0F), 0.0F);
+}
+
+TEST(DropoutFilterTest, ReleaseCounterResetsOnReactivation) {
+  auto filter = makeFilter();
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.8F), 0.8F);
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.0F), 0.8F);  // count 1
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.8F), 0.8F);  // re-press resets count
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.0F), 0.8F);  // count restarts at 1
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.0F), 0.0F);  // count 2: released
+}
+
+TEST(DropoutFilterTest, SubThresholdAxisIsNotHeld) {
+  auto filter = makeFilter();
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.05F), 0.0F);
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.0F), 0.0F);
+}
+
+TEST(DropoutFilterTest, ButtonDropoutHeldUntilConfirmed) {
+  auto filter = makeFilter();
+  EXPECT_EQ(applyButton(filter, 1), 1);
+  EXPECT_EQ(applyButton(filter, 0), 1);
+  EXPECT_EQ(applyButton(filter, 0), 0);
+}
+
+TEST(DropoutFilterTest, ZeroConfirmFramesBehavesAsOne) {
+  auto filter = makeFilter(0, 0);
+  EXPECT_EQ(applyButton(filter, 1), 1);
+  EXPECT_EQ(applyButton(filter, 0), 0);
+
+  auto axis_filter = makeFilter(0, 0);
+  EXPECT_FLOAT_EQ(applyAxis(axis_filter, 0.8F), 0.8F);
+  EXPECT_FLOAT_EQ(applyAxis(axis_filter, 0.0F), 0.0F);
+}
+
+TEST(DropoutFilterTest, ResizesForDifferentMessageShapes) {
+  auto filter = makeFilter();
+  EXPECT_FLOAT_EQ(applyAxis(filter, 0.8F), 0.8F);
+
+  sensor_msgs::msg::Joy small_msg;
+  small_msg.axes.assign(3, 0.5F);
+  small_msg.buttons.assign(2, 1);
+  filter.apply(small_msg);
+  ASSERT_EQ(small_msg.axes.size(), 3U);
+  ASSERT_EQ(small_msg.buttons.size(), 2U);
+  EXPECT_FLOAT_EQ(small_msg.axes[0], 0.5F);
+  EXPECT_EQ(small_msg.buttons[0], 1);
+}
+
+TEST(DropoutFilterTest, ResetClearsHeldState) {
+  auto filter = makeFilter();
+  auto active_msg = makeJoy(0.8F, 1);
+  filter.apply(active_msg);
+  EXPECT_FLOAT_EQ(active_msg.axes[0], 0.8F);
+  EXPECT_EQ(active_msg.buttons[0], 1);
+
+  filter.reset(kAxisCount, kButtonCount);
+
+  // Without reset these would be held for one more frame.
+  auto neutral_msg = makeJoy();
+  filter.apply(neutral_msg);
+  EXPECT_FLOAT_EQ(neutral_msg.axes[0], 0.0F);
+  EXPECT_EQ(neutral_msg.buttons[0], 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/uart_joy_driver/test/test_joy_line_parser.cpp
+++ b/uart_joy_driver/test/test_joy_line_parser.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Questix Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <sensor_msgs/msg/joy.hpp>
+#include <string>
+#include <uart_joy_driver/joy_line_parser.hpp>
+#include <vector>
+
+namespace {
+
+constexpr double kDeadzone = 0.05;
+
+sensor_msgs::msg::Joy makeJoy() {
+  sensor_msgs::msg::Joy joy_msg;
+  joy_msg.axes.assign(uart_joy_driver::kJoyAxisCount, 0.0F);
+  joy_msg.buttons.assign(uart_joy_driver::kJoyButtonCount, 0);
+  return joy_msg;
+}
+
+TEST(ParseHexByteTest, AcceptsValidTokens) {
+  uint8_t value = 0xAA;
+  EXPECT_TRUE(uart_joy_driver::parseHexByte("00", value));
+  EXPECT_EQ(value, 0);
+  EXPECT_TRUE(uart_joy_driver::parseHexByte("FF", value));
+  EXPECT_EQ(value, 255);
+  EXPECT_TRUE(uart_joy_driver::parseHexByte("ff", value));
+  EXPECT_EQ(value, 255);
+  EXPECT_TRUE(uart_joy_driver::parseHexByte("7", value));
+  EXPECT_EQ(value, 7);
+}
+
+TEST(ParseHexByteTest, RejectsInvalidTokens) {
+  uint8_t value = 0;
+  EXPECT_FALSE(uart_joy_driver::parseHexByte("", value));
+  EXPECT_FALSE(uart_joy_driver::parseHexByte("100", value));
+  EXPECT_FALSE(uart_joy_driver::parseHexByte("GG", value));
+  EXPECT_FALSE(uart_joy_driver::parseHexByte("0x", value));
+}
+
+TEST(NormalizeAxisTest, NeutralValueIsZero) {
+  EXPECT_DOUBLE_EQ(uart_joy_driver::normalizeAxis(0x80, false, kDeadzone), 0.0);
+  EXPECT_DOUBLE_EQ(uart_joy_driver::normalizeAxis(0x80, true, kDeadzone), 0.0);
+}
+
+TEST(NormalizeAxisTest, ExtremesAreClampedAndInverted) {
+  // 0x00 -> (0 - 128) / 127 = -1.0079 -> clamped to -1.0 -> inverted to +1.0.
+  EXPECT_DOUBLE_EQ(uart_joy_driver::normalizeAxis(0x00, true, kDeadzone), 1.0);
+  // 0xFF -> (255 - 128) / 127 = +1.0 -> inverted to -1.0.
+  EXPECT_DOUBLE_EQ(uart_joy_driver::normalizeAxis(0xFF, true, kDeadzone), -1.0);
+}
+
+TEST(NormalizeAxisTest, DeadzoneSnapsSmallValuesToZero) {
+  // 0x86 -> 6 / 127 = 0.0472 < 0.05 -> 0.0.
+  EXPECT_DOUBLE_EQ(uart_joy_driver::normalizeAxis(0x86, false, kDeadzone), 0.0);
+  // 0x8E -> 14 / 127 = 0.1102 >= 0.05 -> nonzero.
+  EXPECT_NEAR(uart_joy_driver::normalizeAxis(0x8E, false, kDeadzone), 14.0 / 127.0, 1e-9);
+}
+
+TEST(FillDpadAxesTest, MapsAllDirections) {
+  struct Case {
+    uint8_t dpad;
+    float horizontal;
+    float vertical;
+  };
+  const std::vector<Case> cases = {
+      {0, 0.0F, 0.0F},   {1, 0.0F, 1.0F},  {2, -1.0F, 1.0F},   {3, -1.0F, 0.0F},
+      {4, -1.0F, -1.0F}, {5, 0.0F, -1.0F}, {6, 1.0F, -1.0F},   {7, 1.0F, 0.0F},
+      {8, 1.0F, 1.0F},   {9, 0.0F, 0.0F},  {0xFF, 0.0F, 0.0F},
+  };
+
+  for (const auto& test_case : cases) {
+    auto joy_msg = makeJoy();
+    uart_joy_driver::fillDpadAxes(test_case.dpad, joy_msg);
+    EXPECT_FLOAT_EQ(joy_msg.axes[6], test_case.horizontal) << "dpad=" << int{test_case.dpad};
+    EXPECT_FLOAT_EQ(joy_msg.axes[7], test_case.vertical) << "dpad=" << int{test_case.dpad};
+  }
+}
+
+TEST(ParseControllerLineTest, ParsesSevenTokenLine) {
+  sensor_msgs::msg::Joy joy_msg;
+  ASSERT_TRUE(uart_joy_driver::parseControllerLine("01,02,05,80,80,80,80", kDeadzone, joy_msg));
+
+  ASSERT_EQ(joy_msg.axes.size(), uart_joy_driver::kJoyAxisCount);
+  ASSERT_EQ(joy_msg.buttons.size(), uart_joy_driver::kJoyButtonCount);
+
+  // byte0 = 0x01 -> button A only; byte1 = 0x02 -> Plus only.
+  EXPECT_EQ(joy_msg.buttons[0], 1);
+  for (size_t i = 1; i < 9; ++i) {
+    EXPECT_EQ(joy_msg.buttons[i], 0) << "button " << i;
+  }
+  EXPECT_EQ(joy_msg.buttons[9], 1);
+  for (size_t i = 10; i < joy_msg.buttons.size(); ++i) {
+    EXPECT_EQ(joy_msg.buttons[i], 0) << "button " << i;
+  }
+
+  // dpad = 5 -> down: axes[6] = 0, axes[7] = -1; sticks neutral.
+  EXPECT_FLOAT_EQ(joy_msg.axes[6], 0.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[7], -1.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[0], 0.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[1], 0.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[3], 0.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[4], 0.0F);
+}
+
+TEST(ParseControllerLineTest, ParsesEightTokenLineWithFunctionId) {
+  sensor_msgs::msg::Joy joy_msg;
+  ASSERT_TRUE(uart_joy_driver::parseControllerLine("01,01,02,05,00,FF,80,80", kDeadzone, joy_msg));
+
+  // Data bytes after the function id: byte0=0x01, byte1=0x02, dpad=5,
+  // lx=0x00, ly=0xFF, rx=0x80, ry=0x80.
+  EXPECT_EQ(joy_msg.buttons[0], 1);
+  EXPECT_EQ(joy_msg.buttons[9], 1);
+  EXPECT_FLOAT_EQ(joy_msg.axes[6], 0.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[7], -1.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[0], 1.0F);   // lx=0x00 inverted.
+  EXPECT_FLOAT_EQ(joy_msg.axes[1], -1.0F);  // ly=0xFF inverted.
+  EXPECT_FLOAT_EQ(joy_msg.axes[3], 0.0F);
+  EXPECT_FLOAT_EQ(joy_msg.axes[4], 0.0F);
+}
+
+TEST(ParseControllerLineTest, RejectsWrongFunctionId) {
+  sensor_msgs::msg::Joy joy_msg;
+  EXPECT_FALSE(uart_joy_driver::parseControllerLine("02,01,02,05,80,80,80,80", kDeadzone, joy_msg));
+}
+
+TEST(ParseControllerLineTest, StripsKeyPrefix) {
+  sensor_msgs::msg::Joy joy_msg;
+  ASSERT_TRUE(uart_joy_driver::parseControllerLine("JOY:01,00,05,80,80,80,80", kDeadzone, joy_msg));
+  EXPECT_EQ(joy_msg.buttons[0], 1);
+  EXPECT_FLOAT_EQ(joy_msg.axes[7], -1.0F);
+}
+
+TEST(ParseControllerLineTest, RejectsMalformedLines) {
+  sensor_msgs::msg::Joy joy_msg;
+  EXPECT_FALSE(uart_joy_driver::parseControllerLine("01,02,03,04,05,06", kDeadzone, joy_msg));
+  EXPECT_FALSE(
+      uart_joy_driver::parseControllerLine("01,02,03,04,05,06,07,08,09", kDeadzone, joy_msg));
+  EXPECT_FALSE(uart_joy_driver::parseControllerLine("01,GG,05,80,80,80,80", kDeadzone, joy_msg));
+  EXPECT_FALSE(uart_joy_driver::parseControllerLine("", kDeadzone, joy_msg));
+}
+
+TEST(ParseControllerLineTest, FullButtonBitmaps) {
+  sensor_msgs::msg::Joy joy_msg;
+  ASSERT_TRUE(uart_joy_driver::parseControllerLine("FF,3F,00,80,80,80,80", kDeadzone, joy_msg));
+
+  ASSERT_EQ(joy_msg.axes.size(), uart_joy_driver::kJoyAxisCount);
+  ASSERT_EQ(joy_msg.buttons.size(), uart_joy_driver::kJoyButtonCount);
+
+  // byte0 = 0xFF -> buttons[0..7] all pressed.
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(joy_msg.buttons[i], 1) << "button " << i;
+  }
+  // byte1 = 0x3F -> buttons[8..13] all pressed; 14 and 15 unused.
+  for (size_t i = 8; i < 14; ++i) {
+    EXPECT_EQ(joy_msg.buttons[i], 1) << "button " << i;
+  }
+  EXPECT_EQ(joy_msg.buttons[14], 0);
+  EXPECT_EQ(joy_msg.buttons[15], 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## 概要

Issue #91 チェックリスト項目3: `UartJoyDriverComponent::parseControllerLine` / `applyDropoutFilter`(7/8トークン、異常系、ドロップアウト保持)のユニットテスト整備。

- 行パーサを `uart_joy_driver` 名前空間のフリー関数へ抽出(`parseControllerLine` / `parseHexByte` / `normalizeAxis` / `fillDpadAxes`)。deadzone は引数化
- ドロップアウトフィルタを状態保持クラス `DropoutFilter`(`configure` / `apply` / `reset`)へ移植。`std::max(1, frames)` フロアや float/double 比較の意味論まで完全一致(原実装と行単位で同一)
- Node 生成(シリアル open + rclcpp::init)なしでテスト可能に
- 挙動中立の変更 1 点: パーサ内の `header.stamp = this->now()` を削除(呼び出し元 `readTimerCallback` が publish 直前に必ず上書きしていることを確認済み)
- 7/8 トークン、function ID 不一致、`key:` プレフィクス、不正 hex、D-pad 全値、ボタンビットマップ全展開、ドロップアウト保持/解放デバウンス/再入力リセット/reset() の計 20 テスト

## 検証

- `colcon test-result`: 47 tests, 0 failures(test_joy_line_parser 12/12、test_dropout_filter 8/8)
- fail 検知実証: 期待値を改変 → exit 1 確認後、復元して green
- `ament_clang_format`: clean

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)