### PR TITLE
fix: drain DDT serial output with tcdrain

### DIFF
--- a/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
@@ -198,6 +198,7 @@ private:
   bool parseFeedback(int expected_motor_id, const std::vector<uint8_t>& frame);
 
   // Utility methods
+  bool drainSerialOutput();
   bool sendCommand(const std::vector<uint8_t>& command, int retry_count = 3);
   ssize_t writeSerial(const void* data, size_t size);
   ssize_t readSerial(void* data, size_t size);

--- a/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <map>
 #include <mutex>
+#include <rclcpp/clock.hpp>
 #include <vector>
 
 #include "motor_control_lib/base_motor_controller.hpp"
@@ -168,6 +169,7 @@ private:
 
   // Serial communication
   int serial_fd_;
+  rclcpp::Clock throttle_clock_{RCL_STEADY_TIME};
 
   // 公開APIから触る状態マップとシリアル送受信の保護。
   // 公開メソッド同士が内部で呼び合うため recursive_mutex を使う。

--- a/motor_control_lib/src/ddt_motor_lib.cpp
+++ b/motor_control_lib/src/ddt_motor_lib.cpp
@@ -8,6 +8,8 @@
 #include <sys/select.h>
 
 #include <algorithm>
+#include <cerrno>
+#include <cstring>
 #include <thread>
 
 #include "motor_control_lib/ddt_protocol.hpp"
@@ -504,7 +506,9 @@ bool DdtMotorLib::sendFrameWithFeedback(int motor_id, const std::vector<uint8_t>
       std::this_thread::sleep_for(5ms);
       continue;
     }
