### PR TITLE
feat: convert drive_component to a lifecycle node

### DIFF
--- a/launcher/config/drive_component.yaml
+++ b/launcher/config/drive_component.yaml
@@ -7,6 +7,13 @@ drive_component:
     serial_port: "/dev/ttyACM0"
     baud_rate: 57600
 
+    # Lifecycle auto start / ライフサイクル自動起動
+    # 非常停止中はモータが通電されず接続できないため、unconfigured で待機し
+    # connect_retry_period_sec 間隔で接続を再試行、成功したら自動で activate する。
+    # false にすると ros2 lifecycle set で手動遷移する運用になる。
+    auto_start: true
+    connect_retry_period_sec: 1.0
+
     # ロボット物理パラメータ
     wheel_radius: 0.1 # ホイール半径 [m]
     wheel_separation: 0.5 # ホイール間隔 [m]

--- a/motor_control_app/CMakeLists.txt
+++ b/motor_control_app/CMakeLists.txt
@@ -98,6 +98,7 @@ if(BUILD_TESTING)
 
   ament_auto_add_gtest(test_shot_angle test/test_shot_angle.cpp)
   ament_auto_add_gtest(test_drive_watchdog test/test_drive_watchdog.cpp)
+  ament_auto_add_gtest(test_lifecycle_auto_start test/test_lifecycle_auto_start.cpp)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/motor_control_app/config/drive_component.yaml
+++ b/motor_control_app/config/drive_component.yaml
@@ -7,6 +7,13 @@ drive_component:
     serial_port: "/dev/ttyACM0"
     baud_rate: 57600
 
+    # Lifecycle auto start / ライフサイクル自動起動
+    # 非常停止中はモータが通電されず接続できないため、unconfigured で待機し
+    # connect_retry_period_sec 間隔で接続を再試行、成功したら自動で activate する。
+    # false にすると ros2 lifecycle set で手動遷移する運用になる。
+    auto_start: true
+    connect_retry_period_sec: 1.0
+
     # ロボット物理パラメータ
     wheel_radius: 0.1 # ホイール半径 [m]
     wheel_separation: 0.5 # ホイール間隔 [m]

--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -109,6 +109,10 @@ private:
   void resetCommandState();
 
   // ROS 2 通信
+  // Twist/status/watchdog/auto-start callbacks intentionally share the node's default
+  // MutuallyExclusive callback group, so callbacks do not run concurrently. If entities are
+  // split across callback groups, synchronize motor_initialized_, diff_drive_, command state,
+  // timer pointers, and all motor serial operations before enabling concurrent execution.
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr status_publisher_;
   rclcpp::TimerBase::SharedPtr status_timer_;

