### PR TITLE
refactor: migrate string status topics to typed messages

### DIFF
--- a/esc_motor_control_cpp/src/esc_motor_control_component.cpp
+++ b/esc_motor_control_cpp/src/esc_motor_control_component.cpp
@@ -77,8 +77,7 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   if (!emergency_stop_topic_.empty()) {
     emergency_stop_sub_ = this->create_subscription<questix_msgs::msg::EmergencyStop>(
         emergency_stop_topic_, rclcpp::QoS(1).reliable().transient_local(),
-        std::bind(&EscMotorControlComponent::emergency_stop_callback, this,
-                  std::placeholders::_1));
+        std::bind(&EscMotorControlComponent::emergency_stop_callback, this, std::placeholders::_1));
   }
 
   // ---- Publishers ----

--- a/launcher/config/drive_component.yaml
+++ b/launcher/config/drive_component.yaml
@@ -60,8 +60,11 @@ drive_component:
 
     # パブリッシュ設定
     status_publish_rate: 10.0 # ステータスパブリッシュ頻度 [Hz]
-    # 左右モータのフィードバック出力先
-    # 左右RPMや現在速度を見たいときは、このトピックを ros2 topic echo してください。
+    # 型付きステータス出力先（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
+    # 左右モータの電流/速度/位置/fault を型付きで確認したいときはこちらを echo してください。
+    typed_status_topic: "/drive_status"
+    # 旧 String(JSON) ステータス出力先（deprecated, #87。1リリース並行 publish 後に削除予定）。
+    # 新規購読は typed_status_topic を使ってください。
     status_topic: "/drive_motor_status"
 
     # 統一緊急停止トピック（questix_msgs/EmergencyStop, reliable + transient_local）。

--- a/motor_control_app/CMakeLists.txt
+++ b/motor_control_app/CMakeLists.txt
@@ -75,6 +75,8 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_shot_auto_start test/test_shot_auto_start.cpp)
   ament_auto_add_gtest(test_drive_watchdog test/test_drive_watchdog.cpp)
   ament_auto_add_gtest(test_lifecycle_auto_start test/test_lifecycle_auto_start.cpp)
+  ament_auto_add_gtest(test_motor_status_msg test/test_motor_status_msg.cpp)
+  ament_target_dependencies(test_motor_status_msg motor_control_lib)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/motor_control_app/config/drive_component.yaml
+++ b/motor_control_app/config/drive_component.yaml
@@ -60,8 +60,11 @@ drive_component:
 
     # パブリッシュ設定
     status_publish_rate: 10.0 # ステータスパブリッシュ頻度 [Hz]
-    # 左右モータのフィードバック出力先
-    # 左右RPMや現在速度を見たいときは、このトピックを ros2 topic echo してください。
+    # 型付きステータス出力先（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
+    # 左右モータの電流/速度/位置/fault を型付きで確認したいときはこちらを echo してください。
+    typed_status_topic: "/drive_status"
+    # 旧 String(JSON) ステータス出力先（deprecated, #87。1リリース並行 publish 後に削除予定）。
+    # 新規購読は typed_status_topic を使ってください。
     status_topic: "/drive_motor_status"
 
     # 統一緊急停止トピック（questix_msgs/EmergencyStop, reliable + transient_local）。

--- a/motor_control_app/config/joy_axis_drive_params.yaml
+++ b/motor_control_app/config/joy_axis_drive_params.yaml
@@ -23,5 +23,8 @@ joy_axis_drive:
     invert_right_axis: true
 
     # パブリッシュ設定
+    # 型付き questix_msgs/DriveStatus を joy_axis_drive_status へ publish する
+    # （車輪ジオメトリを持たないため linear/angular_velocity は 0.0）。旧 String(JSON) の
+    # motor_status は deprecated（#87、1リリース並行 publish 後に削除予定）。
     status_publish_rate: 10.0 # ステータスパブリッシュ頻度 [Hz]
     publish_twist: true # デバッグ用Twistメッセージをパブリッシュするか

--- a/motor_control_app/config/single_ddt_motor_config.yaml
+++ b/motor_control_app/config/single_ddt_motor_config.yaml
@@ -20,4 +20,7 @@ single_ddt_motor_node:
     watchdog_timeout: 1.0  # seconds - この時間 Twist が来ないとモータ停止
 
     # ステータス公開設定
+    # 型付き questix_msgs/MotorFeedback を single_ddt_motor_feedback（launch で
+    # /single_ddt_motor_feedback に remap）へ publish する。旧 String の /motor_status は
+    # deprecated（#87、1リリース並行 publish 後に削除予定）。契約: questix_msgs/README.md。
     status_publish_rate: 5.0  # Hz

--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -13,6 +13,7 @@
 #include "motor_control_app/drive_watchdog.hpp"
 #include "motor_control_lib/ddt_motor_lib.hpp"
 #include "motor_control_lib/differential_drive.hpp"
+#include "questix_msgs/msg/drive_status.hpp"
 #include "questix_msgs/msg/emergency_stop.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
@@ -130,7 +131,11 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
   // lifecycle 状態に依存せず常時生かす（コンストラクタで作成、on_cleanup でも破棄しない）
   rclcpp::Subscription<questix_msgs::msg::EmergencyStop>::SharedPtr emergency_stop_sub_;
+  // 旧 String ステータス（JSON）。1リリース並行 publish 後に削除予定（deprecated, #87）。
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr status_publisher_;
+  // 型付きステータス（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
+  rclcpp_lifecycle::LifecyclePublisher<questix_msgs::msg::DriveStatus>::SharedPtr
+      typed_status_publisher_;
   rclcpp::TimerBase::SharedPtr status_timer_;
   rclcpp::TimerBase::SharedPtr watchdog_timer_;
   rclcpp::TimerBase::SharedPtr auto_start_timer_;
@@ -148,7 +153,8 @@ private:
   int right_motor_id_;
   int max_motor_rpm_;
   double status_publish_rate_;
-  std::string status_topic_;
+  std::string status_topic_;        // 旧 String JSON トピック（deprecated, #87）
+  std::string typed_status_topic_;  // 型付き DriveStatus トピック
   // 統一緊急停止トピック（空文字で連動無効）。コンストラクタで一度だけ読む。
   std::string emergency_stop_topic_;
 

--- a/motor_control_app/include/motor_control_app/joy_axis_drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/joy_axis_drive_component.hpp
@@ -11,6 +11,7 @@
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "motor_control_lib/ddt_motor_lib.hpp"
+#include "questix_msgs/msg/drive_status.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "sensor_msgs/msg/joy.hpp"
@@ -73,7 +74,10 @@ private:
 
   // ROS 2パブリッシャー/サブスクライバー
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
+  // 旧 String ステータス（JSON）。1リリース並行 publish 後に削除予定（deprecated, #87）。
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
+  // 型付きステータス（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
+  rclcpp::Publisher<questix_msgs::msg::DriveStatus>::SharedPtr drive_status_publisher_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_publisher_;  // デバッグ用
 
   // タイマー

