### PR TITLE
fix: harden shot lifecycle and e-stop recovery for PR #79

### DIFF
--- a/motor_control_app/config/shot_config.dualshock.yaml
+++ b/motor_control_app/config/shot_config.dualshock.yaml
@@ -17,6 +17,7 @@ shot_component:
     # connect_retry_period_sec の周期リトライにフォールバックする。
     # "" で連動無効（周期リトライのみ）。
     controllable_topic: "/gpio/controllable"
+    controllable_timeout_sec: 1.0  # <= 0 disables stale-signal fail-safe
 
     port: "/dev/servo"
     baudrate: 115200

--- a/motor_control_app/config/shot_config.uart.yaml
+++ b/motor_control_app/config/shot_config.uart.yaml
@@ -17,6 +17,7 @@ shot_component:
     # connect_retry_period_sec の周期リトライにフォールバックする。
     # "" で連動無効（周期リトライのみ）。
     controllable_topic: "/gpio/controllable"
+    controllable_timeout_sec: 1.0  # <= 0 disables stale-signal fail-safe
 
     port: "/dev/servo"
     baudrate: 115200

--- a/motor_control_app/config/shot_config.yaml
+++ b/motor_control_app/config/shot_config.yaml
@@ -18,6 +18,7 @@ shot_component:
     # connect_retry_period_sec の周期リトライにフォールバックする。
     # "" で連動無効（周期リトライのみ）。
     controllable_topic: "/gpio/controllable"
+    controllable_timeout_sec: 1.0  # <= 0 disables stale-signal fail-safe
 
     port: "/dev/servo"
     baudrate: 115200

--- a/motor_control_app/include/motor_control_app/shot_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/shot_auto_start.hpp
@@ -15,7 +15,13 @@ namespace motor_control_app::shot_auto_start {
 // auto_start タイマー / 非常停止解除エッジが取るべきアクション
 enum class AutoStartAction { kConfigure, kActivate, kWaitEstopRelease, kStopTimer, kNone };
 
-enum class SafetyTeardownAction { kResetRetry, kRearmActive, kStopTimers, kNone };
+enum class SafetyTeardownAction {
+  kResetRetry,
+  kRetryDeactivate,
+  kRetryCleanup,
+  kStopTimers,
+  kNone
+};
 
 struct ControllableTimeoutDecision {
   bool latch_timeout;
@@ -67,12 +73,25 @@ inline SafetyTeardownAction decideSafetyTeardownAction(uint8_t state_id) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
       return SafetyTeardownAction::kResetRetry;
     case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
-      return SafetyTeardownAction::kRearmActive;
+      return SafetyTeardownAction::kRetryDeactivate;
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
+      return SafetyTeardownAction::kRetryCleanup;
     case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
       return SafetyTeardownAction::kStopTimers;
     default:
       return SafetyTeardownAction::kNone;
   }
+}
+
+// A canceled auto-start timer in a manually reached stable pre-active state is an operator hold.
+// Safety teardown still takes precedence while ACTIVE, even though normal activation cancels the
+// timer.
+inline bool shouldHoldManualLifecycle(uint8_t state_id, bool auto_start_timer_canceled) {
+  if (!auto_start_timer_canceled) {
+    return false;
+  }
+  return state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
+         state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED;
 }
 
 // /gpio/controllable 未受信時は publisher のない環境との互換性のため timeout にしない。

