### PR TITLE
chore: unify package versions to 2.0.0

### DIFF
--- a/description_launch/CHANGELOG.rst
+++ b/description_launch/CHANGELOG.rst
@@ -1,0 +1,10 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package description_launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* feat: update licenses to MIT across all packages and add LICENSE file (`#46 <https://github.com/scramble-robot/questix/issues/46>`_)
+* Feat: add robot description (`#32 <https://github.com/scramble-robot/questix/issues/32>`_)
+* Contributors: Akihisa Nagata, Kajioka Manami

--- a/description_launch/package.xml
+++ b/description_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>description_launch</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Questix description package</description>
   <maintainer email="manami.bean14@gmail.com">kajimame</maintainer>
   <license>MIT</license>

--- a/esc_motor_control_cpp/CHANGELOG.rst
+++ b/esc_motor_control_cpp/CHANGELOG.rst
@@ -1,0 +1,15 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package esc_motor_control_cpp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* fix(launcher): restore fire_button=5 and add per-controller YAML profiles (`#47 <https://github.com/scramble-robot/questix/issues/47>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* Fix/uart joy (`#38 <https://github.com/scramble-robot/questix/issues/38>`_)
+* feat: add UART Switch2 joy driver and stabilize robot control path (`#30 <https://github.com/scramble-robot/questix/issues/30>`_)
+* merge feature test in 0411 (`#29 <https://github.com/scramble-robot/questix/issues/29>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi

--- a/esc_motor_control_cpp/package.xml
+++ b/esc_motor_control_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>esc_motor_control_cpp</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>C++ ROS2 ESC motor control node with pigpio/lgpio backend support</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/gpio_reader/CHANGELOG.rst
+++ b/gpio_reader/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package gpio_reader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* fix: improve launch parameter consistency after controller profiles (`#48 <https://github.com/scramble-robot/questix/issues/48>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* feat: Ubuntu 24.04 / ROS 2 Jazzy 前提のベースラインへ統一 (`#39 <https://github.com/scramble-robot/questix/issues/39>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/gpio_reader/package.xml
+++ b/gpio_reader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>gpio_reader</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>ROS2 package for reading GPIO values on Raspberry Pi 5</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_controller/CHANGELOG.rst
+++ b/joy_controller/CHANGELOG.rst
@@ -2,6 +2,21 @@
 Changelog for package joy_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* fix: improve launch parameter consistency after controller profiles (`#48 <https://github.com/scramble-robot/questix/issues/48>`_)
+* feat: update licenses to MIT across all packages and add LICENSE file (`#46 <https://github.com/scramble-robot/questix/issues/46>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* feat: Ubuntu 24.04 / ROS 2 Jazzy 前提のベースラインへ統一 (`#39 <https://github.com/scramble-robot/questix/issues/39>`_)
+* fix: correct angular input ratio and update launch arguments for joy controller (`#37 <https://github.com/scramble-robot/questix/issues/37>`_)
+* feat: add UART Switch2 joy driver and stabilize robot control path (`#30 <https://github.com/scramble-robot/questix/issues/30>`_)
+* merge feature test in 0411 (`#29 <https://github.com/scramble-robot/questix/issues/29>`_)
+* refactor: rename project from shr to Questix and add auto_start script (`#28 <https://github.com/scramble-robot/questix/issues/28>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/joy_controller/package.xml
+++ b/joy_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_controller</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>Integrated Joy Controller for ROS2 with enhanced joystick functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_gate/CHANGELOG.rst
+++ b/joy_gate/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package joy_gate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* feat: update licenses to MIT across all packages and add LICENSE file (`#46 <https://github.com/scramble-robot/questix/issues/46>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* Contributors: Akihisa Nagata
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/joy_gate/package.xml
+++ b/joy_gate/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_gate</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>Joy message gating based on GPIO controllable status</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/launcher/CHANGELOG.rst
+++ b/launcher/CHANGELOG.rst
@@ -1,6 +1,24 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package questix_launcher
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* fix: add brake on stop parameter for improved motor control
+* fix: questix_launcher の esc 依存名を修正 (`#64 <https://github.com/scramble-robot/questix/issues/64>`_)
+* fix: remove unnecessary dependency on servo_control_ros2 from package.xml (`#63 <https://github.com/scramble-robot/questix/issues/63>`_)
+* feat: add current motor mode (`#57 <https://github.com/scramble-robot/questix/issues/57>`_)
+* fix(launcher): restore fire_button=5 and add per-controller YAML profiles (`#47 <https://github.com/scramble-robot/questix/issues/47>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* feat: Ubuntu 24.04 / ROS 2 Jazzy 前提のベースラインへ統一 (`#39 <https://github.com/scramble-robot/questix/issues/39>`_)
+* fix: correct angular input ratio and update launch arguments for joy controller (`#37 <https://github.com/scramble-robot/questix/issues/37>`_)
+* feat: add controller type configuration for UART and DualShock support
+* feat: add UART Switch2 joy driver and stabilize robot control path (`#30 <https://github.com/scramble-robot/questix/issues/30>`_)
+* merge feature test in 0411 (`#29 <https://github.com/scramble-robot/questix/issues/29>`_)
+* refactor: rename project from shr to Questix and add auto_start script (`#28 <https://github.com/scramble-robot/questix/issues/28>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi
 
 1.0.0 (2025-11-17)
 ------------------

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>questix_launcher</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>Questix system launcher package with XML-based launch files</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/motor_control_app/CHANGELOG.rst
+++ b/motor_control_app/CHANGELOG.rst
@@ -2,6 +2,25 @@
 Changelog for package motor_control_app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* test: add shot component angle conversion unit tests (`#106 <https://github.com/scramble-robot/questix/issues/106>`_)
+* fix: address fork PR15 review comments (`#77 <https://github.com/scramble-robot/questix/issues/77>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* fix: add brake on stop parameter for improved motor control
+* fix: initialize current tilt angle (`#73 <https://github.com/scramble-robot/questix/issues/73>`_)
+* fix: rename pan parameters to tilt in configuration and implementation (`#71 <https://github.com/scramble-robot/questix/issues/71>`_)
+* feat: add current motor mode (`#57 <https://github.com/scramble-robot/questix/issues/57>`_)
+* fix: improve launch parameter consistency after controller profiles (`#48 <https://github.com/scramble-robot/questix/issues/48>`_)
+* fix(launcher): restore fire_button=5 and add per-controller YAML profiles (`#47 <https://github.com/scramble-robot/questix/issues/47>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* feat: Ubuntu 24.04 / ROS 2 Jazzy 前提のベースラインへ統一 (`#39 <https://github.com/scramble-robot/questix/issues/39>`_)
+* Fix/uart joy (`#38 <https://github.com/scramble-robot/questix/issues/38>`_)
+* feat: add UART Switch2 joy driver and stabilize robot control path (`#30 <https://github.com/scramble-robot/questix/issues/30>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_app</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>Refactored motor control application using the new motor_control_lib</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib/CHANGELOG.rst
+++ b/motor_control_lib/CHANGELOG.rst
@@ -2,6 +2,23 @@
 Changelog for package motor_control_lib
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* test: add feetech modbus protocol unit tests (`#104 <https://github.com/scramble-robot/questix/issues/104>`_)
+* test: add ddt current-loop pi unit tests (`#103 <https://github.com/scramble-robot/questix/issues/103>`_)
+* test: add ddt protocol pack/parse unit tests (`#102 <https://github.com/scramble-robot/questix/issues/102>`_)
+* feat: add servo gui tool for calibration (`#76 <https://github.com/scramble-robot/questix/issues/76>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* fix: add brake on stop parameter for improved motor control
+* fix: correct byte order in sendMotorVelocity function for proper protocol compliance
+* fix: rename pan parameters to tilt in configuration and implementation (`#71 <https://github.com/scramble-robot/questix/issues/71>`_)
+* fix: harden current-mode PI state handling (`#66 <https://github.com/scramble-robot/questix/issues/66>`_)
+* feat: add current motor mode (`#57 <https://github.com/scramble-robot/questix/issues/57>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* refactor: rename project from shr to Questix and add auto_start script (`#28 <https://github.com/scramble-robot/questix/issues/28>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/motor_control_lib/package.xml
+++ b/motor_control_lib/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_lib</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>Motor control library with common interfaces for drive and shot functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib_simple/CHANGELOG.rst
+++ b/motor_control_lib_simple/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package motor_control_lib_simple
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* No functional changes; version aligned to the repository-wide 2.0.0 baseline
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/motor_control_lib_simple/package.xml
+++ b/motor_control_lib_simple/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>motor_control_lib_simple</name>
-    <version>0.0.0</version>
+    <version>2.0.0</version>
     <description>シンプルなモータ制御ライブラリ</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/operation_manager/CHANGELOG.rst
+++ b/operation_manager/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package operation_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* fix: resolve repository audit defects and harden ci checks (`#75 <https://github.com/scramble-robot/questix/issues/75>`_)
+* feat: update licenses to MIT across all packages and add LICENSE file (`#46 <https://github.com/scramble-robot/questix/issues/46>`_)
+* Contributors: Akihisa Nagata
+
 1.0.0 (2025-11-17)
 ------------------
 * refactor: add ref system and delete unused packages (`#21 <https://github.com/asa-naki/questy/issues/21>`_)

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>operation_manager</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Determine whether GPIO IO is controllable by subscribing to GPIO topics.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="robot-manager",
-    version="0.1.0",
+    version="2.0.0",
     packages=find_packages(),
     include_package_data=True,
     package_data={"robot_manager": ["static/*"]},

--- a/uart_joy_driver/CHANGELOG.rst
+++ b/uart_joy_driver/CHANGELOG.rst
@@ -1,0 +1,17 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package uart_joy_driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.0.0 (2026-07-16)
+------------------
+* chore: unify package versions to 2.0.0 (`#108 <https://github.com/scramble-robot/questix/issues/108>`_)
+* test: add uart joy parser and dropout filter unit tests (`#105 <https://github.com/scramble-robot/questix/issues/105>`_)
+* feat: update licenses to MIT across all packages and add LICENSE file (`#46 <https://github.com/scramble-robot/questix/issues/46>`_)
+* fix: fix launch files and parameters for consistency and clarity (`#45 <https://github.com/scramble-robot/questix/issues/45>`_)
+* fix: fix ci fail (`#41 <https://github.com/scramble-robot/questix/issues/41>`_)
+* feat: Ubuntu 24.04 / ROS 2 Jazzy 前提のベースラインへ統一 (`#39 <https://github.com/scramble-robot/questix/issues/39>`_)
+* Fix/uart joy (`#38 <https://github.com/scramble-robot/questix/issues/38>`_)
+* feat: add controller type configuration for UART and DualShock support
+* feat: add UART Switch2 joy driver and stabilize robot control path (`#30 <https://github.com/scramble-robot/questix/issues/30>`_)
+* merge feature test in 0411 (`#29 <https://github.com/scramble-robot/questix/issues/29>`_)
+* Contributors: Akihisa Nagata, Yuichiroh Kobayashi

--- a/uart_joy_driver/package.xml
+++ b/uart_joy_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>uart_joy_driver</name>
-    <version>0.1.0</version>
+    <version>2.0.0</version>
     <description>UART serial joystick driver for Switch-style controllers. Reads 7-byte hex protocol from UART and publishes sensor_msgs/Joy.</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>


### PR DESCRIPTION
## 概要

#98 で採用したバージョニング・ロードマップの「🏷️ v2.0.0 — 現 main を基準化（実機不要）」に従い、リポジトリ内のバージョン表記を 2.0.0 に統一する。

## 変更内容

- `package.xml` ×11（`0.0.0`、`uart_joy_driver` のみ `0.1.0`）→ `2.0.0`
- `scripts/setup.py`（`0.1.0`）→ `2.0.0`

## 背景

既存の `1.0.0` タグは旧 Python 版 ESC 時代の履歴を指しており、現 main は C++ 版へのアーキテクチャ入れ替え済みのため MAJOR bump（詳細は #98 の採用コメント参照）。

## マージ後の作業（このPRの範囲外）

- main HEAD に `2.0.0` タグを打ち、`2.0.0` リリースを作成
- 旧 `1.0.0` draft リリースは破棄（タグは記録として保持）
- 以降の安全パッチ（#80 / #82 / #107 等）は v2.0.1 として積み上げ

## 検証

- バージョン文字列の置換のみ（ロジック変更なし）。`git diff` で 12 ファイル・各1行の変更であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)