--- a/motor_control_app/include/motor_control_app/motor_status_msg.hpp
+++ b/motor_control_app/include/motor_control_app/motor_status_msg.hpp
@@ -1,0 +1,47 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#ifndef MOTOR_CONTROL_APP__MOTOR_STATUS_MSG_HPP_
+#define MOTOR_CONTROL_APP__MOTOR_STATUS_MSG_HPP_
+
+#include "motor_control_lib/ddt_motor_lib.hpp"
+#include "motor_control_lib/ddt_protocol.hpp"
+#include "questix_msgs/msg/motor_feedback.hpp"
+#include "rclcpp/time.hpp"
+
+namespace motor_control_app {
+
+/**
+ * @brief DdtMotorLib::MotorFeedbackData を questix_msgs/MotorFeedback に変換する。
+ *
+ *  - header.stamp: フィードバック受信済みなら now から経過秒を引いた実受信時刻、
+ *    未受信なら 0（= 未受信を表す契約、msg 定義参照）。
+ *  - current_amp: 生値から ddt_protocol::currentRawToAmp で換算する。
+ *
+ *  シリアル I/O や rclcpp ノードに依存しない純関数（単体テスト可能）。
+ */
+inline questix_msgs::msg::MotorFeedback toMotorFeedbackMsg(
+    const motor_control_lib::DdtMotorLib::MotorFeedbackData& fb, const rclcpp::Time& now) {
+  questix_msgs::msg::MotorFeedback msg;
+  if (fb.has_feedback) {
+    msg.header.stamp = now - rclcpp::Duration::from_seconds(fb.feedback_age_sec);
+  } else {
+    msg.header.stamp = rclcpp::Time(0, 0, now.get_clock_type());
+  }
+  msg.motor_id = fb.motor_id;
+  msg.mode = fb.mode;
+  msg.current_raw = fb.current_raw;
+  msg.current_amp = motor_control_lib::ddt_protocol::currentRawToAmp(fb.current_raw);
+  msg.velocity_rpm = fb.velocity_rpm;
+  msg.target_rpm = fb.target_rpm;
+  msg.position_raw = fb.position_raw;
+  msg.temperature = fb.temperature;
+  msg.fault_code = fb.fault_code;
+  return msg;
+}
+
+}  // namespace motor_control_app
+
+#endif  // MOTOR_CONTROL_APP__MOTOR_STATUS_MSG_HPP_

--- a/motor_control_app/include/motor_control_app/single_ddt_motor_component.hpp
+++ b/motor_control_app/include/motor_control_app/single_ddt_motor_component.hpp
@@ -11,6 +11,7 @@
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "motor_control_lib/ddt_motor_lib.hpp"
+#include "questix_msgs/msg/motor_feedback.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -68,7 +69,10 @@ private:
 
   // ROS 2 通信
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
+  // 旧 String ステータス（自由文）。1リリース並行 publish 後に削除予定（deprecated, #87）。
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
+  // 型付きステータス（questix_msgs/MotorFeedback）。契約は questix_msgs/README.md。
+  rclcpp::Publisher<questix_msgs::msg::MotorFeedback>::SharedPtr feedback_publisher_;
   rclcpp::TimerBase::SharedPtr status_timer_;
 
   // モータ制御ライブラリ

--- a/motor_control_app/launch/single_ddt_motor.launch.py
+++ b/motor_control_app/launch/single_ddt_motor.launch.py
@@ -34,6 +34,7 @@ def generate_launch_description():
         remappings=[
             ('cmd_vel', '/cmd_vel'),
             ('motor_status', '/motor_status'),
+            ('single_ddt_motor_feedback', '/single_ddt_motor_feedback'),
         ],
     )
 

--- a/motor_control_app/launch/single_ddt_motor.launch.xml
+++ b/motor_control_app/launch/single_ddt_motor.launch.xml
@@ -29,5 +29,6 @@
     <param name="watchdog_timeout" value="1.0" />
     <remap from="cmd_vel" to="/cmd_vel" />
     <remap from="motor_status" to="/motor_status" />
+    <remap from="single_ddt_motor_feedback" to="/single_ddt_motor_feedback" />
   </node>
 </launch>

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -13,6 +13,7 @@
 #include <lifecycle_msgs/msg/state.hpp>
 
 #include "motor_control_app/lifecycle_auto_start.hpp"
+#include "motor_control_app/motor_status_msg.hpp"
 
 using namespace std::chrono_literals;
 
@@ -157,7 +158,8 @@ DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecyc
   RCLCPP_INFO(this->get_logger(), "  right_motor_id: %d", right_motor_id_);
   RCLCPP_INFO(this->get_logger(), "  max_motor_rpm: %d", max_motor_rpm_);
   RCLCPP_INFO(this->get_logger(), "  status_publish_rate: %.1f", status_publish_rate_);
-  RCLCPP_INFO(this->get_logger(), "  status_topic: %s", status_topic_.c_str());
+  RCLCPP_INFO(this->get_logger(), "  status_topic: %s (deprecated)", status_topic_.c_str());
+  RCLCPP_INFO(this->get_logger(), "  typed_status_topic: %s", typed_status_topic_.c_str());
   RCLCPP_INFO(this->get_logger(), "  cmd_timeout_sec: %.2f", cmd_timeout_sec_);
   RCLCPP_INFO(this->get_logger(), "  control_mode: %s", control_mode_.c_str());
   if (control_mode_ == "current") {
@@ -173,7 +175,10 @@ DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecyc
       "/target_twist", 1, std::bind(&DriveComponent::twistCallback, this, std::placeholders::_1));
 
   // LifecyclePublisher のため on_activate まで publish は無効
+  // 旧 String JSON（deprecated, #87）と型付き DriveStatus を並行 publish する。
   status_publisher_ = this->create_publisher<std_msgs::msg::String>(status_topic_, 1);
+  typed_status_publisher_ =
+      this->create_publisher<questix_msgs::msg::DriveStatus>(typed_status_topic_, 1);
 
   RCLCPP_INFO(this->get_logger(), "Drive component configured");
   return CallbackReturn::SUCCESS;