--- a/motor_control_app/include/motor_control_app/shot_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/shot_auto_start.hpp
@@ -22,7 +22,8 @@ enum class AutoStartAction { kConfigure, kActivate, kWaitEstopRelease, kStopTime
 // unconfigured -> kConfigure（接続を試行。非常停止中は kWaitEstopRelease で保留）
 // inactive     -> kActivate（運用状態へ遷移。非常停止中は kWaitEstopRelease で保留）
 // active       -> kStopTimer（正常稼働中。手動 deactivate/cleanup を尊重して停止）
-// それ以外（finalized・遷移中など）-> kNone（何もしない）
+// finalized    -> kStopTimer（以後の自動遷移を停止）
+// 遷移中・unknown -> kNone（何もしない）
 inline AutoStartAction decideAutoStartAction(uint8_t state_id, bool have_controllable,
                                              bool controllable) {
   const bool estop_active = have_controllable && !controllable;
@@ -32,10 +33,32 @@ inline AutoStartAction decideAutoStartAction(uint8_t state_id, bool have_control
     case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
       return estop_active ? AutoStartAction::kWaitEstopRelease : AutoStartAction::kActivate;
     case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
       return AutoStartAction::kStopTimer;
     default:
       return AutoStartAction::kNone;
   }
+}
+
+inline bool isTransitionState(uint8_t state_id) {
+  switch (state_id) {
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// /gpio/controllable 未受信時は publisher のない環境との互換性のため timeout にしない。
+// 一度受信後は、最後に true だった信号だけを fail-safe teardown の対象にする。
+inline bool shouldFailSafeControllableTimeout(double timeout_sec, bool have_controllable,
+                                              bool controllable, double elapsed_sec) {
+  return timeout_sec > 0.0 && have_controllable && controllable && elapsed_sec > timeout_sec;
 }
 
 }  // namespace motor_control_app::shot_auto_start

--- a/motor_control_app/include/motor_control_app/shot_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/shot_auto_start.hpp
@@ -6,6 +6,7 @@
 #ifndef MOTOR_CONTROL_APP__SHOT_AUTO_START_HPP_
 #define MOTOR_CONTROL_APP__SHOT_AUTO_START_HPP_
 
+#include <cmath>
 #include <cstdint>
 #include <lifecycle_msgs/msg/state.hpp>
 
@@ -13,6 +14,13 @@ namespace motor_control_app::shot_auto_start {
 
 // auto_start タイマー / 非常停止解除エッジが取るべきアクション
 enum class AutoStartAction { kConfigure, kActivate, kWaitEstopRelease, kStopTimer, kNone };
+
+enum class SafetyTeardownAction { kResetRetry, kRearmActive, kStopTimers, kNone };
+
+struct ControllableTimeoutDecision {
+  bool latch_timeout;
+  bool fail_safe;
+};
 
 // 現在の lifecycle 状態と /gpio/controllable の受信状況から自動起動アクションを決定する。
 // have_controllable: /gpio/controllable を1回でも受信したか。未受信の環境
@@ -54,11 +62,40 @@ inline bool isTransitionState(uint8_t state_id) {
   }
 }
 
+inline SafetyTeardownAction decideSafetyTeardownAction(uint8_t state_id) {
+  switch (state_id) {
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
+      return SafetyTeardownAction::kResetRetry;
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
+      return SafetyTeardownAction::kRearmActive;
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
+      return SafetyTeardownAction::kStopTimers;
+    default:
+      return SafetyTeardownAction::kNone;
+  }
+}
+
 // /gpio/controllable 未受信時は publisher のない環境との互換性のため timeout にしない。
 // 一度受信後は、最後に true だった信号だけを fail-safe teardown の対象にする。
-inline bool shouldFailSafeControllableTimeout(double timeout_sec, bool have_controllable,
-                                              bool controllable, double elapsed_sec) {
-  return timeout_sec > 0.0 && have_controllable && controllable && elapsed_sec > timeout_sec;
+inline ControllableTimeoutDecision decideControllableTimeout(double timeout_sec,
+                                                             bool have_controllable,
+                                                             bool controllable,
+                                                             double elapsed_sec) {
+  const bool stale_true_signal = std::isfinite(timeout_sec) && timeout_sec > 0.0 &&
+                                 have_controllable && controllable && elapsed_sec > timeout_sec;
+  return {stale_true_signal, stale_true_signal};
+}
+
+inline bool shouldLogControllableRecovery(bool timeout_latched) { return timeout_latched; }
+
+inline bool isValidPositivePeriod(double value) { return std::isfinite(value) && value > 0.0; }
+
+inline double normalizePositivePeriod(double value, double fallback) {
+  return isValidPositivePeriod(value) ? value : fallback;
+}
+
+inline double normalizeControllableTimeout(double value, double fallback) {
+  return std::isfinite(value) ? value : fallback;
 }
 
 }  // namespace motor_control_app::shot_auto_start

--- a/motor_control_app/include/motor_control_app/shot_component.hpp
+++ b/motor_control_app/include/motor_control_app/shot_component.hpp
@@ -95,6 +95,9 @@ private:
   // ACTIVE 中に検出したサーボ通信故障のフラグ。autoStartTimerCallback が拾って
   // deactivate→cleanup→再接続の自動復帰を行う。
   std::atomic<bool> runtime_fault_;
+  // 非常停止や通信故障によるdeactivate/cleanupが完了していない状態。
+  // ACTIVEではdeactivate、INACTIVEではcleanupをtimerから再試行する。
+  std::atomic<bool> teardown_pending_;
 
   bool is_shooting_;
   bool last_button_state_;
@@ -109,7 +112,8 @@ private:
   // All callbacks intentionally use the node's default MutuallyExclusive callback group:
   // auto-start, controllable input/timeout, joy input, and the future fire timer added by PR #117.
   // If these entities are split across callback groups, synchronize lifecycle/controllable state,
-  // timer pointers, runtime_fault_, is_shooting_, servo_controller_, and servo serial I/O.
+  // timer pointers, runtime_fault_, teardown_pending_, is_shooting_, servo_controller_, and servo
+  // serial I/O.
   // lifecycle 状態に依存せず常時生かす（unconfigured でも非常停止解除を検知するため）
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr controllable_sub_;
   rclcpp::TimerBase::SharedPtr auto_start_timer_;

--- a/motor_control_app/include/motor_control_app/shot_component.hpp
+++ b/motor_control_app/include/motor_control_app/shot_component.hpp
@@ -52,7 +52,10 @@ private:
   void executeShotSequence();
   void autoStartTimerCallback();
   void controllableCallback(const std_msgs::msg::Bool::SharedPtr msg);
+  void controllableTimeoutCallback();
   void tryAutoStart();
+  void transitionToUnconfiguredForAutoRecovery(const char* reason, bool retry_active_failure);
+  void stopAutoStartTimers();
   void triggerAutoRecovery();
   void disconnectServo();
 
@@ -79,12 +82,15 @@ private:
   int command_rate_limit_ms_;
   bool auto_start_;
   double connect_retry_period_sec_;
+  double controllable_timeout_sec_;
   // 非常停止連動トピック（空文字で連動無効、周期リトライのみ）
   std::string controllable_topic_;
   // /gpio/controllable の受信状況。未受信（have_controllable_=false）なら
   // 非常停止状態が分からないため周期リトライにフォールバックする。
   bool have_controllable_;
   bool controllable_;
+  bool controllable_timed_out_;
+  std::chrono::steady_clock::time_point last_controllable_time_;
   // ACTIVE 中に検出したサーボ通信故障のフラグ。autoStartTimerCallback が拾って
   // deactivate→cleanup→再接続の自動復帰を行う。
   std::atomic<bool> runtime_fault_;
@@ -99,9 +105,14 @@ private:
   rclcpp::Time last_command_time_;
 
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
+  // All callbacks intentionally use the node's default MutuallyExclusive callback group:
+  // auto-start, controllable input/timeout, joy input, and the future fire timer added by PR #117.
+  // If these entities are split across callback groups, synchronize lifecycle/controllable state,
+  // timer pointers, runtime_fault_, is_shooting_, servo_controller_, and servo serial I/O.
   // lifecycle 状態に依存せず常時生かす（unconfigured でも非常停止解除を検知するため）
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr controllable_sub_;
   rclcpp::TimerBase::SharedPtr auto_start_timer_;
+  rclcpp::TimerBase::SharedPtr controllable_timeout_timer_;
 };
 
 }  // namespace motor_control_app

--- a/motor_control_app/include/motor_control_app/shot_component.hpp
+++ b/motor_control_app/include/motor_control_app/shot_component.hpp
@@ -54,7 +54,8 @@ private:
   void controllableCallback(const std_msgs::msg::Bool::SharedPtr msg);
   void controllableTimeoutCallback();
   void tryAutoStart();
-  void transitionToUnconfiguredForAutoRecovery(const char* reason, bool retry_active_failure);
+  void transitionToUnconfiguredForAutoRecovery(const char* reason) noexcept;
+  void handleSafetyTeardownState(const char* reason, uint8_t state_id) noexcept;
   void stopAutoStartTimers();
   void triggerAutoRecovery();
   void disconnectServo();

--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <exception>
 #include <functional>
 #include <lifecycle_msgs/msg/state.hpp>
@@ -78,9 +79,23 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
   this->declare_parameter("controllable_timeout_sec", 1.0);
 
   auto_start_ = this->get_parameter("auto_start").as_bool();
-  connect_retry_period_sec_ = this->get_parameter("connect_retry_period_sec").as_double();
+  const double requested_retry_period = this->get_parameter("connect_retry_period_sec").as_double();
+  connect_retry_period_sec_ = shot_auto_start::normalizePositivePeriod(requested_retry_period, 3.0);
+  if (!shot_auto_start::isValidPositivePeriod(requested_retry_period)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Invalid connect_retry_period_sec=%g; using the default 3.0 seconds",
+                requested_retry_period);
+  }
   controllable_topic_ = this->get_parameter("controllable_topic").as_string();