-    fsync(serial_fd_);
+    if (!drainSerialOutput()) {
+      return false;
+    }
 
     std::vector<uint8_t> feedback_frame;
     if (readFeedbackFrame(motor_id, feedback_frame, /*timeout_ms=*/10)) {
@@ -663,7 +667,10 @@ bool DdtMotorLib::sendCommand(const std::vector<uint8_t>& command, int retry_cou
     try {
       ssize_t written = writeSerial(command.data(), command.size());
       if (written == static_cast<ssize_t>(command.size())) {
-        fsync(serial_fd_);
+        // 書込済みcommandの重複送信を避けるため、drain失敗時は再試行しない。
+        if (!drainSerialOutput()) {
+          return false;
+        }
         std::this_thread::sleep_for(50ms);
         return true;
       }
@@ -673,6 +680,27 @@ bool DdtMotorLib::sendCommand(const std::vector<uint8_t>& command, int retry_cou
     }
   }
   return false;
+}
+
+bool DdtMotorLib::drainSerialOutput() {
+  if (serial_fd_ < 0) {
+    return false;
+  }
+
+  int result;
+  do {
+    result = tcdrain(serial_fd_);
+  } while (result == -1 && errno == EINTR);
+
+  if (result != 0) {
+    const int saved_errno = errno;
+    RCLCPP_WARN_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 1000,
+                         "シリアル送信完了待機に失敗: errno=%d (%s)", saved_errno,
+                         std::strerror(saved_errno));
+    return false;
+  }
+
+  return true;
 }
 
 ssize_t DdtMotorLib::writeSerial(const void* data, size_t size) {

--- a/motor_control_lib/src/ddt_motor_lib.cpp
+++ b/motor_control_lib/src/ddt_motor_lib.cpp
@@ -501,8 +501,7 @@ bool DdtMotorLib::sendFrameWithFeedback(int motor_id, const std::vector<uint8_t>
   for (int attempt = 0; attempt < 3; ++attempt) {
     ssize_t written = writeSerial(frame.data(), frame.size());
     if (written != static_cast<ssize_t>(frame.size())) {
-      RCLCPP_WARN_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 1000, "指令書込失敗 motor=%d",
-                           motor_id);
+      RCLCPP_WARN_THROTTLE(logger_, throttle_clock_, 1000, "指令書込失敗 motor=%d", motor_id);
       std::this_thread::sleep_for(5ms);
       continue;
     }
@@ -553,7 +552,7 @@ int16_t DdtMotorLib::runCurrentLoopStep(int motor_id, int rpm_ref) {
   // ログは従来通り符号反転後の実測値と、それに基づく error を表示する。
   int meas_logged = current_invert_measured_ ? -measured_rpm : measured_rpm;
   double error = static_cast<double>(rpm_ref - meas_logged);
-  RCLCPP_INFO_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 200,
+  RCLCPP_INFO_THROTTLE(logger_, throttle_clock_, 200,
                        "PI motor=%d ref=%d meas=%d err=%.1f integ=%.3fA i_cmd=%.3fA raw=%d dt=%.4f",
                        motor_id, rpm_ref, meas_logged, error, st.pi.integral_amp, i_cmd_amp,
                        static_cast<int>(raw), dt);
@@ -632,7 +631,7 @@ bool DdtMotorLib::parseFeedback(int expected_motor_id, const std::vector<uint8_t
       // ログ用に payload の期待 CRC を再計算する。
       std::vector<uint8_t> payload(frame.begin(), frame.begin() + 9);
       uint8_t expected_crc = ddt_protocol::crc8Maxim(payload);
-      RCLCPP_WARN_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 1000,
+      RCLCPP_WARN_THROTTLE(logger_, throttle_clock_, 1000,
                            "CRC不一致 motor=%d expected=0x%02X got=0x%02X", expected_motor_id,
                            expected_crc, frame[9]);
     }
@@ -688,13 +687,14 @@ bool DdtMotorLib::drainSerialOutput() {
   }
 
   int result;
+  int saved_errno = 0;
   do {
     result = tcdrain(serial_fd_);
-  } while (result == -1 && errno == EINTR);
+    saved_errno = result == -1 ? errno : 0;
+  } while (result == -1 && saved_errno == EINTR);
 
   if (result != 0) {
-    const int saved_errno = errno;
-    RCLCPP_WARN_THROTTLE(logger_, *rclcpp::Clock::make_shared(), 1000,
+    RCLCPP_WARN_THROTTLE(logger_, throttle_clock_, 1000,
                          "シリアル送信完了待機に失敗: errno=%d (%s)", saved_errno,
                          std::strerror(saved_errno));
     return false;


### PR DESCRIPTION
## 概要

fork側レビューPR`Yuichiroh-Kobayashi/questix#19`でGemini Code Assistから指摘された、DDT serial出力の完了待機APIを修正します。

## 問題

`DdtMotorLib`はserial portのfile descriptorに対して`fsync()`を呼んでいました。

`fsync()`は通常のfile内容をstorageへ同期するAPIであり、terminalの送信完了待機には適しません。

対象は以下の2経路です。

- 高頻度の`sendFrameWithFeedback()`
- 低頻度の`sendCommand()`

## 修正

- serial出力完了待機を`tcdrain()`へ変更
- `EINTR`時は再試行
- その他のerrorはログしてfailureとして返す
- full write後のdrain failureで盲目的なcommand再送を行わない
- 固定sleepは追加しない
- `command_wait_ms`およびfeedback timeoutの既存仕様を維持

`tcdrain()`は固定時間sleepではありませんが、terminalの出力queueが空になるまでblockingします。
正常通信時の遅延と、USB serial異常時の挙動は実機確認事項とします。

## 検証

- [x] C++ format
- [x] `git diff --check`
- [x] clean build
- [x] DDT unit tests
- [x] motor_control_lib package tests
- [x] motor_control_app package tests
- [x] 非xmllint failureなし
- [x] GitHub Actions

sanitized clean buildとtargeted DDT unit testsは成功しました。
package testsのfailureは、外部ROS package schemaを取得できないことによる
`xmllint`のみです。その他のtest failureとundefined symbolはありません。

## 実機未確認

- Raspberry Pi 5
- `/dev/motor`実UART
- DDT M0602C
- 50Hz連続指令
- feedback response timing
- `tcdrain()`の実測所要時間
- 左右2モータを50 Hzで送信した場合の実効command rate
- USB serial切断・再接続時の`tcdrain()`の戻り方と遅延
- serial異常時のdrive watchdog / emergency stop応答性
- feedback 10 ms timeoutが送信完了後から開始されること

実機では、指令rate、feedback timeout、CRCログ頻度を別途確認する必要があります。
