### PR TITLE
feat: add questix_msgs and publish /emergency_stop from operation_manager

### DIFF
--- a/operation_manager/README.md
+++ b/operation_manager/README.md
@@ -5,10 +5,15 @@ ROS2 package that subscribes to GPIO topics (published by `gpio_reader`) and dec
 Publishers:
 - `/gpio/controllable` (std_msgs/Bool): true if controllable
 - `/gpio/controllable_diagnostic` (std_msgs/String): diagnostic message (timeout/false value)
+- `/emergency_stop` (questix_msgs/EmergencyStop, reliable + transient_local, keep-last(1)):
+  unified emergency stop state, `active = !controllable`, published on every
+  controllability evaluation (each GPIO update plus the 1 s timer heartbeat).
+  See `questix_msgs/README.md` for the full topic contract and recovery semantics.
 
 Parameters (config/operation_manager.yaml):
 - `monitored_pins`: list of GPIO pin numbers to subscribe to (`gpio_<PIN>` topics)
 - `timeout_seconds`: maximum allowed age of GPIO update before marking not controllable
+- `emergency_stop_topic`: topic name for the unified emergency stop state (default `/emergency_stop`)
 
 Build:
 - colcon build --packages-select operation_manager

--- a/operation_manager/config/operation_manager.yaml
+++ b/operation_manager/config/operation_manager.yaml
@@ -2,3 +2,6 @@ operation_manager_node:
   ros__parameters:
     monitored_pins: [27]
     timeout_seconds: 1.0
+    # 統一緊急停止トピック (questix_msgs/EmergencyStop, reliable + transient_local)。
+    # active = !controllable として毎評価時に発行される。契約: questix_msgs/README.md
+    emergency_stop_topic: "/emergency_stop"

--- a/operation_manager/include/operation_manager/operation_manager_component.hpp
+++ b/operation_manager/include/operation_manager/operation_manager_component.hpp
@@ -8,6 +8,7 @@
 #define OPERATION_MANAGER__OPERATION_MANAGER_COMPONENT_HPP_
 
 #include <map>
+#include <questix_msgs/msg/emergency_stop.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/string.hpp>
@@ -31,11 +32,13 @@ private:
 
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr controllable_pub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr diagnostic_pub_;
+  rclcpp::Publisher<questix_msgs::msg::EmergencyStop>::SharedPtr emergency_stop_pub_;
 
   rclcpp::TimerBase::SharedPtr eval_timer_;
 
   double timeout_seconds_;
   std::vector<int64_t> monitored_pins_;