--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -15,18 +15,28 @@
 #include "motor_control_lib/differential_drive.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 #include "std_msgs/msg/string.hpp"
 
 namespace motor_control_app {
 
 /**
- * @brief DDTモータを使用したドライブコンポーネント
+ * @brief DDTモータを使用したドライブコンポーネント（Lifecycle ノード）
  *
  * geometry_msgs/Twistメッセージを受信してDDTモータを制御します。
- * ROS 2のコンポーネントシステムを使用して実装されています。
+ *
+ * 非常停止中はモータが通電されず、シリアル接続（/dev/ttyACM0 の USB CDC）が
+ * 得られない。そのため起動時は unconfigured で待機し、通電後に
+ * configure（シリアル接続 + モータ初期化）→ activate（twist 受付開始）で
+ * 運用状態に遷移する。auto_start=true（既定）の場合、内蔵タイマーが
+ * configure/activate を成功するまで再試行するので、外部の lifecycle manager
+ * なしで systemd 起動に耐える（shot_component と同パターン）。
  */
-class DriveComponent : public rclcpp::Node {
+class DriveComponent : public rclcpp_lifecycle::LifecycleNode {
 public:
+  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
   /**
    * @brief コンストラクタ
    * @param options ノードオプション
@@ -36,7 +46,14 @@ public:
   /**
    * @brief デストラクタ
    */
-  virtual ~DriveComponent();
+  ~DriveComponent() override;
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State& state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State& state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State& state) override;
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State& state) override;
+  CallbackReturn on_shutdown(const rclcpp_lifecycle::State& state) override;
+  CallbackReturn on_error(const rclcpp_lifecycle::State& state) override;
 
 private:
   /**
@@ -58,9 +75,22 @@ private:
   void watchdogTimerCallback();
 
   /**
-   * @brief パラメータを初期化
+   * @brief auto_start タイマーコールバック
+   *
+   * unconfigured なら configure、inactive なら activate を試行し、
+   * active に到達したらタイマーを止める（手動 deactivate を自動で覆さない）。
    */
-  void initializeParameters();
+  void autoStartTimerCallback();
+
+  /**
+   * @brief パラメータを宣言（コンストラクタで一度だけ呼ぶ）
+   */
+  void declareParameters();
+
+  /**
+   * @brief パラメータを取得（on_configure で呼び、cleanup→configure で再読込可能にする）
+   */
+  void readParameters();
 
   /**
    * @brief DDTモータライブラリを初期化
@@ -68,11 +98,22 @@ private:
    */
   bool initializeMotorLib();
 
+  /**
+   * @brief モータライブラリを安全に停止・解放（何度呼んでも安全）
+   */
+  void shutdownMotorLib();
+
+  /**
+   * @brief スルーレート制限用のコマンド状態をリセット
+   */
+  void resetCommandState();
+
   // ROS 2 通信
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr status_publisher_;
   rclcpp::TimerBase::SharedPtr status_timer_;
   rclcpp::TimerBase::SharedPtr watchdog_timer_;
+  rclcpp::TimerBase::SharedPtr auto_start_timer_;
 
   // モータ制御ライブラリ
   std::shared_ptr<motor_control_lib::DdtMotorLib> motor_lib_;
@@ -115,6 +156,10 @@ private:
 
   // 指令送信後の追加待機 [ms]。0で無効（DDT M0602C の間隔要件用の保険）
   int command_wait_ms_{0};
+
+  // Lifecycle 自動起動（モータ通電まで configure を再試行する）
+  bool auto_start_{true};
+  double connect_retry_period_sec_{1.0};
 
   // 状態フラグ
   bool motor_initialized_;

--- a/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
@@ -6,8 +6,10 @@
 #ifndef MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_
 #define MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_
 
+#include <cmath>
 #include <cstdint>
 #include <lifecycle_msgs/msg/state.hpp>
+#include <limits>
 
 namespace motor_control_app::lifecycle_auto_start {
 
@@ -18,7 +20,8 @@ enum class AutoStartAction { kConfigure, kActivate, kStopTimer, kNone };
 // unconfigured -> kConfigure（接続を試行）
 // inactive     -> kActivate（運用状態へ遷移）
 // active       -> kStopTimer（正常稼働中。手動 deactivate/cleanup を尊重して停止）
-// それ以外（finalized・遷移中など）-> kNone（何もしない）
+// finalized    -> kStopTimer（終了後にタイマーを残さない）
+// transition/unknown -> kNone（何もしない）
 inline AutoStartAction decideAutoStartAction(uint8_t state_id) {
   switch (state_id) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
@@ -26,10 +29,48 @@ inline AutoStartAction decideAutoStartAction(uint8_t state_id) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
       return AutoStartAction::kActivate;
     case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
       return AutoStartAction::kStopTimer;
     default:
       return AutoStartAction::kNone;
   }
+}
+
+inline bool isTransitionState(uint8_t state_id) {
+  switch (state_id) {
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING:
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline bool isValidPositiveValue(double value) { return std::isfinite(value) && value > 0.0; }
+
+inline double normalizeRetryPeriod(double value, double fallback) {
+  return isValidPositiveValue(value) ? value : fallback;
+}
+
+inline int64_t statusTimerPeriodNanoseconds(double rate_hz) {
+  if (!isValidPositiveValue(rate_hz)) {
+    return 0;
+  }
+  constexpr long double kNanosecondsPerSecond = 1000000000.0L;
+  const long double period_ns = kNanosecondsPerSecond / static_cast<long double>(rate_hz);
+  if (!std::isfinite(period_ns) || period_ns < 1.0L ||
+      period_ns > static_cast<long double>(std::numeric_limits<int64_t>::max())) {
+    return 0;
+  }
+  return static_cast<int64_t>(period_ns);
+}
+
+inline bool isValidStatusPublishRate(double value) {
+  return statusTimerPeriodNanoseconds(value) > 0;
 }
 
 }  // namespace motor_control_app::lifecycle_auto_start

--- a/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
@@ -1,0 +1,37 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#ifndef MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_
+#define MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_
+
+#include <cstdint>
+#include <lifecycle_msgs/msg/state.hpp>
+
+namespace motor_control_app::lifecycle_auto_start {
+
+// auto_start タイマーが取るべきアクション
+enum class AutoStartAction { kConfigure, kActivate, kStopTimer, kNone };
+
+// 現在の lifecycle 状態 id から自動起動タイマーのアクションを決定する。
+// unconfigured -> kConfigure（接続を試行）
+// inactive     -> kActivate（運用状態へ遷移）
+// active       -> kStopTimer（正常稼働中。手動 deactivate/cleanup を尊重して停止）
+// それ以外（finalized・遷移中など）-> kNone（何もしない）
+inline AutoStartAction decideAutoStartAction(uint8_t state_id) {
+  switch (state_id) {
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
+      return AutoStartAction::kConfigure;
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
+      return AutoStartAction::kActivate;
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
+      return AutoStartAction::kStopTimer;
+    default:
+      return AutoStartAction::kNone;
+  }
+}
+
+}  // namespace motor_control_app::lifecycle_auto_start
+
+#endif  // MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -11,6 +11,8 @@
 
     <depend>rclcpp</depend>
     <depend>rclcpp_components</depend>
+    <depend>rclcpp_lifecycle</depend>
+    <depend>lifecycle_msgs</depend>
     <depend>std_msgs</depend>
     <depend>geometry_msgs</depend>
     <depend>sensor_msgs</depend>

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -5,15 +5,20 @@
 // https://opensource.org/licenses/MIT.
 #include "motor_control_app/drive_component.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <functional>
+#include <lifecycle_msgs/msg/state.hpp>
+
+#include "motor_control_app/lifecycle_auto_start.hpp"
 
 using namespace std::chrono_literals;
 
 namespace motor_control_app {
 
 DriveComponent::DriveComponent(const rclcpp::NodeOptions& options)
-    : Node("drive_component", options),
+    : rclcpp_lifecycle::LifecycleNode("drive_component", options),
       last_cmd_linear_(0.0),
       last_cmd_angular_(0.0),
       last_cmd_time_(0, 0, RCL_ROS_TIME),
@@ -21,22 +26,128 @@ DriveComponent::DriveComponent(const rclcpp::NodeOptions& options)
       cmd_timeout_sec_(0.5),
       motor_initialized_(false),
       emergency_stop_active_(false) {
-  RCLCPP_INFO(this->get_logger(), "Initializing Drive Component");
+  // パラメーター宣言（取得は on_configure で行い、cleanup→configure で再読込できるようにする）
+  declareParameters();
 
-  // パラメータを初期化
-  initializeParameters();
+  auto_start_ = this->get_parameter("auto_start").as_bool();
+  connect_retry_period_sec_ = this->get_parameter("connect_retry_period_sec").as_double();
 
-  // DDTモータライブラリを初期化
-  if (!initializeMotorLib()) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to initialize motor library");
-    return;
+  if (auto_start_) {
+    const auto period = std::chrono::duration<double>(std::max(0.5, connect_retry_period_sec_));
+    auto_start_timer_ =
+        this->create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+                                std::bind(&DriveComponent::autoStartTimerCallback, this));
+    RCLCPP_INFO(this->get_logger(),
+                "Drive component created (auto_start=true, retry=%.1fs). "
+                "モータ通電（非常停止解除）を待って自動起動します",
+                connect_retry_period_sec_);
+  } else {
+    RCLCPP_INFO(this->get_logger(),
+                "Drive component created (auto_start=false). "
+                "外部から lifecycle configure/activate してください");
+  }
+}
+
+DriveComponent::~DriveComponent() {
+  if (auto_start_timer_) {
+    auto_start_timer_->cancel();
+  }
+  if (status_timer_) {
+    status_timer_->cancel();
+  }
+  if (watchdog_timer_) {
+    watchdog_timer_->cancel();
+  }
+  shutdownMotorLib();
+}
+
+void DriveComponent::autoStartTimerCallback() {
+  using lifecycle_auto_start::AutoStartAction;
+  using lifecycle_auto_start::decideAutoStartAction;
+
+  AutoStartAction action = decideAutoStartAction(this->get_current_state().id());
+  if (action == AutoStartAction::kConfigure) {
+    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                         "モータ接続を試行します（未通電時は失敗し、通電後に自動復帰します）");
+    this->configure();
+    // 通電済みの通常起動で従来同等のタイミングで走行可能にするため、
+    // configure 成功時は同一ティックで activate まで進める。
+    action = decideAutoStartAction(this->get_current_state().id());
+  }
+  if (action == AutoStartAction::kActivate) {
+    this->activate();
+  } else if (action == AutoStartAction::kStopTimer) {
+    // 正常稼働中はタイマーを止め、手動 deactivate/cleanup を尊重する。
+    auto_start_timer_->cancel();
+  }
+}
+
+DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecycle::State&) {
+  readParameters();
+
+  // 未通電（非常停止中）は USB CDC デバイス自体が存在しない。ライブラリを構築する前に
+  // デバイスの有無を確認し、リトライ毎のライブラリ内 ERROR ログで journald を汚さない。
+  if (!std::filesystem::exists(serial_port_)) {
+    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                         "シリアルデバイス %s がありません（モータ未通電の可能性）。"
+                         "通電を待って再試行します",
+                         serial_port_.c_str());
+    return CallbackReturn::FAILURE;
   }
 