-  controllable_timeout_sec_ = this->get_parameter("controllable_timeout_sec").as_double();
+  const double requested_controllable_timeout =
+      this->get_parameter("controllable_timeout_sec").as_double();
+  controllable_timeout_sec_ =
+      shot_auto_start::normalizeControllableTimeout(requested_controllable_timeout, 1.0);
+  if (!std::isfinite(requested_controllable_timeout)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Invalid controllable_timeout_sec=%g; using the default 1.0 seconds",
+                requested_controllable_timeout);
+  }
 
   if (auto_start_) {
     const auto period = std::chrono::duration<double>(std::max(0.5, connect_retry_period_sec_));
@@ -125,7 +140,7 @@ void ShotComponent::autoStartTimerCallback() {
         runtime_fault_.exchange(false)) {
       RCLCPP_WARN(this->get_logger(),
                   "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
-      transitionToUnconfiguredForAutoRecovery("runtime fault", true);
+      transitionToUnconfiguredForAutoRecovery("runtime fault");
       return;
     }
     tryAutoStart();
@@ -184,32 +199,69 @@ void ShotComponent::tryAutoStart() {
   }
 }
 
-void ShotComponent::transitionToUnconfiguredForAutoRecovery(const char* reason,
-                                                            bool retry_active_failure) {
+void ShotComponent::transitionToUnconfiguredForAutoRecovery(const char* reason) noexcept {
   if (!auto_start_timer_) {
     return;
   }
-  uint8_t state_id = this->get_current_state().id();
-  if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-    state_id = this->deactivate().id();
-  }
-  if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
-    state_id = this->cleanup().id();
-  }
-  if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
-    runtime_fault_ = false;
-    auto_start_timer_->reset();
-  } else if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-    if (retry_active_failure) {
-      runtime_fault_ = true;
-      auto_start_timer_->reset();
+  try {
+    uint8_t state_id = this->get_current_state().id();
+    if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+      state_id = this->deactivate().id();
     }
-    RCLCPP_WARN(this->get_logger(), "%s teardown left ShotComponent ACTIVE", reason);
-  } else if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED) {
-    stopAutoStartTimers();
-  } else if (!shot_auto_start::isTransitionState(state_id)) {
-    RCLCPP_WARN(this->get_logger(), "%s teardown ended in unexpected state: %u", reason,
-                static_cast<unsigned int>(state_id));
+    if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+      state_id = this->cleanup().id();
+    }
+    handleSafetyTeardownState(reason, state_id);
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR(this->get_logger(), "%s teardown transition failed: %s", reason, error.what());
+    uint8_t state_id = lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
+    try {
+      state_id = this->get_current_state().id();
+    } catch (...) {
+      RCLCPP_ERROR(this->get_logger(), "%s teardown state inspection failed", reason);
+    }
+    handleSafetyTeardownState(reason, state_id);
+  } catch (...) {
+    RCLCPP_ERROR(this->get_logger(), "%s teardown transition failed with unknown exception",
+                 reason);
+    uint8_t state_id = lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
+    try {
+      state_id = this->get_current_state().id();
+    } catch (...) {
+      RCLCPP_ERROR(this->get_logger(), "%s teardown state inspection failed", reason);
+    }
+    handleSafetyTeardownState(reason, state_id);
+  }
+}
+
+void ShotComponent::handleSafetyTeardownState(const char* reason, uint8_t state_id) noexcept {
+  using shot_auto_start::SafetyTeardownAction;
+  try {
+    switch (shot_auto_start::decideSafetyTeardownAction(state_id)) {
+      case SafetyTeardownAction::kResetRetry:
+        runtime_fault_ = false;
+        auto_start_timer_->reset();
+        return;
+      case SafetyTeardownAction::kRearmActive:
+        runtime_fault_ = true;
+        auto_start_timer_->reset();
+        RCLCPP_WARN(this->get_logger(), "%s teardown left ShotComponent ACTIVE; retry armed",
+                    reason);
+        return;
+      case SafetyTeardownAction::kStopTimers:
+        stopAutoStartTimers();
+        return;
+      case SafetyTeardownAction::kNone:
+        if (!shot_auto_start::isTransitionState(state_id)) {
+          RCLCPP_WARN(this->get_logger(), "%s teardown ended in unexpected state: %u", reason,
+                      static_cast<unsigned int>(state_id));
+        }
+        return;
+    }
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR(this->get_logger(), "%s teardown follow-up failed: %s", reason, error.what());
+  } catch (...) {
+    RCLCPP_ERROR(this->get_logger(), "%s teardown follow-up failed with unknown exception", reason);
   }
 }
 
@@ -228,7 +280,7 @@ void ShotComponent::controllableCallback(const std_msgs::msg::Bool::SharedPtr ms
   }
   const bool first = !have_controllable_;
   const bool prev = controllable_;
-  const bool recovered = controllable_timed_out_;
+  const bool recovered = shot_auto_start::shouldLogControllableRecovery(controllable_timed_out_);
   have_controllable_ = true;
   controllable_ = msg->data;
   controllable_timed_out_ = false;
@@ -249,25 +301,13 @@ void ShotComponent::controllableCallback(const std_msgs::msg::Bool::SharedPtr ms
       RCLCPP_WARN(this->get_logger(),
                   "非常停止押下を検出（%s=false）。deactivate→cleanup してサーボ接続を解放します",
                   controllable_topic_.c_str());
-      try {
-        transitionToUnconfiguredForAutoRecovery("controllable=false", false);
-      } catch (const std::exception& error) {
-        RCLCPP_ERROR(this->get_logger(), "E-stop teardown failed: %s", error.what());
-      } catch (...) {
-        RCLCPP_ERROR(this->get_logger(), "E-stop teardown failed with unknown exception");
-      }
+      transitionToUnconfiguredForAutoRecovery("controllable=false");
     } else if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
                auto_start_timer_ && !auto_start_timer_->is_canceled()) {
       RCLCPP_WARN(this->get_logger(),
                   "非常停止押下を検出（%s=false）。cleanup してサーボ接続を解放します",
                   controllable_topic_.c_str());
-      try {
-        transitionToUnconfiguredForAutoRecovery("controllable=false", false);
-      } catch (const std::exception& error) {
-        RCLCPP_ERROR(this->get_logger(), "E-stop cleanup failed: %s", error.what());
-      } catch (...) {
-        RCLCPP_ERROR(this->get_logger(), "E-stop cleanup failed with unknown exception");
-      }
+      transitionToUnconfiguredForAutoRecovery("controllable=false");
     }
     return;
   }