+  std::string emergency_stop_topic_;
 };
 
 }  // namespace operation_manager

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -7,6 +7,7 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <depend>questix_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/operation_manager/src/operation_manager_component.cpp
+++ b/operation_manager/src/operation_manager_component.cpp
@@ -16,13 +16,19 @@ OperationManagerComponent::OperationManagerComponent(const rclcpp::NodeOptions& 
     : Node("operation_manager_node", options) {
   this->declare_parameter<std::vector<int64_t>>("monitored_pins", std::vector<int64_t>{27});
   this->declare_parameter<double>("timeout_seconds", 1.0);
+  this->declare_parameter<std::string>("emergency_stop_topic", "/emergency_stop");
 
   monitored_pins_ = this->get_parameter("monitored_pins").as_integer_array();
   timeout_seconds_ = this->get_parameter("timeout_seconds").as_double();
+  emergency_stop_topic_ = this->get_parameter("emergency_stop_topic").as_string();
 
   controllable_pub_ = this->create_publisher<std_msgs::msg::Bool>("/gpio/controllable", 1);
   diagnostic_pub_ =
       this->create_publisher<std_msgs::msg::String>("/gpio/controllable_diagnostic", 1);
+  // Latched so late-joining subscribers immediately receive the current state
+  // (topic contract: see questix_msgs/README.md).
+  emergency_stop_pub_ = this->create_publisher<questix_msgs::msg::EmergencyStop>(
+      emergency_stop_topic_, rclcpp::QoS(1).reliable().transient_local());
 
   for (const auto& pin : monitored_pins_) {
     unsigned int p = static_cast<unsigned int>(pin);
@@ -82,6 +88,13 @@ void OperationManagerComponent::evaluate_controllability() {
     diag_msg.data = "not_controllable: " + diagnostic;
   }
   diagnostic_pub_->publish(diag_msg);
+
+  questix_msgs::msg::EmergencyStop estop_msg;
+  estop_msg.header.stamp = now;
+  estop_msg.active = !controllable;
+  estop_msg.source = "operation_manager";
+  estop_msg.reason = controllable ? "released" : diagnostic;
+  emergency_stop_pub_->publish(estop_msg);
 }
 
 }  // namespace operation_manager

--- a/questix_msgs/CHANGELOG.rst
+++ b/questix_msgs/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package questix_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* feat: add questix_msgs package with EmergencyStop message for the unified
+  /emergency_stop topic (`#81 <https://github.com/scramble-robot/questix/issues/81>`_)

--- a/questix_msgs/CMakeLists.txt
+++ b/questix_msgs/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.8)
+project(questix_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Interface packages use plain ament_cmake + rosidl instead of the
+# ament_cmake_auto pattern used by the node packages in this repository.
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/EmergencyStop.msg"
+  DEPENDENCIES std_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/questix_msgs/README.md
+++ b/questix_msgs/README.md
@@ -1,0 +1,53 @@
+# questix_msgs
+
+QUESTiX 共通メッセージ定義パッケージ。統一緊急停止インターフェイス
+`/emergency_stop` の一次文書はこの README です。
+
+## メッセージ
+
+### `EmergencyStop.msg`
+
+| フィールド | 型 | 意味 |
+|---|---|---|
+| `header` | `std_msgs/Header` | `stamp` = 判定時刻。`frame_id` は未使用(`""`) |
+| `active` | `bool` | `true` = 緊急停止発動 |
+| `source` | `string` | 発行元識別子(例: `"operation_manager"`) |
+| `reason` | `string` | 原因(例: `"pin 27 is false; "`、`"pin 27 timeout; "`)。解除時は `"released"` |
+
+## `/emergency_stop` トピック契約
+
+- **型**: `questix_msgs/msg/EmergencyStop`
+- **QoS**: reliable + transient_local + keep-last(1)
+  (`rclcpp::QoS(1).reliable().transient_local()`)。
+  購読側も同一 QoS を使うこと。late-join した購読者は最新のラッチ状態を即時受信する。
+- **発行元**: `operation_manager`。GPIO controllability 判定
+  (`evaluate_controllability()`)の毎回実行時に発行する。
+  すなわち GPIO 更新毎(公称 ~20 Hz)+ 1 秒周期タイマーがハートビート下限。
+  `active = !controllable`。
+- **発行者不在環境**: operation_manager は `enable_gpio_ref=true` の構成
+  (`joy_controller_referee.launch.xml`)でのみ起動する。購読側は
+  メッセージを一度も受信していない間は通常動作を継続しなければならない
+  (発行者不在で停止してはならない)。
+- **staleness 検出**: 購読側は「一度以上受信した後に」タイムアウト
+  (推奨 1.0 s)を超えて受信が途絶えた場合をフェイルセーフ条件として
+  扱ってよい(shot_component が実装)。
+
+## 復帰挙動(active=false 受信時)
+
+全購読者とも**自動復帰**。ただしモータが勝手に動き出すことはない。
+
+| 購読者 | 停止時(active=true) | 解除時(active=false) |
+|---|---|---|
+| `drive_component` | フラグ設定 + `diff_drive_->stop()` を即時実行(best-effort)。以後の `/target_twist` は無視 | フラグ解除。`/target_twist` 受付再開。モータは次の twist コマンドまで停止のまま |
+| `shot_component` | deactivate→cleanup でサーボバス解放(unconfigured へ) | auto-start 再アーム。configure→activate を自動リトライ |
+| `esc_motor_control` | フラグ設定 + `set_motor_speed(0.0)` 即時実行。停止中はボタン入力を無視 | フラグ解除。フルスピードボタンの**新たな押下エッジ**まで 0 のまま(押しっぱなしでは再始動しない) |
+
+## 移行メモ
+
+- ESC の `/roller_emergency_status`(`std_msgs/Bool`, transient_local)は
+  `/emergency_stop` の `active` のミラーとして 1 リリース並行 publish され、
+  次リリースで削除予定(deprecated)。新規購読は `/emergency_stop` を使うこと。
+- `joy_gate` は従来どおり `/gpio/controllable` を購読する(スコープ外)。
+- drive_component の受信 staleness タイムアウトは未実装
+  (既存のコマンド watchdog と物理電源断がフェイルセーフを担う)。
+  ハートビートを利用したタイムアウト追加はフォローアップ候補。

--- a/questix_msgs/msg/EmergencyStop.msg
+++ b/questix_msgs/msg/EmergencyStop.msg
@@ -1,0 +1,20 @@
+# Robot-wide emergency stop state, published latched on /emergency_stop.
+#
+# Publisher:   operation_manager (derived from GPIO controllability)
+# Subscribers: drive_component, shot_component, esc_motor_control
+#
+# QoS contract: reliable + transient_local + keep-last(1); published on every
+# controllability evaluation (each GPIO update plus a 1 s heartbeat timer).
+#
+# active=true  -> emergency stop engaged; each subscriber performs its own stop
+# active=false -> released; subscribers resume accepting commands, motors stay
+#                 stopped until the next operator command (auto recovery)
+#
+# See questix_msgs/README.md for the full topic contract and per-subscriber
+# recovery semantics.
+
+std_msgs/Header header  # stamp = evaluation time; frame_id unused ("")
+bool active             # true = emergency stop engaged
+string source           # origin identifier, e.g. "operation_manager"
+string reason           # human-readable cause, e.g. "pin 27 is false; ";
+                        # "released" when active=false

--- a/questix_msgs/package.xml
+++ b/questix_msgs/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>questix_msgs</name>
+  <version>2.0.1</version>
+  <description>Common message definitions for QUESTiX, including the unified emergency stop interface.</description>
+  <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>std_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## 概要

Issue #81 のフェーズ1。初のインターフェイスパッケージ `questix_msgs` を新設し、統一緊急停止トピック `/emergency_stop` を operation_manager から発行する。購読側（drive / shot / esc）の配線は後続 PR で行う（このPRは純追加で既存挙動を変えない）。

Refs #81

## 変更点

- **`questix_msgs`（新規）**: `EmergencyStop.msg`（`header`, `active`, `source`, `reason`）。トピック契約と購読者ごとの復帰セマンティクスを `questix_msgs/README.md` に一次文書として記載。
  - interface パッケージの標準慣行に従い `ament_cmake` + `rosidl_default_generators` を使用（本リポジトリの node パッケージが使う `ament_cmake_auto` からの意図的逸脱）。
- **operation_manager**: 既存の GPIO controllability 判定（`evaluate_controllability()`）から `/emergency_stop` を発行。`active = !controllable`、`reason` は既存 diagnostic 文字列を流用、解除時は `"released"`。パラメータ `emergency_stop_topic`（既定 `/emergency_stop`）を追加。`/gpio/controllable` の発行は従来どおり維持（joy_gate が使用）。

## トピック契約

- QoS: reliable + transient_local + keep-last(1)。late-join した購読者は最新のラッチ状態を即受信。
- 発行タイミング: 判定の毎回（GPIO 更新毎 ~20Hz + 1s タイマーがハートビート下限）。
- 発行元は `enable_gpio_ref=true` の構成でのみ起動。購読側は publisher 不在環境でも動作継続すること（後続PRで担保）。

## 検証

- `colcon build` / `colcon test`（questix_msgs, operation_manager）パス。
- `ament_clang_format` クリーン、`git diff --check` クリーン。
- スモークテスト: operation_manager を単体起動し、1s 後に `/emergency_stop` が `active: true, reason: "pin 27 timeout; "` でラッチ発行されることを `ros2 topic echo`（QoS 一致）で確認。
- **Pi 5 実機検証は未実施**（GPIO/systemd は実機が authoritative）。

## AGENTS.md パッケージ追加チェックリスト

- CI: 新規トップレベル `questix_msgs/` は path filter でビルド発火。colcon が全ワークスペースをビルド、rosdep が package.xml から解決するため CI 構造変更は不要。
- `launcher/package.xml` は変更なし（questix_msgs は launch から参照されず、購読パッケージ経由で推移的に解決）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