-  // ROS 2 通信の設定
+  // シリアル接続 + モータ初期化（非常停止中はポートが無い / 開けない場合がある）
+  if (!initializeMotorLib()) {
+    // 半構築のインスタンスを残さない（次回の configure 再試行のため）
+    diff_drive_.reset();
+    motor_lib_.reset();
+    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                         "モータ初期化に失敗しました (port=%s)。通電を待って再試行します",
+                         serial_port_.c_str());
+    return CallbackReturn::FAILURE;
+  }
+
+  RCLCPP_INFO(this->get_logger(), "Parameters:");
+  RCLCPP_INFO(this->get_logger(), "  serial_port: %s", serial_port_.c_str());
+  RCLCPP_INFO(this->get_logger(), "  baud_rate: %d", baud_rate_);
+  RCLCPP_INFO(this->get_logger(), "  wheel_radius: %.3f", wheel_radius_);
+  RCLCPP_INFO(this->get_logger(), "  wheel_separation: %.3f", wheel_separation_);
+  RCLCPP_INFO(this->get_logger(), "  left_motor_id: %d", left_motor_id_);
+  RCLCPP_INFO(this->get_logger(), "  right_motor_id: %d", right_motor_id_);
+  RCLCPP_INFO(this->get_logger(), "  max_motor_rpm: %d", max_motor_rpm_);
+  RCLCPP_INFO(this->get_logger(), "  status_publish_rate: %.1f", status_publish_rate_);
+  RCLCPP_INFO(this->get_logger(), "  status_topic: %s", status_topic_.c_str());
+  RCLCPP_INFO(this->get_logger(), "  cmd_timeout_sec: %.2f", cmd_timeout_sec_);
+  RCLCPP_INFO(this->get_logger(), "  control_mode: %s", control_mode_.c_str());
+  if (control_mode_ == "current") {
+    RCLCPP_INFO(
+        this->get_logger(),
+        "  current_kp: %.4f  current_ki: %.4f  max_current_amp: %.2f  integral_limit_amp: %.2f",
+        current_kp_, current_ki_, max_current_amp_, integral_limit_amp_);
+    RCLCPP_INFO(this->get_logger(), "  current_zero_deadband_rpm: %d", current_zero_deadband_rpm_);
+  }
+
+  // twist 購読（コールバックは ACTIVE のときのみ処理する）
   twist_subscription_ = this->create_subscription<geometry_msgs::msg::Twist>(
       "/target_twist", 1, std::bind(&DriveComponent::twistCallback, this, std::placeholders::_1));
 
