### PR TITLE
fix: guard drive lifecycle transitions and timer parameters

### DIFF
--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -109,6 +109,10 @@ private:
   void resetCommandState();
 
   // ROS 2 通信
+  // Twist/status/watchdog/auto-start callbacks intentionally share the node's default
+  // MutuallyExclusive callback group, so callbacks do not run concurrently. If entities are
+  // split across callback groups, synchronize motor_initialized_, diff_drive_, command state,
+  // timer pointers, and all motor serial operations before enabling concurrent execution.
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr status_publisher_;
   rclcpp::TimerBase::SharedPtr status_timer_;

--- a/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
@@ -6,6 +6,7 @@
 #ifndef MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_
 #define MOTOR_CONTROL_APP__LIFECYCLE_AUTO_START_HPP_
 
+#include <cmath>
 #include <cstdint>
 #include <lifecycle_msgs/msg/state.hpp>
 
@@ -47,6 +48,14 @@ inline bool isTransitionState(uint8_t state_id) {
       return false;
   }
 }
+
+inline bool isValidPositiveValue(double value) { return std::isfinite(value) && value > 0.0; }
+
+inline double normalizeRetryPeriod(double value, double fallback) {
+  return isValidPositiveValue(value) ? value : fallback;
+}
+
+inline bool isValidStatusPublishRate(double value) { return isValidPositiveValue(value); }
 
 }  // namespace motor_control_app::lifecycle_auto_start
 

--- a/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstdint>
 #include <lifecycle_msgs/msg/state.hpp>
+#include <limits>
 
 namespace motor_control_app::lifecycle_auto_start {
 
@@ -55,7 +56,22 @@ inline double normalizeRetryPeriod(double value, double fallback) {
   return isValidPositiveValue(value) ? value : fallback;
 }
 
-inline bool isValidStatusPublishRate(double value) { return isValidPositiveValue(value); }
+inline int64_t statusTimerPeriodNanoseconds(double rate_hz) {
+  if (!isValidPositiveValue(rate_hz)) {
+    return 0;
+  }
+  constexpr long double kNanosecondsPerSecond = 1000000000.0L;
+  const long double period_ns = kNanosecondsPerSecond / static_cast<long double>(rate_hz);
+  if (!std::isfinite(period_ns) || period_ns < 1.0L ||
+      period_ns > static_cast<long double>(std::numeric_limits<int64_t>::max())) {
+    return 0;
+  }
+  return static_cast<int64_t>(period_ns);
+}
+
+inline bool isValidStatusPublishRate(double value) {
+  return statusTimerPeriodNanoseconds(value) > 0;
+}
 
 }  // namespace motor_control_app::lifecycle_auto_start
 

--- a/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
+++ b/motor_control_app/include/motor_control_app/lifecycle_auto_start.hpp
@@ -18,7 +18,8 @@ enum class AutoStartAction { kConfigure, kActivate, kStopTimer, kNone };
 // unconfigured -> kConfigure（接続を試行）
 // inactive     -> kActivate（運用状態へ遷移）
 // active       -> kStopTimer（正常稼働中。手動 deactivate/cleanup を尊重して停止）
