### PR TITLE
test: add shot component angle conversion unit tests

### DIFF
--- a/motor_control_app/CMakeLists.txt
+++ b/motor_control_app/CMakeLists.txt
@@ -95,6 +95,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_cpplint ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_shot_angle test/test_shot_angle.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/motor_control_app/include/motor_control_app/shot_angle.hpp
+++ b/motor_control_app/include/motor_control_app/shot_angle.hpp
@@ -1,0 +1,42 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#ifndef MOTOR_CONTROL_APP__SHOT_ANGLE_HPP_
+#define MOTOR_CONTROL_APP__SHOT_ANGLE_HPP_
+
+#include <algorithm>
+
+namespace motor_control_app::shot_angle {
+
+// 角度制限関数
+inline double clampAngle(double angle_deg, double min_deg, double max_deg) {
+  return std::max(min_deg, std::min(max_deg, angle_deg));
+}
+
+// 角度からサーボ位置への変換（角度 -> 0-4095）
+inline int angleToServoPosition(double angle_deg) {
+  // 角度を直接サーボ位置に変換（0度=0, 360度=4095）
+  // 角度を0-360度の範囲で正規化
+  while (angle_deg < 0) angle_deg += 360.0;
+  while (angle_deg >= 360.0) angle_deg -= 360.0;
+
+  // サーボ位置に変換
+  double normalized = angle_deg / 360.0;
+  int position = static_cast<int>(normalized * 4096.0);
+  return std::max(0, std::min(4095, position));
+}
+
+// サーボ位置から角度への変換（0-4095 -> 角度）
+inline double servoPositionToAngle(int position) {
+  // 位置を0-4095の範囲にクランプ
+  position = std::max(0, std::min(4095, position));
+  // 角度に変換（0-4095 -> 0-360度）
+  double normalized = static_cast<double>(position) / 4096.0;
+  return normalized * 360.0;
+}
+
+}  // namespace motor_control_app::shot_angle
+
+#endif  // MOTOR_CONTROL_APP__SHOT_ANGLE_HPP_

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -19,6 +19,7 @@
 
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
+    <test_depend>ament_cmake_gtest</test_depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <thread>
 
