### PR TITLE
fix: clear esc full-speed latch on safety timeout and require re-press

### DIFF
--- a/esc_motor_control_cpp/CMakeLists.txt
+++ b/esc_motor_control_cpp/CMakeLists.txt
@@ -62,6 +62,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_full_speed_logic test/test_full_speed_logic.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.dualshock.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.dualshock.yaml
@@ -20,6 +20,13 @@ esc_motor_control:
     status_topic: "/roller_motor_status"
     emergency_status_topic: "/roller_emergency_status"
 
+    # Safety / timeout-stop behavior:
+    # If no full-speed command arrives within safety_timeout seconds (e.g. the
+    # joy stream drops), the motor is stopped automatically. After a timeout
+    # stop the full-speed latch is cleared and the button must be RELEASED and
+    # PRESSED AGAIN to restart; holding it down will NOT auto-resume
+    # (safety: no motion resumes without a fresh operator press).
+    # Set enable_safety_stop=false to disable the timeout stop entirely.
     enable_safety_stop: true
     safety_timeout: 1.0
 

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.uart.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.uart.yaml
@@ -20,6 +20,13 @@ esc_motor_control:
     status_topic: "/roller_motor_status"
     emergency_status_topic: "/roller_emergency_status"
 
+    # Safety / timeout-stop behavior:
+    # If no full-speed command arrives within safety_timeout seconds (e.g. the
+    # joy stream drops), the motor is stopped automatically. After a timeout
+    # stop the full-speed latch is cleared and the button must be RELEASED and
+    # PRESSED AGAIN to restart; holding it down will NOT auto-resume
+    # (safety: no motion resumes without a fresh operator press).
+    # Set enable_safety_stop=false to disable the timeout stop entirely.
     enable_safety_stop: true
     safety_timeout: 1.0
 

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.yaml
@@ -29,6 +29,13 @@ esc_motor_control:
     emergency_status_topic: "/roller_emergency_status"
 
     # Safety settings
+    # Safety / timeout-stop behavior:
+    # If no full-speed command arrives within safety_timeout seconds (e.g. the
+    # joy stream drops), the motor is stopped automatically. After a timeout
+    # stop the full-speed latch is cleared and the button must be RELEASED and
+    # PRESSED AGAIN to restart; holding it down will NOT auto-resume
+    # (safety: no motion resumes without a fresh operator press).
+    # Set enable_safety_stop=false to disable the timeout stop entirely.
     enable_safety_stop: true # Enable automatic safety stop
     safety_timeout: 1.0 # Seconds without command before safety stop
 

--- a/esc_motor_control_cpp/include/esc_motor_control_cpp/esc_motor_control_component.hpp
+++ b/esc_motor_control_cpp/include/esc_motor_control_cpp/esc_motor_control_component.hpp
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <string>
 
+#include "esc_motor_control_cpp/full_speed_logic.hpp"
 #include "esc_motor_control_cpp/pwm_backend.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
@@ -59,8 +60,7 @@ private:
   // ---------- State ----------
   double current_speed_{0.0};
   bool emergency_stop_active_{false};
-  bool full_speed_active_{false};
-  rclcpp::Time last_command_time_{0, 0, RCL_ROS_TIME};
+  FullSpeedLogic full_speed_logic_;
   std::mutex lock_;
 
   // ---------- PWM ----------

--- a/esc_motor_control_cpp/include/esc_motor_control_cpp/full_speed_logic.hpp
+++ b/esc_motor_control_cpp/include/esc_motor_control_cpp/full_speed_logic.hpp
@@ -1,0 +1,80 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#pragma once
+
+namespace esc_motor_control_cpp {
+
+// フルスピードボタンのラッチ状態機械（ROS 非依存・時刻注入）
+class FullSpeedLogic {
+public:
+  struct Result {
+    bool start_full_speed{false};  // set_motor_speed(full_speed_value_) を実行
+    bool stop{false};              // set_motor_speed(0.0) を実行
+    bool timed_out{false};         // タイムアウト発火（WARN ログ用・1回のみ）
+    bool ignored_press{false};     // 押し直し要求により押下を無視した
+  };
+
+  void configure(double timeout_sec) { timeout_sec_ = timeout_sec; }
+
+  Result onButton(bool pressed, double now_sec) {
+    Result result;
+
+    if (pressed) {
+      if (active_) {
+        // Keep-alive: refresh the timeout window while held.
+        last_command_sec_ = now_sec;
+      } else if (require_release_) {
+        // Latch was cleared by a safety timeout: ignore the held press until a
+        // release is observed. No motion resumes without a fresh operator press.
+        result.ignored_press = true;
+      } else {
+        active_ = true;
+        last_command_sec_ = now_sec;
+        result.start_full_speed = true;
+      }
+    } else {
+      // A release re-arms the latch for the next press.
+      require_release_ = false;
+      if (active_) {
+        active_ = false;
+        result.stop = true;
+      }
+    }
+
+    return result;
+  }
+
+  Result onTimerCheck(double now_sec) {
+    Result result;
+
+    // Timeout disabled, or nothing running: nothing to evaluate.
+    // The '!active_' guard also prevents multiple fires after a single timeout.
+    if (timeout_sec_ <= 0.0 || !active_) {
+      return result;
+    }
+
+    // Strict '>' only: elapsed == timeout_sec_ does not fire.
+    if (now_sec - last_command_sec_ > timeout_sec_) {
+      active_ = false;
+      require_release_ = true;
+
+      result.stop = true;
+      result.timed_out = true;
+    }
+
+    return result;
+  }
+
+  bool isActive() const { return active_; }
+
+private:
+  double timeout_sec_{0.0};
+  bool active_{false};
+  bool require_release_{false};  // タイムアウト後の押し直し要求
+  double last_command_sec_{0.0};
+};
+
+}  // namespace esc_motor_control_cpp