-// それ以外（finalized・遷移中など）-> kNone（何もしない）
+// finalized    -> kStopTimer（終了後にタイマーを残さない）
+// transition/unknown -> kNone（何もしない）
 inline AutoStartAction decideAutoStartAction(uint8_t state_id) {
   switch (state_id) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
@@ -26,9 +27,24 @@ inline AutoStartAction decideAutoStartAction(uint8_t state_id) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
       return AutoStartAction::kActivate;
     case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
       return AutoStartAction::kStopTimer;
     default:
       return AutoStartAction::kNone;
+  }
+}
+
+inline bool isTransitionState(uint8_t state_id) {
+  switch (state_id) {
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING:
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING:
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -109,7 +109,8 @@ DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecyc
 
   if (!lifecycle_auto_start::isValidStatusPublishRate(status_publish_rate_)) {
     RCLCPP_ERROR(this->get_logger(),
-                 "Invalid status_publish_rate=%g; value must be finite and greater than zero",
+                 "Invalid status_publish_rate=%g; value must produce a positive, representable "
+                 "nanosecond timer period",
                  status_publish_rate_);
     return CallbackReturn::FAILURE;
   }
@@ -179,10 +180,10 @@ DriveComponent::CallbackReturn DriveComponent::on_activate(const rclcpp_lifecycl
   resetCommandState();
 
   // ステータスパブリッシュタイマー
-  auto timer_period = std::chrono::duration<double>(1.0 / status_publish_rate_);
+  const auto timer_period = std::chrono::nanoseconds(
+      lifecycle_auto_start::statusTimerPeriodNanoseconds(status_publish_rate_));
   status_timer_ =
-      this->create_wall_timer(std::chrono::duration_cast<std::chrono::milliseconds>(timer_period),
-                              std::bind(&DriveComponent::statusTimerCallback, this));
+      this->create_wall_timer(timer_period, std::bind(&DriveComponent::statusTimerCallback, this));
 
   // コマンド受信ウォッチドッグ（100ms 周期）。cmd_timeout_sec_ <= 0 で無効。
   if (drive_watchdog::isEnabled(cmd_timeout_sec_)) {

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -98,9 +98,11 @@ void DriveComponent::autoStartTimerCallback() {
                            static_cast<unsigned int>(state_id));
     }
   } catch (const std::exception& error) {
-    RCLCPP_ERROR(this->get_logger(), "Drive auto-start transition failed: %s", error.what());
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                          "Drive auto-start transition failed: %s", error.what());
   } catch (...) {
-    RCLCPP_ERROR(this->get_logger(), "Drive auto-start transition failed with unknown exception");
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                          "Drive auto-start transition failed with unknown exception");
   }
 }
 

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -31,7 +31,14 @@ DriveComponent::DriveComponent(const rclcpp::NodeOptions& options)
   declareParameters();
 
   auto_start_ = this->get_parameter("auto_start").as_bool();
-  connect_retry_period_sec_ = this->get_parameter("connect_retry_period_sec").as_double();
+  const double requested_retry_period = this->get_parameter("connect_retry_period_sec").as_double();
+  connect_retry_period_sec_ =
+      lifecycle_auto_start::normalizeRetryPeriod(requested_retry_period, 1.0);
+  if (!lifecycle_auto_start::isValidPositiveValue(requested_retry_period)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Invalid connect_retry_period_sec=%g; using the default 1.0 seconds",
+                requested_retry_period);
+  }
 
   if (auto_start_) {
     const auto period = std::chrono::duration<double>(std::max(0.5, connect_retry_period_sec_));
@@ -99,6 +106,13 @@ void DriveComponent::autoStartTimerCallback() {
 
 DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecycle::State&) {
   readParameters();
+
+  if (!lifecycle_auto_start::isValidStatusPublishRate(status_publish_rate_)) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Invalid status_publish_rate=%g; value must be finite and greater than zero",
+                 status_publish_rate_);
+    return CallbackReturn::FAILURE;
+  }
 
   // 未通電（非常停止中）は USB CDC デバイス自体が存在しない。ライブラリを構築する前に
   // デバイスの有無を確認し、リトライ毎のライブラリ内 ERROR ログで journald を汚さない。

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <filesystem>
 #include <functional>
 #include <lifecycle_msgs/msg/state.hpp>