@@ -300,15 +340,12 @@ void ShotComponent::controllableTimeoutCallback() {
   const double elapsed =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - last_controllable_time_)
           .count();
-  const bool fail_safe = shot_auto_start::shouldFailSafeControllableTimeout(
+  const auto decision = shot_auto_start::decideControllableTimeout(
       controllable_timeout_sec_, have_controllable_, controllable_, elapsed);
-  if (elapsed <= controllable_timeout_sec_) {
+  if (!decision.fail_safe) {
     return;
   }
-  controllable_timed_out_ = true;
-  if (!fail_safe) {
-    return;
-  }
+  controllable_timed_out_ = decision.latch_timeout;
   controllable_ = false;
   // ACTIVEでは通常運転到達時にtimerがcancel済みでもfail-safe teardownする。
   // INACTIVEかつcancel済みはmanual deactivateなのでcleanup/retryで覆さない。
@@ -318,13 +355,7 @@ void ShotComponent::controllableTimeoutCallback() {
   }
   RCLCPP_WARN(this->get_logger(), "%s reception timed out after %.2fs; applying fail-safe teardown",
               controllable_topic_.c_str(), elapsed);
-  try {
-    transitionToUnconfiguredForAutoRecovery("controllable timeout", false);
-  } catch (const std::exception& error) {
-    RCLCPP_ERROR(this->get_logger(), "Controllable timeout teardown failed: %s", error.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->get_logger(), "Controllable timeout teardown failed with unknown exception");
-  }
+  transitionToUnconfiguredForAutoRecovery("controllable timeout");
 }
 
 ShotComponent::CallbackReturn ShotComponent::on_configure(const rclcpp_lifecycle::State&) {

--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <functional>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <string>
@@ -34,9 +35,11 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
       command_rate_limit_ms_(50),
       auto_start_(true),
       connect_retry_period_sec_(3.0),
+      controllable_timeout_sec_(1.0),
       controllable_topic_("/gpio/controllable"),
       have_controllable_(false),
       controllable_(false),
+      controllable_timed_out_(false),
       runtime_fault_(false),
       is_shooting_(false),
       last_button_state_(false),
@@ -72,10 +75,12 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
   this->declare_parameter("connect_retry_period_sec", 3.0);
   // 非常停止連動トピック（auto_start=true のときのみ有効、空文字で連動無効）
   this->declare_parameter("controllable_topic", "/gpio/controllable");
+  this->declare_parameter("controllable_timeout_sec", 1.0);
 
   auto_start_ = this->get_parameter("auto_start").as_bool();
   connect_retry_period_sec_ = this->get_parameter("connect_retry_period_sec").as_double();
   controllable_topic_ = this->get_parameter("controllable_topic").as_string();
+  controllable_timeout_sec_ = this->get_parameter("controllable_timeout_sec").as_double();
 
   if (auto_start_) {
     const auto period = std::chrono::duration<double>(std::max(0.5, connect_retry_period_sec_));
@@ -86,6 +91,11 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
       controllable_sub_ = this->create_subscription<std_msgs::msg::Bool>(
           controllable_topic_, 1,
           std::bind(&ShotComponent::controllableCallback, this, std::placeholders::_1));
+      if (controllable_timeout_sec_ > 0.0) {
+        controllable_timeout_timer_ =
+            this->create_wall_timer(std::chrono::milliseconds(100),
+                                    std::bind(&ShotComponent::controllableTimeoutCallback, this));
+      }
     }
     RCLCPP_INFO(this->get_logger(),
                 "Shot component created (auto_start=true, retry=%.1fs, estop_topic=%s). "
@@ -100,65 +110,132 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
 }
 
 ShotComponent::~ShotComponent() {
-  if (auto_start_timer_) {
-    auto_start_timer_->cancel();
+  stopAutoStartTimers();
+  try {
+    disconnectServo();
+  } catch (...) {
+    // Destructors must not propagate hardware cleanup failures.
   }
-  disconnectServo();
 }
 
 void ShotComponent::autoStartTimerCallback() {
-  if (this->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
-      runtime_fault_.exchange(false)) {
-    // ACTIVE 中に検出したサーボ通信故障からの自動復帰。一旦 deactivate→cleanup
-    // で解体し、次周期以降の configure→activate で接続とサーボ応答を確認し直す。
-    RCLCPP_WARN(this->get_logger(),
-                "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
-    this->deactivate();
-    this->cleanup();
-    // on_deactivate がタイマーを止めるため、自動復帰経路のみここで再開する
-    auto_start_timer_->reset();
-    return;
+  try {
+    const uint8_t state_id = this->get_current_state().id();
+    if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
+        runtime_fault_.exchange(false)) {
+      RCLCPP_WARN(this->get_logger(),
+                  "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
+      transitionToUnconfiguredForAutoRecovery("runtime fault", true);
+      return;
+    }
+    tryAutoStart();
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR(this->get_logger(), "Shot auto-start callback failed: %s", error.what());
+  } catch (...) {
+    RCLCPP_ERROR(this->get_logger(), "Shot auto-start callback failed with unknown exception");
   }
-  tryAutoStart();
 }
 
 void ShotComponent::tryAutoStart() {
   using shot_auto_start::AutoStartAction;
   using shot_auto_start::decideAutoStartAction;
 
-  auto action =
-      decideAutoStartAction(this->get_current_state().id(), have_controllable_, controllable_);
+  if (!auto_start_timer_) {
+    return;
+  }
+  uint8_t state_id = this->get_current_state().id();
+  auto action = decideAutoStartAction(state_id, have_controllable_, controllable_);
   if (action == AutoStartAction::kWaitEstopRelease) {
     RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
                          "非常停止中のため接続試行を保留しています（解除で自動再開します）");
     return;
   }
   if (action == AutoStartAction::kStopTimer) {
-    // 正常稼働中はタイマーを止め、手動 deactivate/cleanup を尊重する。
-    if (auto_start_timer_) {
-      auto_start_timer_->cancel();
+    auto_start_timer_->cancel();
+    return;
+  }
+  if (action == AutoStartAction::kNone) {
+    if (!shot_auto_start::isTransitionState(state_id)) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                           "Unexpected lifecycle state during shot auto-start: %u",
+                           static_cast<unsigned int>(state_id));
     }
     return;
   }
   if (action == AutoStartAction::kConfigure) {
     RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
                          "サーボ接続を試行します（非常停止中は失敗し、解除後に自動復帰します）");
-    this->configure();
+    state_id = this->configure().id();
     // 接続に成功したら同一周期内で activate まで進める（非常停止解除エッジからの
     // 即時起動と、タイマー経路の起動を同じ動きにする）
-    action =
-        decideAutoStartAction(this->get_current_state().id(), have_controllable_, controllable_);
+    action = decideAutoStartAction(state_id, have_controllable_, controllable_);
   }
   if (action == AutoStartAction::kActivate) {
-    this->activate();
+    state_id = this->activate().id();
+    action = decideAutoStartAction(state_id, have_controllable_, controllable_);
+  }
+  if (action == AutoStartAction::kStopTimer) {
+    auto_start_timer_->cancel();
+  } else if (action == AutoStartAction::kNone && !shot_auto_start::isTransitionState(state_id) &&
+             state_id != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                         "Shot auto-start transition ended in unexpected state: %u",
+                         static_cast<unsigned int>(state_id));
+  }
+}
+
+void ShotComponent::transitionToUnconfiguredForAutoRecovery(const char* reason,
+                                                            bool retry_active_failure) {
+  if (!auto_start_timer_) {
+    return;
+  }
+  uint8_t state_id = this->get_current_state().id();
+  if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    state_id = this->deactivate().id();
+  }
+  if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+    state_id = this->cleanup().id();
+  }
+  if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+    runtime_fault_ = false;
+    auto_start_timer_->reset();
+  } else if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    if (retry_active_failure) {
+      runtime_fault_ = true;
+      auto_start_timer_->reset();
+    }
+    RCLCPP_WARN(this->get_logger(), "%s teardown left ShotComponent ACTIVE", reason);
+  } else if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED) {
+    stopAutoStartTimers();
+  } else if (!shot_auto_start::isTransitionState(state_id)) {
+    RCLCPP_WARN(this->get_logger(), "%s teardown ended in unexpected state: %u", reason,
+                static_cast<unsigned int>(state_id));
+  }
+}
+
+void ShotComponent::stopAutoStartTimers() {
+  if (auto_start_timer_) {
+    auto_start_timer_->cancel();
+  }
+  if (controllable_timeout_timer_) {
+    controllable_timeout_timer_->cancel();
   }
 }
 
 void ShotComponent::controllableCallback(const std_msgs::msg::Bool::SharedPtr msg) {
+  if (!msg) {
+    return;
+  }
   const bool first = !have_controllable_;
   const bool prev = controllable_;
+  const bool recovered = controllable_timed_out_;
   have_controllable_ = true;
   controllable_ = msg->data;
+  controllable_timed_out_ = false;
+  last_controllable_time_ = std::chrono::steady_clock::now();
+  if (recovered) {
+    RCLCPP_INFO(this->get_logger(), "%s reception recovered", controllable_topic_.c_str());
+  }
   if (!first && controllable_ == prev) {
     return;  // 値に変化なし（~20Hz で配信されるため、エッジのみ処理する）
   }
@@ -172,17 +249,25 @@ void ShotComponent::controllableCallback(const std_msgs::msg::Bool::SharedPtr ms
       RCLCPP_WARN(this->get_logger(),
                   "非常停止押下を検出（%s=false）。deactivate→cleanup してサーボ接続を解放します",
                   controllable_topic_.c_str());
-      this->deactivate();
-      this->cleanup();
-      runtime_fault_ = false;
-      // on_deactivate がタイマーを止めるため、解除待ちのためここで再開する
-      auto_start_timer_->reset();
+      try {
+        transitionToUnconfiguredForAutoRecovery("controllable=false", false);
+      } catch (const std::exception& error) {
+        RCLCPP_ERROR(this->get_logger(), "E-stop teardown failed: %s", error.what());
+      } catch (...) {
+        RCLCPP_ERROR(this->get_logger(), "E-stop teardown failed with unknown exception");
+      }
     } else if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
                auto_start_timer_ && !auto_start_timer_->is_canceled()) {
       RCLCPP_WARN(this->get_logger(),
                   "非常停止押下を検出（%s=false）。cleanup してサーボ接続を解放します",
                   controllable_topic_.c_str());
-      this->cleanup();
+      try {
+        transitionToUnconfiguredForAutoRecovery("controllable=false", false);
+      } catch (const std::exception& error) {
+        RCLCPP_ERROR(this->get_logger(), "E-stop cleanup failed: %s", error.what());
+      } catch (...) {
+        RCLCPP_ERROR(this->get_logger(), "E-stop cleanup failed with unknown exception");
+      }
     }
     return;
   }