--- a/esc_motor_control_cpp/package.xml
+++ b/esc_motor_control_cpp/package.xml
@@ -14,6 +14,7 @@
     <depend>std_msgs</depend>
     <depend>sensor_msgs</depend>
 
+    <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
 

--- a/esc_motor_control_cpp/src/esc_motor_control_component.cpp
+++ b/esc_motor_control_cpp/src/esc_motor_control_component.cpp
@@ -53,7 +53,7 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   gpio_chip_num_ = this->get_parameter("gpio_chip_num").as_int();
 
   // ---- Internal state ----
-  last_command_time_ = this->now();
+  full_speed_logic_.configure(safety_timeout_);
 
   // ---- QoS ----
   rclcpp::QoS qos_transient(10);
@@ -170,7 +170,6 @@ void EscMotorControlComponent::set_motor_speed(double speed) {
   speed = std::max(min_speed_, std::min(max_speed_, speed));
 
   current_speed_ = speed;
-  last_command_time_ = this->now();
 
   if (pwm_ && pwm_->name() != "simulation") {
     int pulse_us = speed_to_pulse_us(speed);
@@ -191,19 +190,22 @@ void EscMotorControlComponent::joy_callback(const sensor_msgs::msg::Joy::SharedP
 
   bool full_speed_pressed = (msg->buttons[full_speed_button_] == 1);
 
-  if (full_speed_pressed && !full_speed_active_) {
-    RCLCPP_INFO(this->get_logger(), "Full-speed button PRESSED");
-    full_speed_active_ = true;
-    set_motor_speed(full_speed_value_);
-
-  } else if (full_speed_pressed && full_speed_active_) {
+  FullSpeedLogic::Result r;
+  {
     std::lock_guard<std::mutex> guard(lock_);
-    last_command_time_ = this->now();
+    r = full_speed_logic_.onButton(full_speed_pressed, this->now().seconds());
+  }
+  // Lock released before set_motor_speed(), which takes lock_ itself.
 
-  } else if (!full_speed_pressed && full_speed_active_) {
+  if (r.start_full_speed) {
+    RCLCPP_INFO(this->get_logger(), "Full-speed button PRESSED");
+    set_motor_speed(full_speed_value_);
+  } else if (r.stop) {
     RCLCPP_INFO(this->get_logger(), "Full-speed button RELEASED");
-    full_speed_active_ = false;
     set_motor_speed(0.0);
+  } else if (r.ignored_press) {
+    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                         "Full-speed press ignored after safety timeout: release and press again");
   }
 }
 
@@ -213,14 +215,17 @@ void EscMotorControlComponent::joy_callback(const sensor_msgs::msg::Joy::SharedP
 void EscMotorControlComponent::safety_check() {
   if (!enable_safety_stop_) return;
 
-  double elapsed;
+  FullSpeedLogic::Result r;
   {
     std::lock_guard<std::mutex> guard(lock_);
-    elapsed = (this->now() - last_command_time_).seconds();
+    r = full_speed_logic_.onTimerCheck(this->now().seconds());
   }
+  // Lock released before set_motor_speed(), which takes lock_ itself.
 
-  if (elapsed > safety_timeout_ && !emergency_stop_active_) {
+  if (r.timed_out) {
     RCLCPP_WARN(this->get_logger(), "Safety timeout: stopping motor");
+  }
+  if (r.stop && !emergency_stop_active_) {
     set_motor_speed(0.0);
   }
 }

--- a/esc_motor_control_cpp/test/test_full_speed_logic.cpp
+++ b/esc_motor_control_cpp/test/test_full_speed_logic.cpp
@@ -1,0 +1,200 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include "esc_motor_control_cpp/full_speed_logic.hpp"
+
+namespace {
+
+esc_motor_control_cpp::FullSpeedLogic makeLogic(double timeout_sec = 1.0) {
+  esc_motor_control_cpp::FullSpeedLogic logic;
+  logic.configure(timeout_sec);
+  return logic;
+}
+
+}  // namespace
+
+TEST(FullSpeedLogicTest, InitiallyInactiveAndNoFalseFire) {
+  auto logic = makeLogic();
+  EXPECT_FALSE(logic.isActive());
+
+  // No press has occurred; the timer must not report anything.
+  const auto r = logic.onTimerCheck(1000.0);
+  EXPECT_FALSE(r.start_full_speed);
+  EXPECT_FALSE(r.stop);
+  EXPECT_FALSE(r.timed_out);
+  EXPECT_FALSE(r.ignored_press);
+  EXPECT_FALSE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, PressStartsReleaseStops) {
+  auto logic = makeLogic();
+
+  const auto r_press = logic.onButton(true, 0.0);
+  EXPECT_TRUE(r_press.start_full_speed);
+  EXPECT_FALSE(r_press.stop);
+  EXPECT_TRUE(logic.isActive());
+
+  const auto r_release = logic.onButton(false, 0.1);
+  EXPECT_FALSE(r_release.start_full_speed);
+  EXPECT_TRUE(r_release.stop);
+  EXPECT_FALSE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, HeldKeepAliveNeverTimesOut) {
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+
+  // Held-button messages every 0.5s, checked every 0.1s, for 5 simulated seconds.
+  double t = 0.0;
+  double next_msg = 0.5;
+  while (t <= 5.0) {
+    if (t >= next_msg) {
+      const auto r = logic.onButton(true, t);
+      EXPECT_FALSE(r.stop);
+      next_msg += 0.5;
+    }
+    const auto r = logic.onTimerCheck(t);
+    EXPECT_FALSE(r.timed_out);
+    t += 0.1;
+  }
+  EXPECT_TRUE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, KeepAliveResetsTimeoutWindow) {
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+
+  // Just before timeout, a keep-alive refreshes the window.
+  const auto r_keep = logic.onButton(true, 0.9);
+  EXPECT_FALSE(r_keep.stop);
+
+  // 1.5s is > 1.0 since t=0, but only 0.6s since the keep-alive: no timeout.
+  const auto r = logic.onTimerCheck(1.5);
+  EXPECT_FALSE(r.timed_out);
+  EXPECT_TRUE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, BoundaryExactlyAtTimeoutDoesNotFire) {
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+
+  const auto r = logic.onTimerCheck(1.0);  // elapsed == timeout_sec: no fire
+  EXPECT_FALSE(r.stop);
+  EXPECT_FALSE(r.timed_out);
+  EXPECT_TRUE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, JustPastTimeoutFires) {
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+
+  const auto r = logic.onTimerCheck(1.0 + 1e-6);
+  EXPECT_TRUE(r.stop);
+  EXPECT_TRUE(r.timed_out);
+  EXPECT_FALSE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, TimeoutIsSingleShot) {
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+
+  const auto r1 = logic.onTimerCheck(2.0);
+  EXPECT_TRUE(r1.timed_out);
+  EXPECT_TRUE(r1.stop);
+
+  const auto r2 = logic.onTimerCheck(3.0);
+  EXPECT_FALSE(r2.stop);
+  EXPECT_FALSE(r2.timed_out);
+}
+
+TEST(FullSpeedLogicTest, HeldPressAfterTimeoutDoesNotRestart) {
+  // Core of this fix: after a timeout, holding the button down must NOT resume.
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+  logic.onTimerCheck(2.0);  // times out
+  ASSERT_FALSE(logic.isActive());
+
+  // joy recovers while the button is still held: press observed again.
+  const auto r = logic.onButton(true, 2.5);
+  EXPECT_FALSE(r.start_full_speed);
+  EXPECT_TRUE(r.ignored_press);
+  EXPECT_FALSE(logic.isActive());
+
+  // Still held on the next message: still ignored, still stopped.
+  const auto r2 = logic.onButton(true, 3.0);
+  EXPECT_FALSE(r2.start_full_speed);
+  EXPECT_TRUE(r2.ignored_press);
+  EXPECT_FALSE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, ReleaseThenPressAfterTimeoutRestarts) {
+  auto logic = makeLogic(1.0);
+  logic.onButton(true, 0.0);
+  logic.onTimerCheck(2.0);  // times out
+  ASSERT_FALSE(logic.isActive());
+
+  // A fresh release re-arms the latch.
+  const auto r_release = logic.onButton(false, 2.5);
+  EXPECT_FALSE(r_release.stop);
+  EXPECT_FALSE(r_release.ignored_press);
+
+  // A fresh press now restarts full speed.
+  const auto r_press = logic.onButton(true, 2.6);
+  EXPECT_TRUE(r_press.start_full_speed);
+  EXPECT_TRUE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, TimerCheckWhileInactiveIsNoOp) {
+  auto logic = makeLogic(1.0);
+  ASSERT_FALSE(logic.isActive());
+
+  const auto r = logic.onTimerCheck(1000.0);
+  EXPECT_FALSE(r.stop);
+  EXPECT_FALSE(r.timed_out);
+  EXPECT_FALSE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, ZeroTimeoutDisablesFeature) {
+  auto logic = makeLogic(0.0);
+  logic.onButton(true, 0.0);
+
+  const auto r = logic.onTimerCheck(1000.0);
+  EXPECT_FALSE(r.timed_out);
+  EXPECT_TRUE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, NegativeTimeoutDisablesFeature) {
+  auto logic = makeLogic(-1.0);
+  logic.onButton(true, 0.0);
+
+  const auto r = logic.onTimerCheck(1000.0);
+  EXPECT_FALSE(r.timed_out);
+  EXPECT_TRUE(logic.isActive());
+}
+
+TEST(FullSpeedLogicTest, RepeatedNormalCyclesWork) {
+  auto logic = makeLogic(1.0);
+
+  double t = 0.0;
+  for (int i = 0; i < 5; ++i) {
+    const auto r_press = logic.onButton(true, t);
+    EXPECT_TRUE(r_press.start_full_speed);
+    EXPECT_FALSE(r_press.ignored_press);
+    EXPECT_TRUE(logic.isActive());
+
+    const auto r_release = logic.onButton(false, t + 0.1);
+    EXPECT_TRUE(r_release.stop);
+    EXPECT_FALSE(logic.isActive());
+
+    t += 1.0;
+  }
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## 概要

Closes #86

`esc_motor_control_component.cpp` で、セーフティタイムアウト停止後にフルスピードボタンを保持したままだと `full_speed_active_` が true のまま残り、立ち上がりエッジが二度と検出されず、モーターが警告なしに 0 のまま停止し続ける問題を修正します。

issue の選択肢のうち**案B（復帰を実装）**を採用し、復帰セマンティクスは安全側の**押し直し必須**としました: タイムアウト後はボタンの release を一度観測するまで新規押下を無視するため、保持したまま joy が復旧（コントローラ再接続など）してもモーターは自動では回りません。release → press で確実に再開します。

## 変更内容

- ボタン/タイムアウト状態機械を ROS 非依存・時刻注入の `FullSpeedLogic`（ヘッダオンリー）に抽出（joy_gate の `GateLogic`・417b032 と同じパターン）。タイムアウトでラッチ解除 + `require_release_` を設定。
- `set_motor_speed()` の `last_command_time_` 更新副作用を除去（停止後にタイムアウトが再発火しない一因だったため、キープアライブをロジック側に一本化）。
- `joy_callback()` / `safety_check()` はロック下でロジックに委譲し、ロック解放後に `set_motor_speed()` を実行（非再帰ロックの規約を維持）。無視された押下は 5 秒スロットルの INFO で「release して押し直し」を案内。
- gtest 13 ケースを新設（境界 `elapsed == timeout` 非発火、タイムアウト単発、保持のままでは再開しない、release→press で再開、timeout≤0 無効など）。CMakeLists / package.xml にテスト配線を追加。
- config YAML 3 種（通常 / dualshock / uart、同一文言）にタイムアウト停止 → 復帰の仕様コメントを追加（受け入れ条件の文書化に対応）。

## 挙動変化の注記

- タイムアウト WARN は従来の約 1 秒ごとの連発から 1 回のみになります（意図した改善）。
- `emergency_stop_active_` はどこからも書き込まれない死に状態ですが、本 PR ではスコープ外として現状の読み取り/publish のみ維持しています。

## 検証

- `colcon build --packages-select esc_motor_control_cpp` 成功
- `colcon test`: `test_full_speed_logic` 13/13 パス（パッケージ全体 40 テスト・失敗 0）
- `ament_clang_format --config .clang-format`（CI 同等）差分なし、`git diff --check` クリーン

## 残タスク: Raspberry Pi 5 実機検証（受け入れ条件）

- [ ] ボタン押下でフルスピード回転、離すと停止
- [ ] 保持中に joy を切断 → `safety_timeout` 超過でモーター停止 + WARN ログ
- [ ] 保持したまま joy 復旧 → 回らない（自動復帰しない）、スロットル INFO が出る
- [ ] release → press で確実に再開（複数回繰り返して確認）
- [ ] dualshock / uart の config バリアントでも同一挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)