@@ -65,20 +66,34 @@ void DriveComponent::autoStartTimerCallback() {
   using lifecycle_auto_start::AutoStartAction;
   using lifecycle_auto_start::decideAutoStartAction;
 
-  AutoStartAction action = decideAutoStartAction(this->get_current_state().id());
-  if (action == AutoStartAction::kConfigure) {
-    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
-                         "モータ接続を試行します（未通電時は失敗し、通電後に自動復帰します）");
-    this->configure();
-    // 通電済みの通常起動で従来同等のタイミングで走行可能にするため、
-    // configure 成功時は同一ティックで activate まで進める。
-    action = decideAutoStartAction(this->get_current_state().id());
+  if (!auto_start_timer_) {
+    return;
   }
-  if (action == AutoStartAction::kActivate) {
-    this->activate();
-  } else if (action == AutoStartAction::kStopTimer) {
-    // 正常稼働中はタイマーを止め、手動 deactivate/cleanup を尊重する。
-    auto_start_timer_->cancel();
+  try {
+    uint8_t state_id = this->get_current_state().id();
+    AutoStartAction action = decideAutoStartAction(state_id);
+    if (action == AutoStartAction::kConfigure) {
+      RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                           "モータ接続を試行します（未通電時は失敗し、通電後に自動復帰します）");
+      state_id = this->configure().id();
+      action = decideAutoStartAction(state_id);
+    }
+    if (action == AutoStartAction::kActivate) {
+      state_id = this->activate().id();
+      action = decideAutoStartAction(state_id);
+    }
+    if (action == AutoStartAction::kStopTimer) {
+      auto_start_timer_->cancel();
+    } else if (action == AutoStartAction::kNone &&
+               !lifecycle_auto_start::isTransitionState(state_id)) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                           "Unexpected lifecycle state during drive auto-start: %u",
+                           static_cast<unsigned int>(state_id));
+    }
+  } catch (const std::exception& error) {
+    RCLCPP_ERROR(this->get_logger(), "Drive auto-start transition failed: %s", error.what());
+  } catch (...) {
+    RCLCPP_ERROR(this->get_logger(), "Drive auto-start transition failed with unknown exception");
   }
 }
 
@@ -202,6 +217,9 @@ DriveComponent::CallbackReturn DriveComponent::on_cleanup(const rclcpp_lifecycle
 }
 
 DriveComponent::CallbackReturn DriveComponent::on_shutdown(const rclcpp_lifecycle::State&) {
+  if (auto_start_timer_) {
+    auto_start_timer_->cancel();
+  }
   status_timer_.reset();
   watchdog_timer_.reset();
   twist_subscription_.reset();

--- a/motor_control_app/test/test_lifecycle_auto_start.cpp
+++ b/motor_control_app/test/test_lifecycle_auto_start.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <lifecycle_msgs/msg/state.hpp>
+#include <limits>
 
 #include "motor_control_app/lifecycle_auto_start.hpp"
 
@@ -14,6 +15,8 @@ namespace {
 using lifecycle_msgs::msg::State;
 using motor_control_app::lifecycle_auto_start::AutoStartAction;
 using motor_control_app::lifecycle_auto_start::decideAutoStartAction;
+using motor_control_app::lifecycle_auto_start::isValidStatusPublishRate;
+using motor_control_app::lifecycle_auto_start::normalizeRetryPeriod;
 
 TEST(LifecycleAutoStart, UnconfiguredTriggersConfigure) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
@@ -60,6 +63,22 @@ TEST(LifecycleAutoStart, UnpoweredStartupRetriesConfigure) {
 
 TEST(LifecycleAutoStart, UnexpectedStateDoesNothing) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNKNOWN), AutoStartAction::kNone);
+}
+
+TEST(LifecycleParameters, InvalidRetryPeriodFallsBackToDefault) {
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(2.5, 1.0), 2.5);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(0.0, 1.0), 1.0);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(-1.0, 1.0), 1.0);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(std::numeric_limits<double>::quiet_NaN(), 1.0), 1.0);
+  EXPECT_DOUBLE_EQ(normalizeRetryPeriod(std::numeric_limits<double>::infinity(), 1.0), 1.0);
+}
+
+TEST(LifecycleParameters, StatusPublishRateMustBeFiniteAndPositive) {
+  EXPECT_TRUE(isValidStatusPublishRate(10.0));
+  EXPECT_FALSE(isValidStatusPublishRate(0.0));
+  EXPECT_FALSE(isValidStatusPublishRate(-1.0));
+  EXPECT_FALSE(isValidStatusPublishRate(std::numeric_limits<double>::quiet_NaN()));
+  EXPECT_FALSE(isValidStatusPublishRate(std::numeric_limits<double>::infinity()));
 }
 
 }  // namespace

--- a/motor_control_app/test/test_lifecycle_auto_start.cpp
+++ b/motor_control_app/test/test_lifecycle_auto_start.cpp
@@ -17,6 +17,7 @@ using motor_control_app::lifecycle_auto_start::AutoStartAction;
 using motor_control_app::lifecycle_auto_start::decideAutoStartAction;
 using motor_control_app::lifecycle_auto_start::isValidStatusPublishRate;
 using motor_control_app::lifecycle_auto_start::normalizeRetryPeriod;