+  // LifecyclePublisher のため on_activate まで publish は無効
   status_publisher_ = this->create_publisher<std_msgs::msg::String>(status_topic_, 1);
+
+  RCLCPP_INFO(this->get_logger(), "Drive component configured");
+  return CallbackReturn::SUCCESS;
+}
+
+DriveComponent::CallbackReturn DriveComponent::on_activate(const rclcpp_lifecycle::State& state) {
+  if (!motor_initialized_ || !diff_drive_) {
+    RCLCPP_ERROR(this->get_logger(), "Motor library not initialized, cannot activate");
+    return CallbackReturn::FAILURE;
+  }
+
+  // LifecyclePublisher を有効化（ステータスタイマー作成より先に呼ぶ）
+  rclcpp_lifecycle::LifecycleNode::on_activate(state);
+
+  // inactive 中の残留指令でスルーレートクランプが誤動作しないようリセット
+  resetCommandState();
 
   // ステータスパブリッシュタイマー
   auto timer_period = std::chrono::duration<double>(1.0 / status_publish_rate_);
@@ -54,21 +165,68 @@ DriveComponent::DriveComponent(const rclcpp::NodeOptions& options)
                 "last command if /target_twist stops");
   }
 
-  RCLCPP_INFO(this->get_logger(), "Drive Component initialized successfully");
-}
-
-DriveComponent::~DriveComponent() {
-  if (motor_lib_ && motor_initialized_) {
-    RCLCPP_INFO(this->get_logger(), "Shutting down motor library");
-    if (diff_drive_) {
-      diff_drive_->stop();
-    }
-    motor_lib_->emergencyStop();
-    motor_lib_->shutdown();
+  RCLCPP_INFO(this->get_logger(), "Drive component activated");
+  // 稼働状態に到達。以降は自動再遷移を止めて手動 deactivate/cleanup を尊重する。
+  if (auto_start_timer_) {
+    auto_start_timer_->cancel();
   }
+  return CallbackReturn::SUCCESS;
 }
 
-void DriveComponent::initializeParameters() {
+DriveComponent::CallbackReturn DriveComponent::on_deactivate(const rclcpp_lifecycle::State& state) {
+  status_timer_.reset();
+  watchdog_timer_.reset();
+  // best-effort で停止指令（電流PI積分状態もリセットされる）
+  if (diff_drive_) {
+    diff_drive_->stop();
+  }
+  resetCommandState();
+  rclcpp_lifecycle::LifecycleNode::on_deactivate(state);
+  // 手動 deactivate を含め、deactivate では自動再遷移を必ず止める
+  // （shot_component bc037d1 と同じ扱い）。
+  if (auto_start_timer_) {
+    auto_start_timer_->cancel();
+  }
+  RCLCPP_INFO(this->get_logger(), "Drive component deactivated (twist input ignored)");
+  return CallbackReturn::SUCCESS;
+}
+
+DriveComponent::CallbackReturn DriveComponent::on_cleanup(const rclcpp_lifecycle::State&) {
+  status_timer_.reset();
+  watchdog_timer_.reset();
+  twist_subscription_.reset();
+  status_publisher_.reset();
+  shutdownMotorLib();
+  RCLCPP_INFO(this->get_logger(), "Drive component cleaned up");
+  return CallbackReturn::SUCCESS;
+}
+
+DriveComponent::CallbackReturn DriveComponent::on_shutdown(const rclcpp_lifecycle::State&) {
+  status_timer_.reset();
+  watchdog_timer_.reset();
+  twist_subscription_.reset();
+  status_publisher_.reset();
+  shutdownMotorLib();
+  RCLCPP_INFO(this->get_logger(), "Drive component shut down");
+  return CallbackReturn::SUCCESS;
+}
+
+DriveComponent::CallbackReturn DriveComponent::on_error(const rclcpp_lifecycle::State&) {
+  // 遷移中に ERROR / 例外が発生したときの後始末。リソースを解放して unconfigured
+  // に戻し、auto_start 有効時はタイマーを再開して自動復帰に委ねる。
+  status_timer_.reset();
+  watchdog_timer_.reset();
+  twist_subscription_.reset();
+  status_publisher_.reset();
+  shutdownMotorLib();
+  if (auto_start_ && auto_start_timer_) {
+    auto_start_timer_->reset();
+  }
+  RCLCPP_WARN(this->get_logger(), "Drive component error handled, returning to unconfigured");
+  return CallbackReturn::SUCCESS;
+}
+
+void DriveComponent::declareParameters() {
   // DDTモータライブラリのパラメータを宣言
   this->declare_parameter("serial_port", "/dev/ttyACM0");
   this->declare_parameter("baud_rate", 115200);
@@ -100,7 +258,12 @@ void DriveComponent::initializeParameters() {
   // 指令送信後の追加待機 [ms]。0で無効。実機の最小コマンド間隔要件用の保険
   this->declare_parameter("command_wait_ms", 0);
 
-  // パラメータを取得
+  // Lifecycle 自動遷移。非常停止解除でモータが通電するまで configure を再試行する。
+  this->declare_parameter("auto_start", true);
+  this->declare_parameter("connect_retry_period_sec", 1.0);
+}
+
+void DriveComponent::readParameters() {
   serial_port_ = this->get_parameter("serial_port").as_string();
   baud_rate_ = this->get_parameter("baud_rate").as_int();
   wheel_radius_ = this->get_parameter("wheel_radius").as_double();
@@ -122,26 +285,6 @@ void DriveComponent::initializeParameters() {
   brake_on_stop_ = this->get_parameter("brake_on_stop").as_bool();
   cmd_timeout_sec_ = this->get_parameter("cmd_timeout_sec").as_double();
   command_wait_ms_ = static_cast<int>(this->get_parameter("command_wait_ms").as_int());
-
-  RCLCPP_INFO(this->get_logger(), "Parameters initialized:");
-  RCLCPP_INFO(this->get_logger(), "  serial_port: %s", serial_port_.c_str());
-  RCLCPP_INFO(this->get_logger(), "  baud_rate: %d", baud_rate_);
-  RCLCPP_INFO(this->get_logger(), "  wheel_radius: %.3f", wheel_radius_);
-  RCLCPP_INFO(this->get_logger(), "  wheel_separation: %.3f", wheel_separation_);
-  RCLCPP_INFO(this->get_logger(), "  left_motor_id: %d", left_motor_id_);
-  RCLCPP_INFO(this->get_logger(), "  right_motor_id: %d", right_motor_id_);
-  RCLCPP_INFO(this->get_logger(), "  max_motor_rpm: %d", max_motor_rpm_);
-  RCLCPP_INFO(this->get_logger(), "  status_publish_rate: %.1f", status_publish_rate_);
-  RCLCPP_INFO(this->get_logger(), "  status_topic: %s", status_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "  cmd_timeout_sec: %.2f", cmd_timeout_sec_);
-  RCLCPP_INFO(this->get_logger(), "  control_mode: %s", control_mode_.c_str());
-  if (control_mode_ == "current") {
-    RCLCPP_INFO(
-        this->get_logger(),
-        "  current_kp: %.4f  current_ki: %.4f  max_current_amp: %.2f  integral_limit_amp: %.2f",
-        current_kp_, current_ki_, max_current_amp_, integral_limit_amp_);
-    RCLCPP_INFO(this->get_logger(), "  current_zero_deadband_rpm: %d", current_zero_deadband_rpm_);
-  }
 }
 
 bool DriveComponent::initializeMotorLib() {
@@ -161,9 +304,8 @@ bool DriveComponent::initializeMotorLib() {
     // 指令送信後の追加待機（既定 0 = 無効）
     motor_lib_->setCommandWaitMs(command_wait_ms_);
 
-    // モータライブラリを初期化
+    // モータライブラリを初期化（シリアルポートを開く。未通電なら失敗して再試行に回る）
     if (!motor_lib_->initialize()) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to initialize motor library");
       return false;
     }
 
@@ -201,7 +343,32 @@ bool DriveComponent::initializeMotorLib() {
   }
 }
 
+void DriveComponent::shutdownMotorLib() {
+  if (motor_lib_ && motor_initialized_) {
+    RCLCPP_INFO(this->get_logger(), "Shutting down motor library");
+    if (diff_drive_) {
+      diff_drive_->stop();
+    }
+    motor_lib_->emergencyStop();
+    motor_lib_->shutdown();
+  }
+  diff_drive_.reset();
+  motor_lib_.reset();
+  motor_initialized_ = false;
+}
+
+void DriveComponent::resetCommandState() {
+  has_last_cmd_ = false;
+  last_cmd_linear_ = 0.0;
+  last_cmd_angular_ = 0.0;
+}
+
 void DriveComponent::twistCallback(const geometry_msgs::msg::Twist::SharedPtr msg) {
+  // inactive 中の twist は無視する（lifecycle activate 後にのみ駆動する）
+  if (this->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    return;
+  }
+
   bool motor_ready = motor_initialized_ && diff_drive_ != nullptr;
   switch (drive_watchdog::decideTwistAction(motor_ready, emergency_stop_active_,
                                             motor_ready && diff_drive_->isHealthy())) {
@@ -213,9 +380,7 @@ void DriveComponent::twistCallback(const geometry_msgs::msg::Twist::SharedPtr ms
     case drive_watchdog::TwistAction::kFaultStop:
       // モータ異常中は最後の指令を保持せず、明示的に停止指令を送る。
       diff_drive_->stop();
-      has_last_cmd_ = false;
-      last_cmd_linear_ = 0.0;
-      last_cmd_angular_ = 0.0;
+      resetCommandState();
       RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                            "Motor not healthy: sending stop command");
       return;
@@ -280,9 +445,7 @@ void DriveComponent::watchdogTimerCallback() {
     diff_drive_->stop();
     // 再発火防止（イベント毎に WARN 1回）。次の /target_twist で自動的に再武装し、
     // スルーレートクランプもゼロから再スタートする。
-    has_last_cmd_ = false;
-    last_cmd_linear_ = 0.0;
-    last_cmd_angular_ = 0.0;
+    resetCommandState();
   }
 }
 

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <filesystem>
 #include <functional>
 #include <lifecycle_msgs/msg/state.hpp>
@@ -30,7 +31,14 @@ DriveComponent::DriveComponent(const rclcpp::NodeOptions& options)
   declareParameters();
 
   auto_start_ = this->get_parameter("auto_start").as_bool();
-  connect_retry_period_sec_ = this->get_parameter("connect_retry_period_sec").as_double();
+  const double requested_retry_period = this->get_parameter("connect_retry_period_sec").as_double();
+  connect_retry_period_sec_ =
+      lifecycle_auto_start::normalizeRetryPeriod(requested_retry_period, 1.0);
+  if (!lifecycle_auto_start::isValidPositiveValue(requested_retry_period)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Invalid connect_retry_period_sec=%g; using the default 1.0 seconds",
+                requested_retry_period);
+  }
 
   if (auto_start_) {
     const auto period = std::chrono::duration<double>(std::max(0.5, connect_retry_period_sec_));
@@ -65,25 +73,49 @@ void DriveComponent::autoStartTimerCallback() {
   using lifecycle_auto_start::AutoStartAction;
   using lifecycle_auto_start::decideAutoStartAction;
 
-  AutoStartAction action = decideAutoStartAction(this->get_current_state().id());
-  if (action == AutoStartAction::kConfigure) {
-    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
-                         "モータ接続を試行します（未通電時は失敗し、通電後に自動復帰します）");
-    this->configure();
-    // 通電済みの通常起動で従来同等のタイミングで走行可能にするため、
-    // configure 成功時は同一ティックで activate まで進める。
-    action = decideAutoStartAction(this->get_current_state().id());
+  if (!auto_start_timer_) {
+    return;
   }
-  if (action == AutoStartAction::kActivate) {
-    this->activate();
-  } else if (action == AutoStartAction::kStopTimer) {
-    // 正常稼働中はタイマーを止め、手動 deactivate/cleanup を尊重する。
-    auto_start_timer_->cancel();
+  try {
+    uint8_t state_id = this->get_current_state().id();
+    AutoStartAction action = decideAutoStartAction(state_id);
+    if (action == AutoStartAction::kConfigure) {
+      RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                           "モータ接続を試行します（未通電時は失敗し、通電後に自動復帰します）");
+      state_id = this->configure().id();
+      action = decideAutoStartAction(state_id);
+    }
+    if (action == AutoStartAction::kActivate) {
+      state_id = this->activate().id();
+      action = decideAutoStartAction(state_id);
+    }
+    if (action == AutoStartAction::kStopTimer) {
+      auto_start_timer_->cancel();
+    } else if (action == AutoStartAction::kNone &&
+               !lifecycle_auto_start::isTransitionState(state_id)) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                           "Unexpected lifecycle state during drive auto-start: %u",
+                           static_cast<unsigned int>(state_id));
+    }
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                          "Drive auto-start transition failed: %s", error.what());
+  } catch (...) {
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                          "Drive auto-start transition failed with unknown exception");
   }
 }
 
 DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecycle::State&) {
   readParameters();
+
+  if (!lifecycle_auto_start::isValidStatusPublishRate(status_publish_rate_)) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Invalid status_publish_rate=%g; value must produce a positive, representable "
+                 "nanosecond timer period",
+                 status_publish_rate_);
+    return CallbackReturn::FAILURE;
+  }
 
   // 未通電（非常停止中）は USB CDC デバイス自体が存在しない。ライブラリを構築する前に
   // デバイスの有無を確認し、リトライ毎のライブラリ内 ERROR ログで journald を汚さない。