+#include "motor_control_app/shot_angle.hpp"
+
 namespace motor_control_app {
 
 ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
@@ -214,7 +216,7 @@ void ShotComponent::executeShotSequence() {
 
 // 角度制限関数
 double ShotComponent::clampAngle(double angle_deg) {
-  return std::max(tilt_min_angle_, std::min(tilt_max_angle_, angle_deg));
+  return shot_angle::clampAngle(angle_deg, tilt_min_angle_, tilt_max_angle_);
 }
 
 // コマンド送信レート制限チェック
@@ -226,24 +228,12 @@ bool ShotComponent::canSendCommand() {
 
 // 角度からサーボ位置への変換（角度 -> 0-4095）
 int ShotComponent::angleToServoPosition(double angle_deg) {
-  // 角度を直接サーボ位置に変換（0度=0, 360度=4095）
-  // 角度を0-360度の範囲で正規化
-  while (angle_deg < 0) angle_deg += 360.0;
-  while (angle_deg >= 360.0) angle_deg -= 360.0;
-
-  // サーボ位置に変換
-  double normalized = angle_deg / 360.0;
-  int position = static_cast<int>(normalized * 4096.0);
-  return std::max(0, std::min(4095, position));
+  return shot_angle::angleToServoPosition(angle_deg);
 }
 
 // サーボ位置から角度への変換（0-4095 -> 角度）
 double ShotComponent::servoPositionToAngle(int position) {
-  // 位置を0-4095の範囲にクランプ
-  position = std::max(0, std::min(4095, position));
-  // 角度に変換（0-4095 -> 0-360度）
-  double normalized = static_cast<double>(position) / 4096.0;
-  return normalized * 360.0;
+  return shot_angle::servoPositionToAngle(position);
 }
 
 }  // namespace motor_control_app

--- a/motor_control_app/test/test_shot_angle.cpp
+++ b/motor_control_app/test/test_shot_angle.cpp
@@ -1,0 +1,80 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include "motor_control_app/shot_angle.hpp"
+
+namespace {
+
+using motor_control_app::shot_angle::angleToServoPosition;
+using motor_control_app::shot_angle::clampAngle;
+using motor_control_app::shot_angle::servoPositionToAngle;
+
+// Default tilt range from the ShotComponent constructor's declare_parameter
+// calls: tilt_min_angle = 0.0, tilt_max_angle = 70.0.
+constexpr double kMinDeg = 0.0;
+constexpr double kMaxDeg = 70.0;
+
+TEST(ShotAngle, ClampAngleMidRangePassthrough) {
+  EXPECT_DOUBLE_EQ(clampAngle(35.0, kMinDeg, kMaxDeg), 35.0);
+}
+
+TEST(ShotAngle, ClampAngleBelowMin) { EXPECT_DOUBLE_EQ(clampAngle(-10.0, kMinDeg, kMaxDeg), 0.0); }
+
+TEST(ShotAngle, ClampAngleAboveMax) { EXPECT_DOUBLE_EQ(clampAngle(120.0, kMinDeg, kMaxDeg), 70.0); }
+
+TEST(ShotAngle, ClampAngleBoundariesExact) {
+  EXPECT_DOUBLE_EQ(clampAngle(0.0, kMinDeg, kMaxDeg), 0.0);
+  EXPECT_DOUBLE_EQ(clampAngle(70.0, kMinDeg, kMaxDeg), 70.0);
+}
+
+TEST(ShotAngle, AngleToServoPositionKnownValues) {
+  EXPECT_EQ(angleToServoPosition(0.0), 0);
+  EXPECT_EQ(angleToServoPosition(90.0), 1024);
+  EXPECT_EQ(angleToServoPosition(180.0), 2048);
+}
+
+TEST(ShotAngle, AngleToServoPositionWrapsPositive) {
+  // 360 degrees normalizes back to 0.
+  EXPECT_EQ(angleToServoPosition(360.0), 0);
+}
+
+TEST(ShotAngle, AngleToServoPositionWrapsNegative) {
+  // -90 degrees wraps to 270 degrees -> 0.75 * 4096 = 3072.
+  EXPECT_EQ(angleToServoPosition(-90.0), 3072);
+}
+
+TEST(ShotAngle, AngleToServoPositionUpperClamp) {
+  // 359.99 degrees truncates to 4095 (never reaches 4096).
+  EXPECT_EQ(angleToServoPosition(359.99), 4095);
+}
+
+TEST(ShotAngle, ServoPositionToAngleKnownValues) {
+  EXPECT_DOUBLE_EQ(servoPositionToAngle(0), 0.0);
+  EXPECT_DOUBLE_EQ(servoPositionToAngle(2048), 180.0);
+}
+
+TEST(ShotAngle, ServoPositionToAngleMaxPosition) {
+  EXPECT_DOUBLE_EQ(servoPositionToAngle(4095), 4095.0 / 4096.0 * 360.0);
+}
+
+TEST(ShotAngle, ServoPositionToAngleClampsBelow) {
+  // -5 clamps to 0.
+  EXPECT_DOUBLE_EQ(servoPositionToAngle(-5), servoPositionToAngle(0));
+}
+
+TEST(ShotAngle, ServoPositionToAngleClampsAbove) {
+  // 5000 clamps to 4095.
+  EXPECT_DOUBLE_EQ(servoPositionToAngle(5000), servoPositionToAngle(4095));
+}
+
+TEST(ShotAngle, RoundTripPositionToAngleToPosition) {
+  for (int position : {0, 1024, 2048, 4095}) {
+    EXPECT_EQ(angleToServoPosition(servoPositionToAngle(position)), position);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
## 概要

Issue #91 チェックリスト項目5: `ShotComponent` の角度⇔サーボ位置変換とクランプのユニットテスト整備。

- 角度クランプ・角度⇔サーボ位置(0-4095)変換を header-only の `motor_control_app::shot_angle` inline 関数へ抽出。`static_cast<int>` の切り捨て挙動を含め逐語移動
- `ShotComponent` の 3 関数は 1 行委譲に(`clampAngle` は `tilt_min_angle_`/`tilt_max_angle_` を渡す)
- `motor_control_app` に初の gtest 基盤を追加
- クランプ境界(実デフォルト 0.0/70.0)、0/90/180/360(wrap)/-90/359.99(上限クランプ)、逆変換、入力クランプ、ラウンドトリップの 13 テスト

**Behavior unchanged.**

## 検証

- `colcon test-result`: 74 tests, 0 failures(新規 gtest 13/13 パス)
- fail 検知実証: 期待値を改変 → exit 1 確認後、復元して green
- `ament_clang_format`: clean

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)