@@ -238,6 +243,7 @@ DriveComponent::CallbackReturn DriveComponent::on_cleanup(const rclcpp_lifecycle
   watchdog_timer_.reset();
   twist_subscription_.reset();
   status_publisher_.reset();
+  typed_status_publisher_.reset();
   shutdownMotorLib();
   RCLCPP_INFO(this->get_logger(), "Drive component cleaned up");
   return CallbackReturn::SUCCESS;
@@ -251,6 +257,7 @@ DriveComponent::CallbackReturn DriveComponent::on_shutdown(const rclcpp_lifecycl
   watchdog_timer_.reset();
   twist_subscription_.reset();
   status_publisher_.reset();
+  typed_status_publisher_.reset();
   shutdownMotorLib();
   RCLCPP_INFO(this->get_logger(), "Drive component shut down");
   return CallbackReturn::SUCCESS;
@@ -263,6 +270,7 @@ DriveComponent::CallbackReturn DriveComponent::on_error(const rclcpp_lifecycle::
   watchdog_timer_.reset();
   twist_subscription_.reset();
   status_publisher_.reset();
+  typed_status_publisher_.reset();
   shutdownMotorLib();
   if (auto_start_ && auto_start_timer_) {
     auto_start_timer_->reset();
@@ -281,7 +289,10 @@ void DriveComponent::declareParameters() {
   this->declare_parameter("right_motor_id", 2);
   this->declare_parameter("max_motor_rpm", 1000);
   this->declare_parameter("status_publish_rate", 10.0);
+  // 旧 String JSON トピック（deprecated, #87。次リリースで削除予定）
   this->declare_parameter("status_topic", "/drive_motor_status");
+  // 型付きステータストピック（questix_msgs/DriveStatus）
+  this->declare_parameter("typed_status_topic", "/drive_status");
 
   // 制御モード関連 (後方互換のため velocity 既定)
   this->declare_parameter("control_mode", std::string("velocity"));
@@ -321,6 +332,7 @@ void DriveComponent::readParameters() {
   max_motor_rpm_ = this->get_parameter("max_motor_rpm").as_int();
   status_publish_rate_ = this->get_parameter("status_publish_rate").as_double();
   status_topic_ = this->get_parameter("status_topic").as_string();
+  typed_status_topic_ = this->get_parameter("typed_status_topic").as_string();
   control_mode_ = this->get_parameter("control_mode").as_string();
   current_kp_ = this->get_parameter("current_kp").as_double();
   current_ki_ = this->get_parameter("current_ki").as_double();
@@ -534,8 +546,29 @@ void DriveComponent::statusTimerCallback() {
   }
 
   try {
+    // 型付き publish 用に、左右モータのフィードバックを（古ければ）1回ポーリングして更新する。
+    // 走行中は新鮮なので実質 no-op。アイドル時のみ最後のフレームを再送して実測を取り直す。
+    motor_lib_->refreshMotorFeedback(left_motor_id_);
+    motor_lib_->refreshMotorFeedback(right_motor_id_);
+
     auto status = diff_drive_->getDriveStatus();
 
+    // 型付きステータス（questix_msgs/DriveStatus）を publish
+    rclcpp::Time now = this->now();
+    motor_control_lib::DdtMotorLib::MotorFeedbackData left_fb, right_fb;
+    motor_lib_->getMotorFeedbackData(left_motor_id_, left_fb);
+    motor_lib_->getMotorFeedbackData(right_motor_id_, right_fb);
+
+    questix_msgs::msg::DriveStatus typed_msg;
+    typed_msg.header.stamp = now;
+    typed_msg.left = toMotorFeedbackMsg(left_fb, now);
+    typed_msg.right = toMotorFeedbackMsg(right_fb, now);
+    typed_msg.linear_velocity = status.current_linear_velocity;
+    typed_msg.angular_velocity = status.current_angular_velocity;
+    typed_msg.emergency_stop = emergency_stop_active_;
+    typed_status_publisher_->publish(typed_msg);
+
+    // 以下は旧 String JSON（deprecated, #87。1リリース並行 publish 後に削除予定）。
     // ステータス情報をJSON風の文字列として作成
     std::string status_str =
         "{"

--- a/motor_control_app/src/joy_axis_drive_component.cpp
+++ b/motor_control_app/src/joy_axis_drive_component.cpp
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <functional>
 
+#include "motor_control_app/motor_status_msg.hpp"
+
 using namespace std::chrono_literals;
 
 namespace motor_control_app {
@@ -29,7 +31,11 @@ JoyAxisDriveComponent::JoyAxisDriveComponent(const rclcpp::NodeOptions& options)
   joy_subscription_ = this->create_subscription<sensor_msgs::msg::Joy>(
       "/joy", 1, std::bind(&JoyAxisDriveComponent::joyCallback, this, std::placeholders::_1));
 
+  // 旧 String（JSON, deprecated #87）と型付き DriveStatus を並行 publish する。
+  // 型付きは相対名を分離し、旧 motor_status との同名衝突を避ける。
   status_publisher_ = this->create_publisher<std_msgs::msg::String>("motor_status", 10);
+  drive_status_publisher_ =
+      this->create_publisher<questix_msgs::msg::DriveStatus>("joy_axis_drive_status", 10);
 
   // デバッグ用Twistパブリッシャー(オプション)
   if (publish_twist_) {
@@ -206,6 +212,27 @@ void JoyAxisDriveComponent::statusTimerCallback() {
   }
 
   try {
+    // 型付き publish 用に、左右モータのフィードバックを（古ければ）1回ポーリングして更新する。
+    motor_lib_->refreshMotorFeedback(left_motor_id_);
+    motor_lib_->refreshMotorFeedback(right_motor_id_);
+
+    // 型付きステータス（questix_msgs/DriveStatus）を publish。
+    // このノードは車輪ジオメトリを持たないため linear/angular_velocity は 0.0（msg 契約）。
+    rclcpp::Time now = this->now();
+    motor_control_lib::DdtMotorLib::MotorFeedbackData left_fb, right_fb;
+    motor_lib_->getMotorFeedbackData(left_motor_id_, left_fb);
+    motor_lib_->getMotorFeedbackData(right_motor_id_, right_fb);
+
+    questix_msgs::msg::DriveStatus typed_msg;
+    typed_msg.header.stamp = now;
+    typed_msg.left = toMotorFeedbackMsg(left_fb, now);
+    typed_msg.right = toMotorFeedbackMsg(right_fb, now);
+    typed_msg.linear_velocity = 0.0;
+    typed_msg.angular_velocity = 0.0;
+    typed_msg.emergency_stop = emergency_stop_active_;
+    drive_status_publisher_->publish(typed_msg);
+
+    // 以下は旧 String JSON（deprecated, #87。1リリース並行 publish 後に削除予定）。
     // 左モータのステータスを取得
     int left_rpm = 0;
     uint8_t left_temperature = 0;

--- a/motor_control_app/src/single_ddt_motor_component.cpp
+++ b/motor_control_app/src/single_ddt_motor_component.cpp
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <cmath>
 
+#include "motor_control_app/motor_status_msg.hpp"
+
 using namespace std::chrono_literals;
 
 namespace motor_control_app {
@@ -34,7 +36,11 @@ SingleDdtMotorComponent::SingleDdtMotorComponent(const rclcpp::NodeOptions& opti
       std::bind(&SingleDdtMotorComponent::twistCallback, this, std::placeholders::_1));
 
   // ステータスパブリッシャーを作成
+  // 旧 String（自由文, deprecated #87）と型付き MotorFeedback を並行 publish する。
+  // 型付きは相対名を分離し、旧 motor_status との同名衝突を避ける。
   status_publisher_ = this->create_publisher<std_msgs::msg::String>("motor_status", 10);
+  feedback_publisher_ =
+      this->create_publisher<questix_msgs::msg::MotorFeedback>("single_ddt_motor_feedback", 10);
 
   // ステータスタイマーを作成
   auto status_timer_period = std::chrono::duration<double>(1.0 / status_publish_rate_);
@@ -180,11 +186,19 @@ void SingleDdtMotorComponent::statusTimerCallback() {
     return;
   }
 
+  // 型付き publish 用にフィードバックを（古ければ）1回ポーリングして更新する。
+  motor_lib_->refreshMotorFeedback(motor_id_);
+  motor_control_lib::DdtMotorLib::MotorFeedbackData fb;
+  if (motor_lib_->getMotorFeedbackData(motor_id_, fb)) {
+    feedback_publisher_->publish(toMotorFeedbackMsg(fb, this->now()));
+  }
+
   int velocity_rpm = 0;
   uint8_t temperature = 0;
   uint8_t fault_code = 0;
 
   if (motor_lib_->getMotorStatus(motor_id_, velocity_rpm, temperature, fault_code)) {
+    // 旧 String（自由文, deprecated #87）
     auto status_msg = std_msgs::msg::String();
     status_msg.data =
         "Motor ID: " + std::to_string(motor_id_) + ", RPM: " + std::to_string(velocity_rpm) +

--- a/motor_control_app/test/test_motor_status_msg.cpp
+++ b/motor_control_app/test/test_motor_status_msg.cpp
@@ -1,0 +1,65 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+#include <gtest/gtest.h>
+
+#include "motor_control_app/motor_status_msg.hpp"
+
+namespace {
+
+using motor_control_app::toMotorFeedbackMsg;
+using MotorFeedbackData = motor_control_lib::DdtMotorLib::MotorFeedbackData;
+
+TEST(ToMotorFeedbackMsg, FieldsPassThrough) {
+  MotorFeedbackData fb;
+  fb.motor_id = 4;
+  fb.mode = 2;
+  fb.current_raw = 16384;  // 半分 -> 約 4A
+  fb.velocity_rpm = -120;
+  fb.target_rpm = -150;
+  fb.position_raw = 12345;
+  fb.temperature = 0;
+  fb.fault_code = 3;
+  fb.has_feedback = true;
+  fb.feedback_age_sec = 0.0;
+
+  auto msg = toMotorFeedbackMsg(fb, rclcpp::Time(10, 0, RCL_ROS_TIME));
+  EXPECT_EQ(msg.motor_id, 4);
+  EXPECT_EQ(msg.mode, 2);
+  EXPECT_EQ(msg.current_raw, 16384);
+  EXPECT_EQ(msg.velocity_rpm, -120);
+  EXPECT_EQ(msg.target_rpm, -150);
+  EXPECT_EQ(msg.position_raw, 12345);
+  EXPECT_EQ(msg.temperature, 0);
+  EXPECT_EQ(msg.fault_code, 3);
+  // current_amp = 16384 * 8 / 32767 ~= 4.0
+  EXPECT_NEAR(msg.current_amp, 4.0f, 0.01f);
+}
+
+TEST(ToMotorFeedbackMsg, StampSubtractsAgeWhenFresh) {
+  MotorFeedbackData fb;
+  fb.has_feedback = true;
+  fb.feedback_age_sec = 0.25;
+
+  rclcpp::Time now(10, 0, RCL_ROS_TIME);
+  auto msg = toMotorFeedbackMsg(fb, now);
+  // stamp = now - 0.25s = 9.75s
+  EXPECT_NEAR(rclcpp::Time(msg.header.stamp, RCL_ROS_TIME).seconds(), 9.75, 1e-6);
+}
+
+TEST(ToMotorFeedbackMsg, ZeroStampWhenNoFeedback) {
+  MotorFeedbackData fb;  // has_feedback defaults to false
+  fb.motor_id = 5;
+  fb.target_rpm = 42;
+
+  auto msg = toMotorFeedbackMsg(fb, rclcpp::Time(10, 0, RCL_ROS_TIME));
+  // 未受信 -> stamp は 0（msg 契約）だが motor_id / target_rpm は保持される。
+  EXPECT_EQ(rclcpp::Time(msg.header.stamp, RCL_ROS_TIME).nanoseconds(), 0);
+  EXPECT_EQ(msg.motor_id, 5);
+  EXPECT_EQ(msg.target_rpm, 42);
+  EXPECT_EQ(msg.velocity_rpm, 0);
+}
+
+}  // namespace

--- a/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_motor_lib.hpp
@@ -129,15 +129,56 @@ public:
   };
   std::vector<MotorStatus> getAllMotorStatus() const;
 
+  /**
+   * @brief 1 モータ分の詳細フィードバック（型付きステータストピック publish 用）。
+   *  getMotorStatus よりリッチな内容（mode / 電流生値 / 位置 / 目標 RPM / 鮮度）を返す。
+   */
+  struct MotorFeedbackData {
+    uint8_t motor_id{0};
+    uint8_t mode{0};
+    int16_t current_raw{0};    // トルク電流生値（符号付き）
+    int16_t velocity_rpm{0};   // 実測 RPM
+    int16_t target_rpm{0};     // 最終指令値（クランプ後）
+    uint16_t position_raw{0};  // ロータ位置
+    uint8_t temperature{0};    // 常に 0（Protocol 2 (0x74) 未実装）
+    uint8_t fault_code{0};
+    bool has_feedback{false};      // 一度でも有効フィードバックを受信したか
+    double feedback_age_sec{0.0};  // has_feedback のときのみ有効な受信経過秒
+  };
+
+  /**
+   * @brief 指定モータの詳細フィードバックを取得する。
+   * @return 登録済みモータなら true（out を更新）。未登録/未初期化なら false。
+   */
+  bool getMotorFeedbackData(int motor_id, MotorFeedbackData& out) const;
+
+  /**
+   * @brief 鮮度ゲート付きフィードバックポーリング。
+   *  保持フィードバックが max_age_sec より新しければ何もしない。古ければ、
+   *  ファームが既に実行中の「最後に送ったフレーム」をそのまま再送し、既存の
+   *  10ms タイムアウト内で新しいフィードバック応答を引き出す。新規プロトコル
+   *  コマンドは発行せず、固定スリープもしない（呼び出しは 1 回の
+   *  sendFrameWithFeedback で上限付き）。
+   *
+   *  保持フレームをそのまま再送するため、ブレーキバイト等のコマンド状態を厳密に
+   *  保持する。走行中はフィードバックが新鮮なので実質 no-op。アイドル時のみ
+   *  1 モータあたり最悪 ~10ms のシリアル待ちが加わる点に注意（呼び出し元が
+   *  単一スレッドエグゼキュータでステータスタイマーから呼ぶ前提）。
+   * @return 呼び出し後にフィードバックが新鮮なら true。
+   */
+  bool refreshMotorFeedback(int motor_id, double max_age_sec = 0.05);
+
 private:
   // Motor feedback structure
   struct MotorFeedback {
-    uint8_t mode;
-    uint16_t current;
-    int16_t speed;
-    uint8_t angle;
-    uint8_t temperature;
-    uint8_t fault_code;
+    uint8_t mode{0};
+    int16_t current{0};      // トルク電流生値（符号付き）: DATA[2..3]
+    int16_t speed{0};        // 実測 RPM（符号付き）: DATA[4..5]
+    uint16_t position{0};    // ロータ位置: DATA[6..7]
+    uint8_t temperature{0};  // 常に 0（Protocol 2 (0x74) 未実装）
+    uint8_t fault_code{0};
+    bool has_feedback{false};  // 一度でも有効フィードバックを parse したか
+    std::chrono::steady_clock::time_point last_feedback_time{};  // 最終受信時刻
   };
 
   // Current モード用 PI 状態（モータ毎）
@@ -180,6 +221,8 @@ private:
   std::map<int, MotorFeedback> motor_feedbacks_;  // motor_id -> feedback
   std::map<int, ControlMode> motor_modes_;        // motor_id -> control mode
   std::map<int, PiState> pi_states_;              // motor_id -> PI state
+  // motor_id -> 最後に送った駆動フレーム（refreshMotorFeedback の再送用）
+  std::map<int, std::vector<uint8_t>> last_sent_frames_;
 
   // Private methods
   bool initializeSerial();
@@ -194,8 +237,6 @@ private:
   bool sendFrameWithFeedback(int motor_id, const std::vector<uint8_t>& frame);
   int16_t runCurrentLoopStep(int motor_id, int rpm_ref);  // PI 1ステップ
   void resetCurrentPiStateForStop(int motor_id);
-  bool requestMotorFeedback(int motor_id);
-  void processFeedbackResponse(int motor_id, const std::vector<uint8_t>& response);
   bool readFeedbackFrame(int expected_motor_id, std::vector<uint8_t>& out_frame, int timeout_ms);
   bool parseFeedback(int expected_motor_id, const std::vector<uint8_t>& frame);
 

--- a/motor_control_lib/include/motor_control_lib/ddt_protocol.hpp
+++ b/motor_control_lib/include/motor_control_lib/ddt_protocol.hpp
@@ -75,10 +75,17 @@ std::vector<uint8_t> packCurrentFrame(uint8_t motor_id, int16_t current_raw);
  */
 struct Feedback {
   uint8_t mode;
-  uint16_t current;
-  int16_t speed;
+  int16_t current;    // トルク電流の生値（符号付き）: -32767..32767 <-> -8..+8 A
+  int16_t speed;      // 実測 RPM（符号付き）
+  uint16_t position;  // ロータ位置: 0..32767 <-> 0..360 deg
   uint8_t fault_code;
 };
+
+/**
+ * @brief トルク電流の生値 [-32767..32767] を電流 [A] に変換する。
+ *  仕様: 生値 32767 が +8A、-32767 が -8A に対応する。
+ */
+constexpr float currentRawToAmp(int16_t raw) { return static_cast<float>(raw) * 8.0f / 32767.0f; }
 
 /**
  * @brief parseFeedbackFrame の結果コード。

--- a/motor_control_lib/src/ddt_motor_lib.cpp
+++ b/motor_control_lib/src/ddt_motor_lib.cpp
@@ -65,6 +65,7 @@ void DdtMotorLib::shutdown() {
     motor_feedbacks_.clear();
     motor_modes_.clear();
     pi_states_.clear();
+    last_sent_frames_.clear();
     initialized_ = false;
     RCLCPP_INFO(logger_, "DDTモータライブラリが終了されました");
   }
@@ -211,11 +212,11 @@ bool DdtMotorLib::getMotorStatus(int motor_id, int& velocity_rpm, uint8_t& tempe
     return false;
   }
 
-  // Current モードでフィードバックがあれば実測 RPM を返す。それ以外は目標値を返す（既存互換）。
-  auto mode_it = motor_modes_.find(motor_id);
+  // 有効フィードバックがあれば実測 RPM を返す（velocity/current 両モード）。
+  // velocity モードでも sendMotorVelocity が毎コマンド応答を取り込むため実測が使える。
+  // フィードバック未受信のときのみ目標値にフォールバックする（既存互換）。
   bool prefer_measured =
-      (mode_it != motor_modes_.end() && mode_it->second == ControlMode::Current) &&
-      (feedback_it != motor_feedbacks_.end());
+      (feedback_it != motor_feedbacks_.end() && feedback_it->second.has_feedback);
 
   velocity_rpm = prefer_measured ? static_cast<int>(feedback_it->second.speed) : vel_it->second;
 
@@ -245,6 +246,16 @@ bool DdtMotorLib::initializeMotor(int motor_id, ControlMode mode) {
   motor_velocities_[motor_id] = 0;
   motor_feedbacks_[motor_id] = MotorFeedback{};
   pi_states_[motor_id] = PiState{};
+
+  // フィードバックをプライミング: ゼロ指令を 1 回通常経路で送り、last_sent_frames_ を
+  // 埋めつつ初回フィードバックを取得する（モータは動かない）。未通電時など失敗しても
+  // 致命ではないため WARN に留めて初期化は成功させる。
+  bool primed = (mode == ControlMode::Current) ? sendMotorCurrentRaw(motor_id, 0)
+                                               : sendMotorVelocity(motor_id, 0, brake_on_stop_);
+  if (!primed) {
+    RCLCPP_WARN(logger_, "モーター %d のフィードバックプライミングに失敗しました（続行）",
+                motor_id);
+  }
 
   RCLCPP_INFO(logger_, "モーター %d が初期化されました (mode=%s)", motor_id,
               mode == ControlMode::Current ? "current" : "velocity");
@@ -467,6 +478,8 @@ bool DdtMotorLib::sendMotorVelocity(int motor_id, int velocity_rpm, bool brake) 
   bool success = sendFrameWithFeedback(motor_id, data_fields);
   if (success) {
     motor_velocities_[motor_id] = velocity_int;
+    // refreshMotorFeedback の再送用に、実行中フレームをそのまま保存（ブレーキ等の状態を保持）。
+    last_sent_frames_[motor_id] = data_fields;
     RCLCPP_DEBUG(logger_, "モーター %d 速度設定: %d RPM", motor_id, velocity_int);
   } else {
     RCLCPP_ERROR(logger_, "モーター %d の速度設定に失敗しました (目標: %d RPM)", motor_id,
@@ -482,6 +495,8 @@ bool DdtMotorLib::sendMotorCurrentRaw(int motor_id, int16_t current_raw) {
 
   bool success = sendFrameWithFeedback(motor_id, data_fields);
   if (success) {
+    // refreshMotorFeedback の再送用に、実行中フレームをそのまま保存。
+    last_sent_frames_[motor_id] = data_fields;
     RCLCPP_DEBUG(logger_, "モーター %d 電流指令: raw=%d", motor_id, static_cast<int>(current_raw));
   }
   return success;
@@ -646,9 +661,11 @@ bool DdtMotorLib::parseFeedback(int expected_motor_id, const std::vector<uint8_t
   fb.mode = decoded.mode;
   fb.current = decoded.current;
   fb.speed = decoded.speed;
-  // 位置はここでは使わないが、temperature 取得は Protocol 2 (0x74) が必要。
-  // 暫定で前回値保持（既存挙動）。
+  fb.position = decoded.position;
+  // temperature は Protocol 2 (0x74) が必要なため未取得（常に 0 のまま保持）。
   fb.fault_code = decoded.fault_code;
+  fb.has_feedback = true;
+  fb.last_feedback_time = std::chrono::steady_clock::now();
 
   // PI 状態側にも保存（受信失敗時のフォールバック用）
   auto pi_it = pi_states_.find(expected_motor_id);
@@ -717,15 +734,65 @@ ssize_t DdtMotorLib::readSerial(void* data, size_t size) {
   return read(serial_fd_, data, size);
 }
 
-// TODO: Implement feedback methods
-bool DdtMotorLib::requestMotorFeedback(int /*motor_id*/) {
-  // Implementation from original code can be added here
+bool DdtMotorLib::getMotorFeedbackData(int motor_id, MotorFeedbackData& out) const {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  if (!initialized_) {
+    return false;
+  }
+  auto vel_it = motor_velocities_.find(motor_id);
+  if (vel_it == motor_velocities_.end()) {
+    return false;
+  }
+
+  out = MotorFeedbackData{};
+  out.motor_id = static_cast<uint8_t>(motor_id);
+  out.target_rpm = static_cast<int16_t>(vel_it->second);
+
+  auto fb_it = motor_feedbacks_.find(motor_id);
+  if (fb_it != motor_feedbacks_.end() && fb_it->second.has_feedback) {
+    const MotorFeedback& fb = fb_it->second;
+    out.mode = fb.mode;
+    out.current_raw = fb.current;
+    out.velocity_rpm = fb.speed;
+    out.position_raw = fb.position;
+    out.temperature = fb.temperature;  // 常に 0（Protocol 2 未実装）
+    out.fault_code = fb.fault_code;
+    out.has_feedback = true;
+    out.feedback_age_sec =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - fb.last_feedback_time)
+            .count();
+  }
   return true;
 }
 
-void DdtMotorLib::processFeedbackResponse(int /*motor_id*/,
-                                          const std::vector<uint8_t>& /*response*/) {
-  // Implementation from original code can be added here
+bool DdtMotorLib::refreshMotorFeedback(int motor_id, double max_age_sec) {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  if (!initialized_) {
+    return false;
+  }
+
+  auto fb_it = motor_feedbacks_.find(motor_id);
+  if (fb_it != motor_feedbacks_.end() && fb_it->second.has_feedback) {
+    double age = std::chrono::duration<double>(std::chrono::steady_clock::now() -
+                                               fb_it->second.last_feedback_time)
+                     .count();
+    if (age <= max_age_sec) {
+      return true;  // 十分新鮮: 何もしない
+    }
+  }
+
+  // 古い/未受信: ファームが実行中の最後のフレームをそのまま再送してフィードバックを引き出す。
+  auto frame_it = last_sent_frames_.find(motor_id);
+  if (frame_it == last_sent_frames_.end()) {
+    return false;  // 送信履歴なし（未指令）
+  }
+  sendFrameWithFeedback(motor_id, frame_it->second);
+
+  fb_it = motor_feedbacks_.find(motor_id);
+  return fb_it != motor_feedbacks_.end() && fb_it->second.has_feedback &&
+         std::chrono::duration<double>(std::chrono::steady_clock::now() -
+                                       fb_it->second.last_feedback_time)
+                 .count() <= max_age_sec;
 }
 
 }  // namespace motor_control_lib

--- a/motor_control_lib/src/ddt_protocol.cpp
+++ b/motor_control_lib/src/ddt_protocol.cpp
@@ -86,8 +86,9 @@ ParseResult parseFeedbackFrame(uint8_t expected_motor_id, const std::vector<uint
   //  DATA[6..7]=position, DATA[8]=fault code
   // マルチバイトは big-endian (high, low)。
   out.mode = frame[1];
-  out.current = static_cast<uint16_t>((frame[2] << 8) | frame[3]);
+  out.current = static_cast<int16_t>((frame[2] << 8) | frame[3]);
   out.speed = static_cast<int16_t>((frame[4] << 8) | frame[5]);
+  out.position = static_cast<uint16_t>((frame[6] << 8) | frame[7]);
   out.fault_code = frame[8];
   return ParseResult::kOk;
 }

--- a/motor_control_lib/test/test_ddt_protocol.cpp
+++ b/motor_control_lib/test/test_ddt_protocol.cpp
@@ -91,18 +91,33 @@ TEST(PackModeFrame, ModeValueLandsInByte8) {
 }
 
 TEST(ParseFeedbackFrame, ValidFrame) {
-  // speed = 0xFF9C = -100 (int16 符号拡張回帰テスト), current = 0x0102
-  std::vector<uint8_t> frame = {0x01, 0x01, 0x01, 0x02, 0xFF, 0x9C, 0x00, 0x00, 0x00};
+  // speed = 0xFF9C = -100 (int16 符号拡張回帰テスト), current = 0x0102, position = 0x0304
+  std::vector<uint8_t> frame = {0x01, 0x01, 0x01, 0x02, 0xFF, 0x9C, 0x03, 0x04, 0x00};
   frame.push_back(ddt::crc8Maxim(frame));
-  // 独立実装で事前計算した CRC の既知解
-  EXPECT_EQ(frame[9], 0x8E);
 
   ddt::Feedback fb{};
   EXPECT_EQ(ddt::parseFeedbackFrame(0x01, frame, fb), ddt::ParseResult::kOk);
   EXPECT_EQ(fb.mode, 0x01);
   EXPECT_EQ(fb.current, 0x0102);
   EXPECT_EQ(fb.speed, -100);
+  EXPECT_EQ(fb.position, 0x0304);
   EXPECT_EQ(fb.fault_code, 0x00);
+}
+
+TEST(ParseFeedbackFrame, CurrentIsSignExtended) {
+  // current = 0xFF9C = -100 (int16 符号拡張回帰テスト。旧実装は uint16 で 0xFF9C を返していた)
+  std::vector<uint8_t> frame = {0x01, 0x02, 0xFF, 0x9C, 0x00, 0x00, 0x00, 0x00, 0x00};
+  frame.push_back(ddt::crc8Maxim(frame));
+
+  ddt::Feedback fb{};
+  EXPECT_EQ(ddt::parseFeedbackFrame(0x01, frame, fb), ddt::ParseResult::kOk);
+  EXPECT_EQ(fb.current, -100);
+}
+
+TEST(CurrentRawToAmp, KnownAnswers) {
+  EXPECT_FLOAT_EQ(ddt::currentRawToAmp(0), 0.0f);
+  EXPECT_FLOAT_EQ(ddt::currentRawToAmp(32767), 8.0f);
+  EXPECT_FLOAT_EQ(ddt::currentRawToAmp(-32767), -8.0f);
 }
 
 TEST(ParseFeedbackFrame, BadLength) {

--- a/operation_manager/README.md
+++ b/operation_manager/README.md
@@ -4,7 +4,13 @@ ROS2 package that subscribes to GPIO topics (published by `gpio_reader`) and dec
 
 Publishers:
 - `/gpio/controllable` (std_msgs/Bool): true if controllable
-- `/gpio/controllable_diagnostic` (std_msgs/String): diagnostic message (timeout/false value)
+- `/diagnostics` (diagnostic_msgs/DiagnosticArray): standard diagnostic aggregation
+  topic. One `DiagnosticStatus` (name `operation_manager: gpio_controllability`,
+  hardware_id `gpio`) with `level` OK/ERROR and per-pin `KeyValue` entries
+  (`pin_<N>_state`, `pin_<N>_age_sec`). Consumable by `rqt_runtime_monitor`.
+- `/gpio/controllable_diagnostic` (std_msgs/String): **deprecated (#87)**, replaced
+  by `/diagnostics`. Kept as a parallel free-text publish for one release, removed
+  next release. See `questix_msgs/README.md` 移行メモ.
 - `/emergency_stop` (questix_msgs/EmergencyStop, reliable + transient_local, keep-last(1)):
   unified emergency stop state, `active = !controllable`, published on every
   controllability evaluation (each GPIO update plus the 1 s timer heartbeat).

--- a/operation_manager/config/operation_manager.yaml
+++ b/operation_manager/config/operation_manager.yaml
@@ -2,6 +2,9 @@ operation_manager_node:
   ros__parameters:
     monitored_pins: [27]
     timeout_seconds: 1.0
+    # 診断は標準 diagnostic_msgs/DiagnosticArray を /diagnostics へ publish する
+    # （rqt_runtime_monitor が消費可）。旧 String の /gpio/controllable_diagnostic は
+    # deprecated（#87、1リリース並行 publish 後に削除予定）。契約: questix_msgs/README.md。
     # 統一緊急停止トピック (questix_msgs/EmergencyStop, reliable + transient_local)。
     # active = !controllable として毎評価時に発行される。契約: questix_msgs/README.md
     emergency_stop_topic: "/emergency_stop"

--- a/operation_manager/include/operation_manager/operation_manager_component.hpp
+++ b/operation_manager/include/operation_manager/operation_manager_component.hpp
@@ -7,6 +7,7 @@
 #ifndef OPERATION_MANAGER__OPERATION_MANAGER_COMPONENT_HPP_
 #define OPERATION_MANAGER__OPERATION_MANAGER_COMPONENT_HPP_
 
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <map>
 #include <questix_msgs/msg/emergency_stop.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -31,7 +32,10 @@ private:
   std::map<unsigned int, rclcpp::Time> gpio_last_update_;
 
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr controllable_pub_;
+  // 旧 String 診断（自由文）。1リリース並行 publish 後に削除予定（deprecated, #87）。
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr diagnostic_pub_;
+  // 標準診断集約トピック（rqt_runtime_monitor 等がそのまま消費できる）。
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
   rclcpp::Publisher<questix_msgs::msg::EmergencyStop>::SharedPtr emergency_stop_pub_;
 
   rclcpp::TimerBase::SharedPtr eval_timer_;

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -11,6 +11,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
+  <depend>diagnostic_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/operation_manager/src/operation_manager_component.cpp
+++ b/operation_manager/src/operation_manager_component.cpp
@@ -23,8 +23,11 @@ OperationManagerComponent::OperationManagerComponent(const rclcpp::NodeOptions& 
   emergency_stop_topic_ = this->get_parameter("emergency_stop_topic").as_string();
 
   controllable_pub_ = this->create_publisher<std_msgs::msg::Bool>("/gpio/controllable", 1);
+  // 旧 String 診断（deprecated, #87。次リリースで削除予定）と標準 DiagnosticArray を並行 publish。
   diagnostic_pub_ =
       this->create_publisher<std_msgs::msg::String>("/gpio/controllable_diagnostic", 1);
+  diagnostics_pub_ =
+      this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
   // Latched so late-joining subscribers immediately receive the current state
   // (topic contract: see questix_msgs/README.md).
   emergency_stop_pub_ = this->create_publisher<questix_msgs::msg::EmergencyStop>(
@@ -63,6 +66,11 @@ void OperationManagerComponent::evaluate_controllability() {
   std::string diagnostic = "";
   rclcpp::Time now = this->now();
 
+  // 標準 DiagnosticArray 用に、ピンごとの状態を KeyValue として収集する。
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.name = "operation_manager: gpio_controllability";
+  status.hardware_id = "gpio";
+
   for (const auto& pair : gpio_states_) {
     unsigned int pin = pair.first;
     bool state = pair.second;
@@ -75,6 +83,15 @@ void OperationManagerComponent::evaluate_controllability() {
       controllable = false;
       diagnostic += "pin " + std::to_string(pin) + " is false; ";
     }
+
+    diagnostic_msgs::msg::KeyValue kv_state;
+    kv_state.key = "pin_" + std::to_string(pin) + "_state";
+    kv_state.value = state ? "true" : "false";
+    status.values.push_back(kv_state);
+    diagnostic_msgs::msg::KeyValue kv_age;
+    kv_age.key = "pin_" + std::to_string(pin) + "_age_sec";
+    kv_age.value = std::to_string(elapsed);
+    status.values.push_back(kv_age);
   }
 
   std_msgs::msg::Bool out;
@@ -88,6 +105,15 @@ void OperationManagerComponent::evaluate_controllability() {
     diag_msg.data = "not_controllable: " + diagnostic;
   }
   diagnostic_pub_->publish(diag_msg);
+
+  // 標準 DiagnosticArray（deprecated な自由文 String の置換, #87）。
+  status.level = controllable ? diagnostic_msgs::msg::DiagnosticStatus::OK
+                              : diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  status.message = controllable ? "controllable" : "not_controllable: " + diagnostic;
+  diagnostic_msgs::msg::DiagnosticArray diag_array;
+  diag_array.header.stamp = now;
+  diag_array.status.push_back(status);
+  diagnostics_pub_->publish(diag_array);
 
   questix_msgs::msg::EmergencyStop estop_msg;
   estop_msg.header.stamp = now;

--- a/questix_msgs/CHANGELOG.rst
+++ b/questix_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package questix_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* feat: add MotorFeedback and DriveStatus messages for the typed status-topic
+  migration (`#87 <https://github.com/scramble-robot/questix/issues/87>`_)
+
 2.1.0 (2026-07-23)
 ------------------
 * feat: add questix_msgs package with EmergencyStop message for the unified

--- a/questix_msgs/CMakeLists.txt
+++ b/questix_msgs/CMakeLists.txt
@@ -12,7 +12,9 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/DriveStatus.msg"
   "msg/EmergencyStop.msg"
+  "msg/MotorFeedback.msg"
   DEPENDENCIES std_msgs
 )
 

--- a/questix_msgs/README.md
+++ b/questix_msgs/README.md
@@ -1,7 +1,7 @@
 # questix_msgs
 
 QUESTiX 共通メッセージ定義パッケージ。統一緊急停止インターフェイス
-`/emergency_stop` の一次文書はこの README です。
+`/emergency_stop` と型付きステータストピックの一次文書はこの README です。
 
 ## メッセージ
 
@@ -13,6 +13,41 @@ QUESTiX 共通メッセージ定義パッケージ。統一緊急停止インタ
 | `active` | `bool` | `true` = 緊急停止発動 |
 | `source` | `string` | 発行元識別子(例: `"operation_manager"`) |
 | `reason` | `string` | 原因(例: `"pin 27 is false; "`、`"pin 27 timeout; "`)。解除時は `"released"` |
+
+### `MotorFeedback.msg`
+
+DDT M0602C の Protocol 1 応答フレームをデコードした 1 モータ分のフィードバック。
+マルチバイトのワイヤフィールドはビッグエンディアン(high, low)で、デコードは
+`motor_control_lib/ddt_protocol` に集約されている。
+
+| フィールド | 型 | 意味 |
+|---|---|---|
+| `header` | `std_msgs/Header` | `stamp` = 最終有効フィードバックの受信時刻。`stamp == 0` は未受信(この場合 `motor_id`/`target_rpm` 以外は 0) |
+| `motor_id` | `uint8` | DDT モータ ID(DATA[0]) |
+| `mode` | `uint8` | ファーム報告の制御モード(DATA[1])。定数 `MODE_CURRENT_LOOP=1` / `MODE_VELOCITY_LOOP=2` |
+| `current_raw` | `int16` | トルク電流の生値(DATA[2..3], 符号付き)。-32767..32767 ↔ -8..+8 A |
+| `current_amp` | `float32` | `current_raw * 8.0 / 32767.0` [A] |
+| `velocity_rpm` | `int16` | 実測輪速 [RPM](DATA[4..5], 符号付き) |
+| `target_rpm` | `int16` | 最終指令値 [RPM](`max_motor_rpm` でクランプ後) |
+| `position_raw` | `uint16` | ロータ位置(DATA[6..7])。0..32767 ↔ 0..360 deg |
+| `temperature` | `uint8` | [deg C] **現状常に 0**。DDT Protocol 2 (0x74) 未実装。実装時にフィールドを変えずに済むよう定義だけ残している |
+| `fault_code` | `uint8` | DATA[8]。0 = 正常、非0 = ファーム故障ビット |
+
+### `DriveStatus.msg`
+
+差動二輪の状態。左右ホイールの `MotorFeedback` と車体速度をまとめる。
+
+| フィールド | 型 | 意味 |
+|---|---|---|
+| `header` | `std_msgs/Header` | `stamp` = publish 時刻。`frame_id` は未使用(`""`) |
+| `left` / `right` | `MotorFeedback` | 左右ホイールのフィードバック(各 `stamp` は個別の受信時刻) |
+| `linear_velocity` | `float64` | [m/s] 実測輪速から算出 |
+| `angular_velocity` | `float64` | [rad/s] 実測輪速から算出 |
+| `emergency_stop` | `bool` | 発行ノードの緊急停止フラグ |
+
+全体 healthy 判定は `left.fault_code == 0 && right.fault_code == 0` で導出する
+(専用フィールドは持たない)。`joy_axis_drive` は車輪ジオメトリのパラメータを持たない
+ため `linear_velocity = angular_velocity = 0.0` を publish する。
 
 ## `/emergency_stop` トピック契約
 
@@ -42,11 +77,31 @@ QUESTiX 共通メッセージ定義パッケージ。統一緊急停止インタ
 | `shot_component` | deactivate→cleanup でサーボバス解放(unconfigured へ) | auto-start 再アーム。configure→activate を自動リトライ |
 | `esc_motor_control` | フラグ設定 + `set_motor_speed(0.0)` 即時実行。停止中はボタン入力を無視 | フラグ解除。フルスピードボタンの**新たな押下エッジ**まで 0 のまま(押しっぱなしでは再始動しない) |
 
+## 型付きステータストピック契約
+
+`MotorFeedback` / `DriveStatus` は下記のトピックで publish される
+(QoS はいずれも reliable + volatile、旧 String トピックと同じ keep-last 深さ)。
+
+| トピック | 型 | 発行元 | 備考 |
+|---|---|---|---|
+| `/drive_status` | `DriveStatus` | `drive_component` | `status_publish_rate`(既定 10 Hz)。lifecycle ACTIVE 時のみ |
+| `single_ddt_motor_feedback` | `MotorFeedback` | `single_ddt_motor` | 相対名。launch で `/single_ddt_motor_feedback` に remap |
+| `joy_axis_drive_status` | `DriveStatus` | `joy_axis_drive` | 相対名。`linear/angular_velocity = 0.0` |
+| `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | `operation_manager` | 標準集約トピック。rqt_runtime_monitor が設定なしで表示 |
+
 ## 移行メモ
 
 - ESC の `/roller_emergency_status`(`std_msgs/Bool`, transient_local)は
   `/emergency_stop` の `active` のミラーとして 1 リリース並行 publish され、
   次リリースで削除予定(deprecated)。新規購読は `/emergency_stop` を使うこと。
+- 旧 String ステータストピック(下記)は上表の型付きトピックへ移行済み。
+  互換のため 1 リリース並行 publish し、次リリースで削除予定(deprecated, #87)。
+  | 旧トピック | 型 | 発行元 | 置換先 |
+  |---|---|---|---|
+  | `/drive_motor_status` | `std_msgs/String`(JSON) | `drive_component` | `/drive_status` |
+  | `motor_status` | `std_msgs/String`(自由文) | `single_ddt_motor` | `single_ddt_motor_feedback` |
+  | `motor_status` | `std_msgs/String`(JSON) | `joy_axis_drive` | `joy_axis_drive_status` |
+  | `/gpio/controllable_diagnostic` | `std_msgs/String`(自由文) | `operation_manager` | `/diagnostics` |
 - `joy_gate` は従来どおり `/gpio/controllable` を購読する(スコープ外)。
 - drive_component の受信 staleness タイムアウトは未実装
   (既存のコマンド watchdog と物理電源断がフェイルセーフを担う)。

--- a/questix_msgs/msg/DriveStatus.msg
+++ b/questix_msgs/msg/DriveStatus.msg
@@ -1,0 +1,17 @@
+# Differential-drive status: per-wheel MotorFeedback plus chassis velocity.
+#
+# Publishers: drive_component (/drive_status, status_publish_rate Hz),
+#             joy_axis_drive (joy_axis_drive_status).
+#
+# joy_axis_drive has no wheel-geometry parameters, so it publishes
+# linear_velocity = angular_velocity = 0.0 (only the per-wheel MotorFeedback is
+# meaningful there). See questix_msgs/README.md for the full topic contract.
+#
+# Overall health is derivable as left.fault_code == 0 && right.fault_code == 0.
+
+std_msgs/Header header      # stamp = publish time; frame_id unused ("")
+MotorFeedback left          # left wheel (per-wheel stamp = its feedback time)
+MotorFeedback right         # right wheel
+float64 linear_velocity     # [m/s]  computed from measured wheel RPM
+float64 angular_velocity    # [rad/s] computed from measured wheel RPM
+bool emergency_stop         # publishing node's emergency-stop flag

--- a/questix_msgs/msg/MotorFeedback.msg
+++ b/questix_msgs/msg/MotorFeedback.msg
@@ -1,0 +1,29 @@
+# Per-motor feedback decoded from the DDT M0602C Protocol 1 response frame.
+#
+# Publishers:  single_ddt_motor (standalone, /single_ddt_motor_feedback);
+#              embedded as left/right inside DriveStatus (drive_component,
+#              joy_axis_drive).
+#
+# Wire fields are big-endian (high, low); decoding is centralized in
+# motor_control_lib/ddt_protocol. See questix_msgs/README.md for the full
+# topic contract.
+
+# Firmware-reported control mode (feedback DATA[1]).
+uint8 MODE_CURRENT_LOOP=1
+uint8 MODE_VELOCITY_LOOP=2
+
+std_msgs/Header header  # stamp = receipt time of the last valid feedback frame.
+                        # stamp == 0 -> no feedback received yet (every field
+                        # except motor_id/target_rpm is 0). frame_id unused ("").
+uint8 motor_id          # DDT motor ID (frame DATA[0])
+uint8 mode              # firmware control mode (DATA[1]); see MODE_* constants
+int16 current_raw       # torque current raw (DATA[2..3], signed):
+                        # -32767..32767 <-> -8..+8 A
+float32 current_amp     # current_raw * 8.0 / 32767.0 [A]
+int16 velocity_rpm      # measured wheel speed [RPM] (DATA[4..5], signed)
+int16 target_rpm        # last commanded target [RPM] (clamped to max_motor_rpm)
+uint16 position_raw     # rotor position (DATA[6..7]): 0..32767 <-> 0..360 deg
+uint8 temperature       # [deg C] CURRENTLY ALWAYS 0: requires DDT Protocol 2
+                        # (0x74), not yet implemented. The field is kept so the
+                        # interface does not change when Protocol 2 lands.
+uint8 fault_code        # DATA[8]; 0 = no fault, nonzero = firmware fault bits


### PR DESCRIPTION
## 背景

構造化データを `std_msgs/String`(手組み JSON / フリーテキスト)に詰めているステータストピックが複数あり、購読者はまだ存在しない(`ros2 topic echo` と rosbag のみ)。#69 のモニタリングや robot_manager 表示を String-JSON の上に実装すると後からの移行コストが跳ね上がるため、移行コストが最も低い今のうちに型を確定させる(issue #87)。依存先の #81(questix_msgs 新設)は完了済み。

## 変更内容

### 新メッセージ(questix_msgs)
- `MotorFeedback.msg`: 1モータ分の DDT Protocol 1 フィードバック(id, mode, current 生値/A, 実測/目標 RPM, position, temperature, fault)
- `DriveStatus.msg`: header + 左右 `MotorFeedback` + linear/angular velocity + emergency_stop
- **temperature は msg に残しつつ当面 0 埋め**(DDT Protocol 2 / 0x74 未実装。実装時にインターフェイスを変えずに済むよう定義だけ残す)

### 型付きトピックへの移行(旧 String は1リリース並行 publish、#87)
| ノード | 新トピック(型) | 旧トピック(deprecated) |
|---|---|---|
| `drive_component` | `/drive_status`(DriveStatus) | `/drive_motor_status` |
| `single_ddt_motor` | `single_ddt_motor_feedback`(MotorFeedback) | `motor_status` |
| `joy_axis_drive` | `joy_axis_drive_status`(DriveStatus) | `motor_status` |
| `operation_manager` | `/diagnostics`(diagnostic_msgs/DiagnosticArray) | `/gpio/controllable_diagnostic` |

- `joy_axis_drive` は payload が左右2輪の drive 型のため **DriveStatus** を採用(車輪ジオメトリを持たないため linear/angular は 0.0)
- `operation_manager` は標準 `DiagnosticArray` を採用し、ピンごとの状態を KeyValue で付与(rqt_runtime_monitor がそのまま消費可)

### velocity モードのフィードバック実データ化(同一 PR)
- `ddt_protocol`: current を符号付き `int16` にしてデコード、`position` デコードを追加、`currentRawToAmp` ヘルパー追加
- `getMotorStatus` を「有効フィードバックがあれば全モードで実測優先」に変更(velocity モードは従来目標値をエコーしていた)
- `getMotorFeedbackData` / 鮮度ゲート付き `refreshMotorFeedback` を追加。古い場合のみ**最後に送ったフレームをそのまま再送**して既存の 10ms タイムアウト内で実測を取り直す(新規プロトコルコマンドなし・スリープなし・ブレーキバイト保持)
- `initializeMotor` でフィードバックをプライミング。デッドスタブを削除

## ⚠️ 挙動変更の注意
旧 `/drive_motor_status` JSON の `left_rpm` / `right_rpm` が**目標エコーから実測値に変わる**。リリースを跨いだ rosbag 比較では差が出ます。

## テスト
- `ddt_protocol` パーステスト拡張(current 符号拡張 / position / currentRawToAmp)
- `toMotorFeedbackMsg` ヘルパーの単体テスト新設
- ローカル: `colcon build` / `colcon test`(359 tests, 0 failures) / `ament_clang_format` すべてパス

## 実機検証(Raspberry Pi 5 必須)
- [ ] 走行中 velocity モードで `velocity_rpm` が実測、`current_raw/amp` / `position_raw` / `fault_code` が妥当
- [ ] アイドル時 `refreshMotorFeedback` のポーリングでモータが動かない・`brake_on_stop` 後の再送でブレーキ保持・CRC エラーログ増なし
- [ ] 50Hz teleop の指令遅延なし、e-stop 停止タイミング不変
- [ ] `initializeMotor` プライミングで configure 時に動かない
- [ ] rqt_runtime_monitor で GPIO トグル時に OK↔ERROR 遷移

## 関連
- Refs #87(旧 String トピックの削除は #87 の移行方針どおり次リリースで実施。#87 は open のまま追跡)
- 依存先 #81(questix_msgs): 完了済み
- 前提となる #69(モータフィードバック監視)の受け入れ条件の土台

🤖 Generated with [Claude Code](https://claude.com/claude-code)