@@ -150,10 +182,10 @@ DriveComponent::CallbackReturn DriveComponent::on_activate(const rclcpp_lifecycl
   resetCommandState();
 
   // ステータスパブリッシュタイマー
-  auto timer_period = std::chrono::duration<double>(1.0 / status_publish_rate_);
+  const auto timer_period = std::chrono::nanoseconds(
+      lifecycle_auto_start::statusTimerPeriodNanoseconds(status_publish_rate_));
   status_timer_ =
-      this->create_wall_timer(std::chrono::duration_cast<std::chrono::milliseconds>(timer_period),
-                              std::bind(&DriveComponent::statusTimerCallback, this));
+      this->create_wall_timer(timer_period, std::bind(&DriveComponent::statusTimerCallback, this));
 
   // コマンド受信ウォッチドッグ（100ms 周期）。cmd_timeout_sec_ <= 0 で無効。
   if (drive_watchdog::isEnabled(cmd_timeout_sec_)) {
@@ -202,6 +234,9 @@ DriveComponent::CallbackReturn DriveComponent::on_cleanup(const rclcpp_lifecycle
 }
 
 DriveComponent::CallbackReturn DriveComponent::on_shutdown(const rclcpp_lifecycle::State&) {
+  if (auto_start_timer_) {
+    auto_start_timer_->cancel();
+  }
   status_timer_.reset();
   watchdog_timer_.reset();
   twist_subscription_.reset();

--- a/motor_control_app/src/drive_component_node.cpp
+++ b/motor_control_app/src/drive_component_node.cpp
@@ -20,7 +20,8 @@ int main(int argc, char* argv[]) {
   RCLCPP_INFO(drive_node->get_logger(), "Starting Drive Component Node");
 
   try {
-    rclcpp::spin(drive_node);
+    // LifecycleNode は Node を継承しないため base interface 経由で spin する
+    rclcpp::spin(drive_node->get_node_base_interface());
   } catch (const std::exception& e) {
     RCLCPP_ERROR(drive_node->get_logger(), "Exception during execution: %s", e.what());
   }

--- a/motor_control_app/test/test_lifecycle_auto_start.cpp
+++ b/motor_control_app/test/test_lifecycle_auto_start.cpp
@@ -1,0 +1,66 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include <lifecycle_msgs/msg/state.hpp>
+
+#include "motor_control_app/lifecycle_auto_start.hpp"
+
+namespace {
+
+using lifecycle_msgs::msg::State;
+using motor_control_app::lifecycle_auto_start::AutoStartAction;
+using motor_control_app::lifecycle_auto_start::decideAutoStartAction;
+
+TEST(LifecycleAutoStart, UnconfiguredTriggersConfigure) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
+}
+
+TEST(LifecycleAutoStart, InactiveTriggersActivate) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_INACTIVE), AutoStartAction::kActivate);
+}
+
+TEST(LifecycleAutoStart, ActiveStopsTimer) {
+  // 正常稼働に到達したらタイマーを止め、以降の手動 deactivate/cleanup を
+  // 自動再遷移で覆さない（shot_component bc037d1 の教訓）。
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_ACTIVE), AutoStartAction::kStopTimer);
+}
+
+TEST(LifecycleAutoStart, FinalizedDoesNothing) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_FINALIZED), AutoStartAction::kNone);
+}
+
+TEST(LifecycleAutoStart, TransitionStatesDoNothing) {
+  // configure/activate は同期呼び出しだが、遷移中状態を観測しても安全側に倒す。
+  EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_CONFIGURING), AutoStartAction::kNone);
+  EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_ACTIVATING), AutoStartAction::kNone);
+  EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_DEACTIVATING), AutoStartAction::kNone);
+  EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_CLEANINGUP), AutoStartAction::kNone);
+  EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_SHUTTINGDOWN), AutoStartAction::kNone);
+  EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_ERRORPROCESSING), AutoStartAction::kNone);
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNKNOWN), AutoStartAction::kNone);
+}
+
+TEST(LifecycleAutoStart, PoweredStartupReachesActiveInOneTick) {
+  // 通電済み起動: configure 成功で inactive を再評価すると同一ティックで
+  // activate まで進む（起動タイミング維持の受け入れ条件）。
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
+  // configure() 成功後の状態 = INACTIVE
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_INACTIVE), AutoStartAction::kActivate);
+}
+
+TEST(LifecycleAutoStart, UnpoweredStartupRetriesConfigure) {
+  // 未通電起動: configure 失敗で unconfigured に戻り、次ティックも kConfigure。
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/motor_control_app/test/test_lifecycle_auto_start.cpp
+++ b/motor_control_app/test/test_lifecycle_auto_start.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <lifecycle_msgs/msg/state.hpp>
+#include <limits>
 
 #include "motor_control_app/lifecycle_auto_start.hpp"
 
@@ -14,6 +15,9 @@ namespace {
 using lifecycle_msgs::msg::State;
 using motor_control_app::lifecycle_auto_start::AutoStartAction;
 using motor_control_app::lifecycle_auto_start::decideAutoStartAction;
+using motor_control_app::lifecycle_auto_start::isValidStatusPublishRate;
+using motor_control_app::lifecycle_auto_start::normalizeRetryPeriod;
+using motor_control_app::lifecycle_auto_start::statusTimerPeriodNanoseconds;
 
 TEST(LifecycleAutoStart, UnconfiguredTriggersConfigure) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
@@ -29,8 +33,8 @@ TEST(LifecycleAutoStart, ActiveStopsTimer) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_ACTIVE), AutoStartAction::kStopTimer);
 }
 