@@ -199,7 +284,41 @@ void ShotComponent::controllableCallback(const std_msgs::msg::Bool::SharedPtr ms
   // 周期を仕切り直してから即時試行する。失敗時（サーボ起動中など）は
   // connect_retry_period_sec 周期のリトライに引き継ぐ。
   auto_start_timer_->reset();
-  tryAutoStart();
+  try {
+    tryAutoStart();
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR(this->get_logger(), "E-stop release auto-start failed: %s", error.what());
+  } catch (...) {
+    RCLCPP_ERROR(this->get_logger(), "E-stop release auto-start failed with unknown exception");
+  }
+}
+
+void ShotComponent::controllableTimeoutCallback() {
+  if (controllable_timed_out_ || controllable_timeout_sec_ <= 0.0 || !have_controllable_) {
+    return;
+  }
+  const double elapsed =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - last_controllable_time_)
+          .count();
+  const bool fail_safe = shot_auto_start::shouldFailSafeControllableTimeout(
+      controllable_timeout_sec_, have_controllable_, controllable_, elapsed);
+  if (elapsed <= controllable_timeout_sec_) {
+    return;
+  }
+  controllable_timed_out_ = true;
+  if (!fail_safe) {
+    return;
+  }
+  controllable_ = false;
+  RCLCPP_WARN(this->get_logger(), "%s reception timed out after %.2fs; applying fail-safe teardown",
+              controllable_topic_.c_str(), elapsed);
+  try {
+    transitionToUnconfiguredForAutoRecovery("controllable timeout", false);
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR(this->get_logger(), "Controllable timeout teardown failed: %s", error.what());
+  } catch (...) {
+    RCLCPP_ERROR(this->get_logger(), "Controllable timeout teardown failed with unknown exception");
+  }
 }
 
 ShotComponent::CallbackReturn ShotComponent::on_configure(const rclcpp_lifecycle::State&) {
@@ -315,6 +434,8 @@ ShotComponent::CallbackReturn ShotComponent::on_cleanup(const rclcpp_lifecycle::
 }
 
 ShotComponent::CallbackReturn ShotComponent::on_shutdown(const rclcpp_lifecycle::State&) {
+  stopAutoStartTimers();
+  controllable_sub_.reset();
   joy_subscription_.reset();
   disconnectServo();
   RCLCPP_INFO(this->get_logger(), "Shot component shut down");

--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -42,6 +42,7 @@ ShotComponent::ShotComponent(const rclcpp::NodeOptions& options)
       controllable_(false),
       controllable_timed_out_(false),
       runtime_fault_(false),
+      teardown_pending_(false),
       is_shooting_(false),
       last_button_state_(false),
       last_tilt_value_(0.0F),
@@ -136,12 +137,28 @@ ShotComponent::~ShotComponent() {
 void ShotComponent::autoStartTimerCallback() {
   try {
     const uint8_t state_id = this->get_current_state().id();
-    if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
-        runtime_fault_.exchange(false)) {
-      RCLCPP_WARN(this->get_logger(),
-                  "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
-      transitionToUnconfiguredForAutoRecovery("runtime fault");
+    const bool runtime_fault = runtime_fault_.load();
+    const bool teardown_pending = teardown_pending_.load();
+    if ((runtime_fault || teardown_pending) &&
+        (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE ||
+         state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)) {
+      if (runtime_fault) {
+        RCLCPP_WARN(this->get_logger(),
+                    "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
+      } else {
+        RCLCPP_WARN(this->get_logger(),
+                    "未完了の安全teardownを検出。deactivate/cleanupを再試行します");
+      }
+      transitionToUnconfiguredForAutoRecovery(runtime_fault ? "runtime fault"
+                                                            : "pending safety teardown");
       return;
+    }
+    if (teardown_pending && (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED ||
+                             state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)) {
+      handleSafetyTeardownState("pending safety teardown", state_id);
+      if (state_id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED) {
+        return;
+      }
     }
     tryAutoStart();
   } catch (const std::exception& error) {
@@ -240,15 +257,24 @@ void ShotComponent::handleSafetyTeardownState(const char* reason, uint8_t state_
     switch (shot_auto_start::decideSafetyTeardownAction(state_id)) {
       case SafetyTeardownAction::kResetRetry:
         runtime_fault_ = false;
+        teardown_pending_ = false;
         auto_start_timer_->reset();
         return;
-      case SafetyTeardownAction::kRearmActive:
-        runtime_fault_ = true;
+      case SafetyTeardownAction::kRetryDeactivate:
+        teardown_pending_ = true;
         auto_start_timer_->reset();
-        RCLCPP_WARN(this->get_logger(), "%s teardown left ShotComponent ACTIVE; retry armed",
-                    reason);
+        RCLCPP_WARN(this->get_logger(),
+                    "%s teardown left ShotComponent ACTIVE; deactivate retry armed", reason);
+        return;
+      case SafetyTeardownAction::kRetryCleanup:
+        teardown_pending_ = true;
+        auto_start_timer_->reset();
+        RCLCPP_WARN(this->get_logger(),
+                    "%s teardown left ShotComponent INACTIVE; cleanup retry armed", reason);
         return;
       case SafetyTeardownAction::kStopTimers:
+        runtime_fault_ = false;
+        teardown_pending_ = false;
         stopAutoStartTimers();
         return;
       case SafetyTeardownAction::kNone:
@@ -348,9 +374,10 @@ void ShotComponent::controllableTimeoutCallback() {
   controllable_timed_out_ = decision.latch_timeout;
   controllable_ = false;
   // ACTIVEでは通常運転到達時にtimerがcancel済みでもfail-safe teardownする。
-  // INACTIVEかつcancel済みはmanual deactivateなのでcleanup/retryで覆さない。
-  if (this->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
-      (!auto_start_timer_ || auto_start_timer_->is_canceled())) {
+  // INACTIVE/UNCONFIGUREDかつcancel済みはmanual lifecycle操作として尊重する。
+  const uint8_t state_id = this->get_current_state().id();
+  const bool timer_canceled = !auto_start_timer_ || auto_start_timer_->is_canceled();
+  if (shot_auto_start::shouldHoldManualLifecycle(state_id, timer_canceled)) {
     return;
   }
   RCLCPP_WARN(this->get_logger(), "%s reception timed out after %.2fs; applying fail-safe teardown",
@@ -456,6 +483,7 @@ ShotComponent::CallbackReturn ShotComponent::on_deactivate(const rclcpp_lifecycl
   // タイマー発火までの間に手動 deactivate されても再 activate しないための処置で、
   // 自動復帰経路（autoStartTimerCallback）は cleanup 後にタイマーを明示的に再開する。
   runtime_fault_ = false;
+  teardown_pending_ = false;
   if (auto_start_timer_) {
     auto_start_timer_->cancel();
   }
@@ -464,6 +492,7 @@ ShotComponent::CallbackReturn ShotComponent::on_deactivate(const rclcpp_lifecycl
 }
 
 ShotComponent::CallbackReturn ShotComponent::on_cleanup(const rclcpp_lifecycle::State&) {
+  teardown_pending_ = false;
   joy_subscription_.reset();
   disconnectServo();
   RCLCPP_INFO(this->get_logger(), "Shot component cleaned up");
@@ -471,6 +500,8 @@ ShotComponent::CallbackReturn ShotComponent::on_cleanup(const rclcpp_lifecycle::
 }
 
 ShotComponent::CallbackReturn ShotComponent::on_shutdown(const rclcpp_lifecycle::State&) {
+  runtime_fault_ = false;
+  teardown_pending_ = false;
   stopAutoStartTimers();
   controllable_sub_.reset();
   joy_subscription_.reset();
@@ -485,6 +516,7 @@ ShotComponent::CallbackReturn ShotComponent::on_error(const rclcpp_lifecycle::St
   joy_subscription_.reset();
   disconnectServo();
   runtime_fault_ = false;
+  teardown_pending_ = false;
   if (auto_start_ && auto_start_timer_) {
     auto_start_timer_->reset();
   }

--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -111,7 +111,8 @@ void ShotComponent::autoStartTimerCallback() {
       runtime_fault_.exchange(false)) {
     // ACTIVE 中に検出したサーボ通信故障からの自動復帰。一旦 deactivate→cleanup
     // で解体し、次周期以降の configure→activate で接続とサーボ応答を確認し直す。
-    RCLCPP_WARN(this->get_logger(), "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
+    RCLCPP_WARN(this->get_logger(),
+                "サーボ通信故障を検出。deactivate→cleanup して再接続を試みます");
     this->deactivate();
     this->cleanup();
     // on_deactivate がタイマーを止めるため、自動復帰経路のみここで再開する
@@ -187,7 +188,7 @@ void ShotComponent::controllableCallback(const std_msgs::msg::Bool::SharedPtr ms
   }
 
   // 非常停止解除（または初回受信が解除状態）。タイマー停止中は手動運用
-  //（手動 deactivate 済み or 正常 ACTIVE）なので自動遷移しない。
+  // （手動 deactivate 済み or 正常 ACTIVE）なので自動遷移しない。
   if (!auto_start_timer_ || auto_start_timer_->is_canceled()) {
     return;
   }

--- a/motor_control_app/src/shot_component.cpp
+++ b/motor_control_app/src/shot_component.cpp
@@ -310,6 +310,12 @@ void ShotComponent::controllableTimeoutCallback() {
     return;
   }
   controllable_ = false;
+  // ACTIVEでは通常運転到達時にtimerがcancel済みでもfail-safe teardownする。
+  // INACTIVEかつcancel済みはmanual deactivateなのでcleanup/retryで覆さない。
+  if (this->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
+      (!auto_start_timer_ || auto_start_timer_->is_canceled())) {
+    return;
+  }
   RCLCPP_WARN(this->get_logger(), "%s reception timed out after %.2fs; applying fail-safe teardown",
               controllable_topic_.c_str(), elapsed);
   try {

--- a/motor_control_app/test/test_shot_auto_start.cpp
+++ b/motor_control_app/test/test_shot_auto_start.cpp
@@ -14,6 +14,7 @@ namespace {
 using lifecycle_msgs::msg::State;
 using motor_control_app::shot_auto_start::AutoStartAction;
 using motor_control_app::shot_auto_start::decideAutoStartAction;
+using motor_control_app::shot_auto_start::shouldFailSafeControllableTimeout;
 
 // /gpio/controllable 未受信（enable_gpio_ref=false 等）は周期リトライにフォールバック
 TEST(ShotAutoStart, UnconfiguredWithoutControllableFallsBackToConfigure) {
@@ -56,13 +57,39 @@ TEST(ShotAutoStart, ActiveStopsTimerRegardlessOfEstop) {
             AutoStartAction::kStopTimer);
 }
 
-TEST(ShotAutoStart, FinalizedAndTransitionStatesDoNothing) {
+TEST(ShotAutoStart, FinalizedStopsTimerAndTransitionStatesDoNothing) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_FINALIZED, true, true),
-            AutoStartAction::kNone);
+            AutoStartAction::kStopTimer);
   EXPECT_EQ(decideAutoStartAction(State::TRANSITION_STATE_CONFIGURING, true, true),
             AutoStartAction::kNone);
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNKNOWN, true, true),
             AutoStartAction::kNone);
+}
+
+TEST(ShotAutoStart, ConfigureFailureRetriesFromUnconfigured) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED, false, false),
+            AutoStartAction::kConfigure);
+}
+
+TEST(ShotControllableTimeout, DisabledNeverFailsSafe) {
+  EXPECT_FALSE(shouldFailSafeControllableTimeout(0.0, true, true, 10.0));
+  EXPECT_FALSE(shouldFailSafeControllableTimeout(-1.0, true, true, 10.0));
+}
+
+TEST(ShotControllableTimeout, TrueSignalTimesOutFailSafe) {
+  EXPECT_TRUE(shouldFailSafeControllableTimeout(1.0, true, true, 1.01));
+}
+
+TEST(ShotControllableTimeout, FalseSignalTimeoutIsNoOp) {
+  EXPECT_FALSE(shouldFailSafeControllableTimeout(1.0, true, false, 2.0));
+}
+
+TEST(ShotControllableTimeout, NeverReceivedPreservesFallback) {
+  EXPECT_FALSE(shouldFailSafeControllableTimeout(1.0, false, false, 100.0));
+}
+
+TEST(ShotControllableTimeout, FreshOrRecoveredSignalIsNotStale) {
+  EXPECT_FALSE(shouldFailSafeControllableTimeout(1.0, true, true, 0.1));
 }
 
 }  // namespace

--- a/motor_control_app/test/test_shot_auto_start.cpp
+++ b/motor_control_app/test/test_shot_auto_start.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <lifecycle_msgs/msg/state.hpp>
+#include <limits>
 
 #include "motor_control_app/shot_auto_start.hpp"
 
@@ -14,7 +15,12 @@ namespace {
 using lifecycle_msgs::msg::State;
 using motor_control_app::shot_auto_start::AutoStartAction;
 using motor_control_app::shot_auto_start::decideAutoStartAction;
-using motor_control_app::shot_auto_start::shouldFailSafeControllableTimeout;
+using motor_control_app::shot_auto_start::decideControllableTimeout;
+using motor_control_app::shot_auto_start::decideSafetyTeardownAction;
+using motor_control_app::shot_auto_start::normalizeControllableTimeout;
+using motor_control_app::shot_auto_start::normalizePositivePeriod;
+using motor_control_app::shot_auto_start::SafetyTeardownAction;
+using motor_control_app::shot_auto_start::shouldLogControllableRecovery;
 
 // /gpio/controllable 未受信（enable_gpio_ref=false 等）は周期リトライにフォールバック
 TEST(ShotAutoStart, UnconfiguredWithoutControllableFallsBackToConfigure) {
@@ -72,24 +78,54 @@ TEST(ShotAutoStart, ConfigureFailureRetriesFromUnconfigured) {
 }
 
 TEST(ShotControllableTimeout, DisabledNeverFailsSafe) {
-  EXPECT_FALSE(shouldFailSafeControllableTimeout(0.0, true, true, 10.0));
-  EXPECT_FALSE(shouldFailSafeControllableTimeout(-1.0, true, true, 10.0));
+  EXPECT_FALSE(decideControllableTimeout(0.0, true, true, 10.0).fail_safe);
+  EXPECT_FALSE(decideControllableTimeout(-1.0, true, true, 10.0).fail_safe);
 }
 
 TEST(ShotControllableTimeout, TrueSignalTimesOutFailSafe) {
-  EXPECT_TRUE(shouldFailSafeControllableTimeout(1.0, true, true, 1.01));
+  const auto decision = decideControllableTimeout(1.0, true, true, 1.01);
+  EXPECT_TRUE(decision.fail_safe);
+  EXPECT_TRUE(decision.latch_timeout);
 }
 
-TEST(ShotControllableTimeout, FalseSignalTimeoutIsNoOp) {
-  EXPECT_FALSE(shouldFailSafeControllableTimeout(1.0, true, false, 2.0));
+TEST(ShotControllableTimeout, FalseSignalTimeoutDoesNotLatch) {
+  const auto decision = decideControllableTimeout(1.0, true, false, 2.0);
+  EXPECT_FALSE(decision.fail_safe);
+  EXPECT_FALSE(decision.latch_timeout);
+  EXPECT_FALSE(shouldLogControllableRecovery(decision.latch_timeout));
 }
 
 TEST(ShotControllableTimeout, NeverReceivedPreservesFallback) {
-  EXPECT_FALSE(shouldFailSafeControllableTimeout(1.0, false, false, 100.0));
+  EXPECT_FALSE(decideControllableTimeout(1.0, false, false, 100.0).fail_safe);
 }
 
 TEST(ShotControllableTimeout, FreshOrRecoveredSignalIsNotStale) {
-  EXPECT_FALSE(shouldFailSafeControllableTimeout(1.0, true, true, 0.1));
+  EXPECT_FALSE(decideControllableTimeout(1.0, true, true, 0.1).fail_safe);
+}
+
+TEST(ShotSafetyTeardown, ActiveFailureRearmsRetry) {
+  EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_ACTIVE),
+            SafetyTeardownAction::kRearmActive);
+  EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_UNCONFIGURED),
+            SafetyTeardownAction::kResetRetry);
+  EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_FINALIZED),
+            SafetyTeardownAction::kStopTimers);
+}
+
+TEST(ShotParameters, InvalidRetryPeriodFallsBackToDefault) {
+  EXPECT_DOUBLE_EQ(normalizePositivePeriod(2.5, 3.0), 2.5);
+  EXPECT_DOUBLE_EQ(normalizePositivePeriod(0.0, 3.0), 3.0);
+  EXPECT_DOUBLE_EQ(normalizePositivePeriod(-1.0, 3.0), 3.0);
+  EXPECT_DOUBLE_EQ(normalizePositivePeriod(std::numeric_limits<double>::quiet_NaN(), 3.0), 3.0);
+  EXPECT_DOUBLE_EQ(normalizePositivePeriod(std::numeric_limits<double>::infinity(), 3.0), 3.0);
+}
+
+TEST(ShotParameters, NonFiniteControllableTimeoutFallsBackToDefault) {
+  EXPECT_DOUBLE_EQ(normalizeControllableTimeout(0.0, 1.0), 0.0);
+  EXPECT_DOUBLE_EQ(normalizeControllableTimeout(-1.0, 1.0), -1.0);
+  EXPECT_DOUBLE_EQ(normalizeControllableTimeout(std::numeric_limits<double>::quiet_NaN(), 1.0),
+                   1.0);
+  EXPECT_DOUBLE_EQ(normalizeControllableTimeout(std::numeric_limits<double>::infinity(), 1.0), 1.0);
 }
 
 }  // namespace

--- a/motor_control_app/test/test_shot_auto_start.cpp
+++ b/motor_control_app/test/test_shot_auto_start.cpp
@@ -20,6 +20,7 @@ using motor_control_app::shot_auto_start::decideSafetyTeardownAction;
 using motor_control_app::shot_auto_start::normalizeControllableTimeout;
 using motor_control_app::shot_auto_start::normalizePositivePeriod;
 using motor_control_app::shot_auto_start::SafetyTeardownAction;
+using motor_control_app::shot_auto_start::shouldHoldManualLifecycle;
 using motor_control_app::shot_auto_start::shouldLogControllableRecovery;
 
 // /gpio/controllable 未受信（enable_gpio_ref=false 等）は周期リトライにフォールバック
@@ -103,13 +104,22 @@ TEST(ShotControllableTimeout, FreshOrRecoveredSignalIsNotStale) {
   EXPECT_FALSE(decideControllableTimeout(1.0, true, true, 0.1).fail_safe);
 }
 
-TEST(ShotSafetyTeardown, ActiveFailureRearmsRetry) {
+TEST(ShotSafetyTeardown, StableStatesSelectSafeRetryAction) {
   EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_ACTIVE),
-            SafetyTeardownAction::kRearmActive);
+            SafetyTeardownAction::kRetryDeactivate);
+  EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_INACTIVE),
+            SafetyTeardownAction::kRetryCleanup);
   EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_UNCONFIGURED),
             SafetyTeardownAction::kResetRetry);
   EXPECT_EQ(decideSafetyTeardownAction(State::PRIMARY_STATE_FINALIZED),
             SafetyTeardownAction::kStopTimers);
+}
+
+TEST(ShotSafetyTeardown, CanceledTimerHoldsManualPreActiveStates) {
+  EXPECT_TRUE(shouldHoldManualLifecycle(State::PRIMARY_STATE_INACTIVE, true));
+  EXPECT_TRUE(shouldHoldManualLifecycle(State::PRIMARY_STATE_UNCONFIGURED, true));
+  EXPECT_FALSE(shouldHoldManualLifecycle(State::PRIMARY_STATE_ACTIVE, true));
+  EXPECT_FALSE(shouldHoldManualLifecycle(State::PRIMARY_STATE_UNCONFIGURED, false));
 }
 
 TEST(ShotParameters, InvalidRetryPeriodFallsBackToDefault) {


### PR DESCRIPTION
## 概要

PR #79のレビューで確認したLifecycle遷移と非常停止連動の課題に対するfix-up PRです。

PR #79で追加された`/gpio/controllable`連動という基本方針は維持しつつ、異常時に安全な状態へ収束することと、手動のLifecycle操作を自動制御が覆わないことを重視して補強しています。

このPRのbaseは`main`ではなく、PR #79のsource branchです。

Related: #79

## 主な変更

- `configure`、`activate`、`deactivate`、`cleanup`後のLifecycle stateを再確認
- Lifecycle transition例外をcallback外へ漏らさない処理
- ACTIVE残留時の`deactivate`再試行
- INACTIVE残留時の`cleanup`再試行
- `teardown_pending_`による未完了teardownの継続
- FINALIZEDおよびshutdown時のtimer停止
- `/gpio/controllable`受信途絶時のfail-safe teardown
- false状態の受信途絶では不要なtimeout latchを発生させない処理
- 手動deactivate／cleanup後のINACTIVE・UNCONFIGUREDを保持
- `connect_retry_period_sec`と`controllable_timeout_sec`の異常値処理
- clang-format不一致の修正

## 設計上の前提

対象callbackはnodeのdefault `MutuallyExclusive` callback groupを共有します。

現時点ではmutexを追加していません。将来callback groupを分割する場合は、Lifecycle state、timer、controllable state、runtime fault、teardown pending、servo controllerおよびserial I/Oの同期が必要です。

## 検証

- clean full build成功
- full testsで非xmllint failureなし
- Robot Manager unittest 10/10成功
- C++ format成功
- `git diff --check`成功
- undefined symbolなし
- combined構成でamd64／arm64 GitHub Actions成功

Combined Actions:

https://github.com/Yuichiroh-Kobayashi/questix/actions/runs/29636324215

## 未確認

- Raspberry Pi 5
- Feetech servo
- 実際の非常停止押下／解除
- `/gpio/controllable`通信断
- deactivate失敗時の周期retry
- cleanup失敗時の周期retry
- systemd運用