+using motor_control_app::lifecycle_auto_start::statusTimerPeriodNanoseconds;
 
 TEST(LifecycleAutoStart, UnconfiguredTriggersConfigure) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
@@ -79,6 +80,14 @@ TEST(LifecycleParameters, StatusPublishRateMustBeFiniteAndPositive) {
   EXPECT_FALSE(isValidStatusPublishRate(-1.0));
   EXPECT_FALSE(isValidStatusPublishRate(std::numeric_limits<double>::quiet_NaN()));
   EXPECT_FALSE(isValidStatusPublishRate(std::numeric_limits<double>::infinity()));
+}
+
+TEST(LifecycleParameters, StatusTimerPeriodMustRemainPositiveAfterConversion) {
+  EXPECT_EQ(statusTimerPeriodNanoseconds(10.0), 100000000);
+  EXPECT_EQ(statusTimerPeriodNanoseconds(1000.0), 1000000);
+  EXPECT_EQ(statusTimerPeriodNanoseconds(1000000000.0), 1);
+  EXPECT_EQ(statusTimerPeriodNanoseconds(2000000000.0), 0);
+  EXPECT_FALSE(isValidStatusPublishRate(2000000000.0));
 }
 
 }  // namespace

--- a/motor_control_app/test/test_lifecycle_auto_start.cpp
+++ b/motor_control_app/test/test_lifecycle_auto_start.cpp
@@ -29,8 +29,8 @@ TEST(LifecycleAutoStart, ActiveStopsTimer) {
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_ACTIVE), AutoStartAction::kStopTimer);
 }
 
-TEST(LifecycleAutoStart, FinalizedDoesNothing) {
-  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_FINALIZED), AutoStartAction::kNone);
+TEST(LifecycleAutoStart, FinalizedStopsTimer) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_FINALIZED), AutoStartAction::kStopTimer);
 }
 
 TEST(LifecycleAutoStart, TransitionStatesDoNothing) {
@@ -56,6 +56,10 @@ TEST(LifecycleAutoStart, UnpoweredStartupRetriesConfigure) {
   // 未通電起動: configure 失敗で unconfigured に戻り、次ティックも kConfigure。
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
   EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNCONFIGURED), AutoStartAction::kConfigure);
+}
+
+TEST(LifecycleAutoStart, UnexpectedStateDoesNothing) {
+  EXPECT_EQ(decideAutoStartAction(State::PRIMARY_STATE_UNKNOWN), AutoStartAction::kNone);
 }
 
 }  // namespace


### PR DESCRIPTION
## 概要

PR #118の追加レビューで確認したLifecycle遷移とtimer parameterの改善です。

DriveComponentのLifecycle Node化という基本方針は維持し、遷移失敗時に半端な状態を残さないことと、不正なtimer周期を生成しないことを主眼にしています。

このPRのbaseは`main`ではなく、PR #118のsource branchです。

Related: #118

## 主な変更

- `configure`および`activate`後のLifecycle state再確認
- transition中stateでは追加遷移を行わない処理
- Lifecycle transition例外をcallback外へ漏らさない処理
- ACTIVEおよびFINALIZEDでauto-start timerを停止
- shutdown開始時にauto-start timerを停止
- `connect_retry_period_sec`のNaN、Inf、非正値を既定値へfallback
- `status_publish_rate`の不正値をconfigure時に拒否
- status timer周期をnanosecondsで生成
- 1 ns未満または`int64_t`で表現不能な周期を拒否
- default `MutuallyExclusive` callback groupを使う設計前提を明記

## 検証

- clean full build成功
- full testsで非xmllint failureなし
- Robot Manager unittest 10/10成功
- C++ format成功
- `git diff --check`成功
- undefined symbolなし
- combined構成でamd64／arm64 GitHub Actions成功

Combined Actions:

https://github.com/Yuichiroh-Kobayashi/questix/actions/runs/29636324215

## 未確認

- Raspberry Pi 5
- DDT実機
- モータ未通電状態からの自動復帰
- 手動deactivate
- 実走行
- USB serial切断
- watchdog／非常停止応答