-TEST(LifecycleAutoStart, FinalizedDoesNothing) {
-  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_FINALIZED), AutoStartAction::kNone);
+TEST(LifecycleAutoStart, FinalizedStopsTimer) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_FINALIZED), AutoStartAction::kStopTimer);
 }
 
 TEST(LifecycleAutoStart, TransitionStatesDoNothing) {
@@ -56,6 +60,34 @@ TEST(LifecycleAutoStart, UnpoweredStartupRetriesConfigure) {
   // 未通電起動: configure 失敗で unconfigured に戻り、次ティックも kConfigure。
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
+}
+
+TEST(LifecycleAutoStart, UnexpectedStateDoesNothing) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNKNOWN), AutoStartAction::kNone);
+}
+
+TEST(LifecycleParameters, InvalidRetryPeriodFallsBackToDefault) {
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(2.5, 1.0), 2.5);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(0.0, 1.0), 1.0);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(-1.0, 1.0), 1.0);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(std::numeric_limits<double>::quiet_NaN(), 1.0), 1.0);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(std::numeric_limits<double>::infinity(), 1.0), 1.0);
+}
+
+TEST(LifecycleParameters, StatusPublishRateMustBeFiniteAndPositive) {
+  EXPECT_TRUE(isValidStatusPublishRate(10.0));
+  EXPECT_FALSE(isValidStatusPublishRate(0.0));
+  EXPECT_FALSE(isValidStatusPublishRate(-1.0));
+  EXPECT_FALSE(isValidStatusPublishRate(std::numeric_limits<double>::quiet_NaN()));
+  EXPECT_FALSE(isValidStatusPublishRate(std::numeric_limits<double>::infinity()));
+}
+
+TEST(LifecycleParameters, StatusTimerPeriodMustRemainPositiveAfterConversion) {
+  EXPECT_EQ(statusTimerPeriodNanoseconds(10.0), 100000000);
+  EXPECT_EQ(statusTimerPeriodNanoseconds(1000.0), 1000000);
+  EXPECT_EQ(statusTimerPeriodNanoseconds(1000000000.0), 1);
+  EXPECT_EQ(statusTimerPeriodNanoseconds(2000000000.0), 0);
+  EXPECT_FALSE(isValidStatusPublishRate(2000000000.0));
 }
 
 }  // namespace


