### PR TITLE
fix: reject non-finite control inputs

### DIFF
--- a/motor_control_app/include/motor_control_app/shot_angle.hpp
+++ b/motor_control_app/include/motor_control_app/shot_angle.hpp
@@ -7,6 +7,7 @@
 #define MOTOR_CONTROL_APP__SHOT_ANGLE_HPP_
 
 #include <algorithm>
+#include <cmath>
 
 namespace motor_control_app::shot_angle {
 
@@ -17,10 +18,16 @@ inline double clampAngle(double angle_deg, double min_deg, double max_deg) {
 
 // 角度からサーボ位置への変換（角度 -> 0-4095）
 inline int angleToServoPosition(double angle_deg) {
+  if (!std::isfinite(angle_deg)) {
+    return 0;
+  }
+
   // 角度を直接サーボ位置に変換（0度=0, 360度=4095）
   // 角度を0-360度の範囲で正規化
-  while (angle_deg < 0) angle_deg += 360.0;
-  while (angle_deg >= 360.0) angle_deg -= 360.0;
+  angle_deg = std::fmod(angle_deg, 360.0);
+  if (angle_deg < 0.0) {
+    angle_deg += 360.0;
+  }
 
   // サーボ位置に変換
   double normalized = angle_deg / 360.0;

--- a/motor_control_app/test/test_shot_angle.cpp
+++ b/motor_control_app/test/test_shot_angle.cpp
@@ -5,6 +5,8 @@
 // https://opensource.org/licenses/MIT.
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "motor_control_app/shot_angle.hpp"
 
 namespace {
@@ -45,6 +47,17 @@ TEST(ShotAngle, AngleToServoPositionWrapsPositive) {
 TEST(ShotAngle, AngleToServoPositionWrapsNegative) {
   // -90 degrees wraps to 270 degrees -> 0.75 * 4096 = 3072.
   EXPECT_EQ(angleToServoPosition(-90.0), 3072);
+}
+
+TEST(ShotAngle, AngleToServoPositionRejectsNonFinite) {
+  EXPECT_EQ(angleToServoPosition(std::numeric_limits<double>::quiet_NaN()), 0);
+  EXPECT_EQ(angleToServoPosition(std::numeric_limits<double>::infinity()), 0);
+  EXPECT_EQ(angleToServoPosition(-std::numeric_limits<double>::infinity()), 0);
+}
+
+TEST(ShotAngle, AngleToServoPositionWrapsLargeFiniteValues) {
+  EXPECT_EQ(angleToServoPosition(360000090.0), 1024);
+  EXPECT_EQ(angleToServoPosition(-360000090.0), 3072);
 }
 
 TEST(ShotAngle, AngleToServoPositionUpperClamp) {

--- a/motor_control_lib/src/ddt_current_pi.cpp
+++ b/motor_control_lib/src/ddt_current_pi.cpp
@@ -11,7 +11,7 @@
 namespace motor_control_lib::ddt_current_pi {
 
 double sanitizeDt(double dt_seconds) {
-  if (dt_seconds <= 0.0 || dt_seconds > 0.2) {
+  if (!(dt_seconds > 0.0 && dt_seconds <= 0.2)) {
     return 0.01;  // 異常値クリップ（初回および異常時のフォールバック [s]）
   }
   return dt_seconds;

--- a/motor_control_lib/test/test_ddt_current_pi.cpp
+++ b/motor_control_lib/test/test_ddt_current_pi.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <limits>
 
 #include "motor_control_lib/ddt_current_pi.hpp"
 
@@ -85,6 +86,9 @@ TEST(SanitizeDt, ClipsAbnormalValues) {
   EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.25), 0.01);
   EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.05), 0.05);
   EXPECT_DOUBLE_EQ(pi::sanitizeDt(0.2), 0.2);  // 境界は保持
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(std::numeric_limits<double>::quiet_NaN()), 0.01);
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(std::numeric_limits<double>::infinity()), 0.01);
+  EXPECT_DOUBLE_EQ(pi::sanitizeDt(-std::numeric_limits<double>::infinity()), 0.01);
 }
 
 TEST(InZeroDeadband, Boundaries) {


### PR DESCRIPTION
## 概要

fork側のv2.0.0同期レビュー
`Yuichiroh-Kobayashi/questix#18`
でGemini Code Assistから指摘された、非有限値に対する安全性問題を修正します。

## 問題

### Shot angle

`angleToServoPosition()`はwhile loopで角度を正規化していました。

- NaNでは比較が成立せず、後続の数値変換が不定
- Infinityではloopが終了しない
- 巨大な有限値では過大な反復が発生

ロボット制御callback内で長時間停止する可能性があります。

### DDT current PI

`sanitizeDt()`の既存条件はNaNを拒否できず、
NaNがPI積分処理へ伝播する可能性がありました。

## 修正

- shot angle
  - `std::isfinite()`で非有限値を拒否
  - `std::fmod()`で定数時間の角度正規化
  - 非有限値はservo position `0`へフォールバック
- DDT current PI
  - 正常範囲を肯定形で検証
  - NaNおよび±Infinityを`0.01 s`へフォールバック

## テスト

追加:

- shot angle
  - NaN
  - +Infinity
  - -Infinity
  - 巨大な正負有限値
- sanitizeDt
  - NaN
  - +Infinity
  - -Infinity

既存のwrap、clamp、境界値、PI制御テストは維持しています。

## 確認

- [x] C++ format
- [x] `git diff --check`
- [x] sanitized full clean build（11 packages）
- [x] `test_shot_angle`（15 tests pass）
- [x] `test_ddt_current_pi`（9 tests pass）
- [x] package tests（非xmllint failureなし）
- [x] full tests（非xmllint failureなし）
- [x] GitHub Actions（7 checks pass）

検証directory: `/tmp/questix-nonfinite-fix-final.phWU1B`

`colcon test`はpackage/fullともstatus 0でした。`colcon test-result`はローカル環境から`http://download.ros.org/schema/package_format3.xsd`を取得できないxmllintのみstatus 1で、unit test・C++ lint・Python testに追加failureはありません。

## 非対応のレビュー指摘

`linear_y_axis`の境界確認不足との指摘もありましたが、
現在のコードは以下の条件内でのみ配列へアクセスしています。

```cpp
linear_y_axis_ >= 0 &&
static_cast<size_t>(linear_y_axis_) < msg->axes.size()
```

`linear_y_axis_ < 0`は横移動を無効化する既存仕様です。
そのためコード変更は行いません。

## 実機

実機未確認です。

今回の変更は異常な数値入力を安全値へ変換する防御処理であり、
正常な有限値の数値挙動は維持します。
