### PR TITLE
chore: release 2.2.0

### DIFF
--- a/description_launch/CHANGELOG.rst
+++ b/description_launch/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package description_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* Version bump only for package description_launch
+
 2.1.0 (2026-07-23)
 ------------------
 * Version bump only for package description_launch

--- a/description_launch/package.xml
+++ b/description_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>description_launch</name>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <description>Questix description package</description>
   <maintainer email="manami.bean14@gmail.com">kajimame</maintainer>
   <license>MIT</license>

--- a/esc_motor_control_cpp/CHANGELOG.rst
+++ b/esc_motor_control_cpp/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package esc_motor_control_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)
+* Contributors: Akihisa Nagata
+
 2.1.0 (2026-07-23)
 ------------------
 * feat: link esc_motor_control to the unified /emergency_stop topic (`#125 <https://github.com/scramble-robot/questix/issues/125>`_)

--- a/esc_motor_control_cpp/package.xml
+++ b/esc_motor_control_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>esc_motor_control_cpp</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>C++ ROS2 ESC motor control node with pigpio/lgpio backend support</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/gpio_reader/CHANGELOG.rst
+++ b/gpio_reader/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package gpio_reader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* Version bump only for package gpio_reader
+
 2.1.0 (2026-07-23)
 ------------------
 * Version bump only for package gpio_reader

--- a/gpio_reader/package.xml
+++ b/gpio_reader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>gpio_reader</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>ROS2 package for reading GPIO values on Raspberry Pi 5</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_controller/CHANGELOG.rst
+++ b/joy_controller/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package joy_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* Version bump only for package joy_controller
+
 2.1.0 (2026-07-23)
 ------------------
 * Version bump only for package joy_controller

--- a/joy_controller/package.xml
+++ b/joy_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_controller</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>Integrated Joy Controller for ROS2 with enhanced joystick functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_gate/CHANGELOG.rst
+++ b/joy_gate/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package joy_gate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* Version bump only for package joy_gate
+
 2.1.0 (2026-07-23)
 ------------------
 * Version bump only for package joy_gate

--- a/joy_gate/package.xml
+++ b/joy_gate/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_gate</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>Joy message gating based on GPIO controllable status</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/launcher/CHANGELOG.rst
+++ b/launcher/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package questix_launcher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)
+* Contributors: Akihisa Nagata
+
 2.1.0 (2026-07-23)
 ------------------
 * feat: link drive, shot, and esc components to /emergency_stop (`#125 <https://github.com/scramble-robot/questix/issues/125>`_)

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>questix_launcher</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>Questix system launcher package with XML-based launch files</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/motor_control_app/CHANGELOG.rst
+++ b/motor_control_app/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package motor_control_app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)
+* Contributors: Akihisa Nagata
+
 2.1.0 (2026-07-23)
 ------------------
 * feat: link drive and shot components to /emergency_stop (`#125 <https://github.com/scramble-robot/questix/issues/125>`_)

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_app</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>Refactored motor control application using the new motor_control_lib</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib/CHANGELOG.rst
+++ b/motor_control_lib/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package motor_control_lib
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)
+* Contributors: Akihisa Nagata
+
 2.1.0 (2026-07-23)
 ------------------
 * chore: remove unused legacy motor apps (`#123 <https://github.com/scramble-robot/questix/issues/123>`_)

--- a/motor_control_lib/package.xml
+++ b/motor_control_lib/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_lib</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>Motor control library with common interfaces for drive and shot functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib_simple/CHANGELOG.rst
+++ b/motor_control_lib_simple/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package motor_control_lib_simple
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* Version bump only for package motor_control_lib_simple
+
 2.1.0 (2026-07-23)
 ------------------
 * Version bump only for package motor_control_lib_simple

--- a/motor_control_lib_simple/package.xml
+++ b/motor_control_lib_simple/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>motor_control_lib_simple</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>シンプルなモータ制御ライブラリ</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/operation_manager/CHANGELOG.rst
+++ b/operation_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package operation_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)
+* Contributors: Akihisa Nagata
+
 2.1.0 (2026-07-23)
 ------------------
 * feat: add questix_msgs and publish /emergency_stop from operation_manager (`#124 <https://github.com/scramble-robot/questix/issues/124>`_)

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>operation_manager</name>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <description>Determine whether GPIO IO is controllable by subscribing to GPIO topics.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/questix_msgs/CHANGELOG.rst
+++ b/questix_msgs/CHANGELOG.rst
@@ -2,10 +2,11 @@
 Changelog for package questix_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.2.0 (2026-07-23)
+------------------
 * feat: add MotorFeedback and DriveStatus messages for the typed status-topic
   migration (`#87 <https://github.com/scramble-robot/questix/issues/87>`_)
+* Contributors: Akihisa Nagata
 
 2.1.0 (2026-07-23)
 ------------------

--- a/questix_msgs/package.xml
+++ b/questix_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>questix_msgs</name>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <description>Common message definitions for QUESTiX, including the unified emergency stop interface.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="robot-manager",
-    version="2.1.0",
+    version="2.2.0",
     packages=find_packages(),
     include_package_data=True,
     package_data={"robot_manager": ["static/*"]},

--- a/uart_joy_driver/CHANGELOG.rst
+++ b/uart_joy_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package uart_joy_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.2.0 (2026-07-23)
+------------------
+* Version bump only for package uart_joy_driver
+
 2.1.0 (2026-07-23)
 ------------------
 * Version bump only for package uart_joy_driver

--- a/uart_joy_driver/package.xml
+++ b/uart_joy_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>uart_joy_driver</name>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>UART serial joystick driver for Switch-style controllers. Reads 7-byte hex protocol from UART and publishes sensor_msgs/Joy.</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>


### PR DESCRIPTION
## Summary

Bump all package versions from 2.1.0 to 2.2.0 (`package.xml` and `scripts/setup.py`) and add 2.2.0 changelog sections summarizing the changes merged since the 2.1.0 baseline.

## Highlights

- **refactor: migrate string status topics to typed messages** (#127) — adds `MotorFeedback` and `DriveStatus` messages to `questix_msgs` (#87) and migrates `motor_control_app`, `motor_control_lib`, `operation_manager`, `launcher`, and `esc_motor_control_cpp` off string status topics.

## Notes

- 25 files changed: 12 `package.xml`, 12 `CHANGELOG.rst`, and `scripts/setup.py` — mirrors the 2.1.0 release (#126).
- Packages unaffected by #127 get a "Version bump only" changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)