### PR DESCRIPTION
## 概要

Closes #85

`drive_component` はコンストラクタ内で DDT モータのシリアル接続（`/dev/ttyACM0`）に失敗すると early return し、購読のない半初期化ノードとして残っていました。PR #79 の shot_component と同じライフサイクルノード化パターンを適用し、モータ未通電のまま systemd 起動しても通電後に自動で運用状態に復帰するようにします。

## 変更内容

- `rclcpp_lifecycle::LifecycleNode` 化。コンストラクタはパラメータ宣言とリトライタイマー作成のみ（ハードウェアアクセス・early return なし）
- `on_configure`: シリアル接続 + モータ初期化（`initializeMotor`）。失敗は FAILURE で unconfigured に戻す。未通電の一般ケース（USB CDC デバイスファイル不在）はライブラリを構築せず、30 秒スロットルの WARN 1 行だけで静かに再試行する（journald 対策）
- `on_activate`: status publisher（LifecyclePublisher）有効化、status/watchdog タイマー作成、twist 受付開始。inactive 中の twist はコールバック先頭の状態ガードで無視
- `auto_start` / `connect_retry_period_sec` パラメータで内蔵リトライ（外部 lifecycle manager 不要）。**通電済み起動のタイミング維持のため、configure 成功時は同一ティックで activate まで進め、リトライ周期は 1.0s**（shot は 3.0s）
- 手動 `deactivate` では auto_start タイマーを止め、自動で再 activate しない（shot の bc037d1 と同じ扱い）
- `on_error` / `on_cleanup` / `on_shutdown` で `emergencyStop()` + `shutdown()` を確実に呼ぶ（`shutdownMotorLib()` に集約、デストラクタからも安全）
- standalone 実行ファイル `drive_component_node` は base interface 経由の spin に変更
- 遷移判断ロジックを `lifecycle_auto_start.hpp` の純粋関数に切り出し gtest 追加（`drive_watchdog.hpp` と同スタイル）
- `package.xml` に `rclcpp_lifecycle` / `lifecycle_msgs` を追加
- `drive_component.yaml`（launcher / motor_control_app の両方、同期維持）に `auto_start: true` / `connect_retry_period_sec: 1.0` を追加
- PR #111 のウォッチドッグ / fault-stop は無変更で共存（タイマーは on_activate/on_deactivate で作成・破棄）

## launch / systemd への影響

- launch / systemd unit の変更は不要（`auto_start=true` 既定）
- `drive_component.launch.py` の `respawn=True` は、初期化失敗でプロセスが落ちなくなるため実質発火しなくなります（意図した挙動変化）

## 検証

- `colcon build` / `colcon test` 成功（105 tests, 0 failures）、`ament_clang_format` 通過
- ハードなしスモーク（AMD64）:
  - デバイスなし起動 → プロセス存続・`unconfigured` 待機・静かなリトライ・`lifecycle set shutdown` 正常
  - pty 疑似デバイスを後から出現させると自動で configure → activate、`/drive_motor_status` 配信開始（通電済み起動なら約 1 秒で active）
  - 手動 `deactivate` 後、3 秒経過しても自動再 activate されない
- [ ] **Raspberry Pi 5 実機検証（authoritative）**: モータ未通電 systemd 起動 → 通電後の自動復帰、通電済み通常起動のタイミング、`/target_twist` での走行、手動 deactivate でのモータ停止

## フォローアップ候補

- 稼働中障害（ACTIVE 中のシリアル断・書き込み失敗など）からの自動復帰（shot の `triggerAutoRecovery` / `runtime_fault_` 相当）は本 PR のスコープ外。drive の fault_code（通信は生きているがモータがハードウェア異常を報告）は再接続で解消しないため、既存の fault-stop（#111）の挙動を維持しています。必要なら別 issue で検討

## 関連

- #85（本対応）
- PR #79（shot_component の同パターン。本 PR は #79 とコード上の依存なし・独立してマージ可能。両方マージ時に package.xml で軽微なコンフリクトの可能性あり）
- #111（ウォッチドッグ。無変更で共存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)