### PR TITLE
refactor: remove deprecated string status topics and esc bool mirror

### DIFF
--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.dualshock.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.dualshock.yaml
@@ -23,9 +23,6 @@ esc_motor_control:
     # （復帰にはフルスピードボタンの再押下が必要）。空文字 "" で連動無効。
     # 発行元は operation_manager（契約: questix_msgs/README.md）。
     emergency_stop_topic: "/emergency_stop"
-    # Deprecated: /emergency_stop の active フラグをミラーする出力（std_msgs/Bool）。
-    # 次リリースで削除予定。新規購読は /emergency_stop を使うこと。
-    emergency_status_topic: "/roller_emergency_status"
 
     # Safety / timeout-stop behavior:
     # If no full-speed command arrives within safety_timeout seconds (e.g. the

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.uart.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.uart.yaml
@@ -23,9 +23,6 @@ esc_motor_control:
     # （復帰にはフルスピードボタンの再押下が必要）。空文字 "" で連動無効。
     # 発行元は operation_manager（契約: questix_msgs/README.md）。
     emergency_stop_topic: "/emergency_stop"
-    # Deprecated: /emergency_stop の active フラグをミラーする出力（std_msgs/Bool）。
-    # 次リリースで削除予定。新規購読は /emergency_stop を使うこと。
-    emergency_status_topic: "/roller_emergency_status"
 
     # Safety / timeout-stop behavior:
     # If no full-speed command arrives within safety_timeout seconds (e.g. the

--- a/esc_motor_control_cpp/config/esc_motor_control_cpp.yaml
+++ b/esc_motor_control_cpp/config/esc_motor_control_cpp.yaml
@@ -31,9 +31,6 @@ esc_motor_control:
     # （復帰にはフルスピードボタンの再押下が必要）。空文字 "" で連動無効。
     # 発行元は operation_manager（契約: questix_msgs/README.md）。
     emergency_stop_topic: "/emergency_stop"
-    # Deprecated: /emergency_stop の active フラグをミラーする出力（std_msgs/Bool）。
-    # 次リリースで削除予定。新規購読は /emergency_stop を使うこと。
-    emergency_status_topic: "/roller_emergency_status"
 
     # Safety settings
     # Safety / timeout-stop behavior:

--- a/esc_motor_control_cpp/include/esc_motor_control_cpp/esc_motor_control_component.hpp
+++ b/esc_motor_control_cpp/include/esc_motor_control_cpp/esc_motor_control_component.hpp
@@ -15,7 +15,6 @@
 #include "questix_msgs/msg/emergency_stop.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
-#include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/float32.hpp"
 
 namespace esc_motor_control_cpp {
@@ -54,9 +53,6 @@ private:
   std::string status_topic_;
   // 統一緊急停止トピック（questix_msgs/EmergencyStop, 入力）。空文字で連動無効。
   std::string emergency_stop_topic_;
-  // Deprecated: /emergency_stop の active フラグをミラーする出力（std_msgs/Bool）。
-  // 1リリースだけ並行 publish し、次リリースで削除予定。新規購読は /emergency_stop を使うこと。
-  std::string emergency_status_topic_;
   int min_pulse_width_us_;
   int max_pulse_width_us_;
   int neutral_pulse_width_us_;
@@ -76,8 +72,6 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
   rclcpp::Subscription<questix_msgs::msg::EmergencyStop>::SharedPtr emergency_stop_sub_;
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr status_pub_;
-  // Deprecated: 下記の /roller_emergency_status（std_msgs/Bool）。上記コメント参照。
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr emergency_pub_;
   rclcpp::TimerBase::SharedPtr status_timer_;
   rclcpp::TimerBase::SharedPtr safety_timer_;
 };

--- a/esc_motor_control_cpp/src/esc_motor_control_component.cpp
+++ b/esc_motor_control_cpp/src/esc_motor_control_component.cpp
@@ -31,9 +31,6 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   this->declare_parameter<std::string>("status_topic", "/roller_motor_status");
   // 統一緊急停止トピック（questix_msgs/EmergencyStop, 入力）。空文字で連動無効。
   this->declare_parameter<std::string>("emergency_stop_topic", "/emergency_stop");
-  // Deprecated: /emergency_stop の active フラグをミラーする出力（std_msgs/Bool）。
-  // 次リリースで削除予定。新規購読は /emergency_stop を使うこと。
-  this->declare_parameter<std::string>("emergency_status_topic", "/roller_emergency_status");
   this->declare_parameter<int>("min_pulse_width", 0);         // μs (speed=-1.0)
   this->declare_parameter<int>("max_pulse_width", 2000);      // μs (speed=1.0)
   this->declare_parameter<int>("neutral_pulse_width", 1000);  // μs (ESC arm/idle)
@@ -53,7 +50,6 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   joy_topic_ = this->get_parameter("joy_topic").as_string();
   status_topic_ = this->get_parameter("status_topic").as_string();
   emergency_stop_topic_ = this->get_parameter("emergency_stop_topic").as_string();
-  emergency_status_topic_ = this->get_parameter("emergency_status_topic").as_string();
   min_pulse_width_us_ = this->get_parameter("min_pulse_width").as_int();
   max_pulse_width_us_ = this->get_parameter("max_pulse_width").as_int();
   neutral_pulse_width_us_ = this->get_parameter("neutral_pulse_width").as_int();
@@ -62,10 +58,6 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
 
   // ---- Internal state ----
   full_speed_logic_.configure(safety_timeout_);
-
-  // ---- QoS ----
-  rclcpp::QoS qos_transient(10);
-  qos_transient.reliable().transient_local();
 
   // ---- Subscribers ----
   joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
@@ -82,10 +74,6 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
 
   // ---- Publishers ----
   status_pub_ = this->create_publisher<std_msgs::msg::Float32>(status_topic_, 10);
-  // Deprecated: /roller_emergency_status（std_msgs/Bool）。/emergency_stop の active を
-  // ミラーするだけの出力で、次リリースで削除予定。新規購読は /emergency_stop を使うこと。
-  emergency_pub_ =
-      this->create_publisher<std_msgs::msg::Bool>(emergency_status_topic_, qos_transient);
 
   // ---- Timers ----
   status_timer_ =
@@ -103,7 +91,6 @@ EscMotorControlComponent::EscMotorControlComponent(const rclcpp::NodeOptions& op
   RCLCPP_INFO(this->get_logger(), "PWM backend: %s", pwm_ ? pwm_->name().c_str() : "none");
   RCLCPP_INFO(this->get_logger(), "Test Mode: %s", test_mode_ ? "true" : "false");
   RCLCPP_INFO(this->get_logger(), "Status topic: %s", status_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Emergency topic: %s", emergency_status_topic_.c_str());
   RCLCPP_INFO(this->get_logger(), "Pulse range: %d - %d μs  (neutral %d μs)", min_pulse_width_us_,
               max_pulse_width_us_, neutral_pulse_width_us_);
 
@@ -286,12 +273,6 @@ void EscMotorControlComponent::publish_status() {
   auto status_msg = std_msgs::msg::Float32();
   status_msg.data = static_cast<float>(current_speed_);
   status_pub_->publish(status_msg);
-
-  // Deprecated: /roller_emergency_status は /emergency_stop の active フラグをミラーする
-  // だけの互換出力。1リリースだけ並行 publish し、次リリースで削除予定。
-  auto emergency_msg = std_msgs::msg::Bool();
-  emergency_msg.data = emergency_stop_active_;
-  emergency_pub_->publish(emergency_msg);
 }
 
 }  // namespace esc_motor_control_cpp

--- a/launcher/config/drive_component.yaml
+++ b/launcher/config/drive_component.yaml
@@ -63,9 +63,6 @@ drive_component:
     # 型付きステータス出力先（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
     # 左右モータの電流/速度/位置/fault を型付きで確認したいときはこちらを echo してください。
     typed_status_topic: "/drive_status"
-    # 旧 String(JSON) ステータス出力先（deprecated, #87。1リリース並行 publish 後に削除予定）。
-    # 新規購読は typed_status_topic を使ってください。
-    status_topic: "/drive_motor_status"
 
     # 統一緊急停止トピック（questix_msgs/EmergencyStop, reliable + transient_local）。
     # active=true 受信で即時停止＋twist 無視、active=false で twist 受付を再開する

--- a/motor_control_app/config/drive_component.yaml
+++ b/motor_control_app/config/drive_component.yaml
@@ -63,9 +63,6 @@ drive_component:
     # 型付きステータス出力先（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
     # 左右モータの電流/速度/位置/fault を型付きで確認したいときはこちらを echo してください。
     typed_status_topic: "/drive_status"
-    # 旧 String(JSON) ステータス出力先（deprecated, #87。1リリース並行 publish 後に削除予定）。
-    # 新規購読は typed_status_topic を使ってください。
-    status_topic: "/drive_motor_status"
 
     # 統一緊急停止トピック（questix_msgs/EmergencyStop, reliable + transient_local）。
     # active=true 受信で即時停止＋twist 無視、active=false で twist 受付を再開する

--- a/motor_control_app/config/joy_axis_drive_params.yaml
+++ b/motor_control_app/config/joy_axis_drive_params.yaml
@@ -24,7 +24,6 @@ joy_axis_drive:
 
     # パブリッシュ設定
     # 型付き questix_msgs/DriveStatus を joy_axis_drive_status へ publish する
-    # （車輪ジオメトリを持たないため linear/angular_velocity は 0.0）。旧 String(JSON) の
-    # motor_status は deprecated（#87、1リリース並行 publish 後に削除予定）。
+    # （車輪ジオメトリを持たないため linear/angular_velocity は 0.0）。
     status_publish_rate: 10.0 # ステータスパブリッシュ頻度 [Hz]
     publish_twist: true # デバッグ用Twistメッセージをパブリッシュするか

--- a/motor_control_app/config/single_ddt_motor_config.yaml
+++ b/motor_control_app/config/single_ddt_motor_config.yaml
@@ -21,6 +21,5 @@ single_ddt_motor_node:
 
     # ステータス公開設定
     # 型付き questix_msgs/MotorFeedback を single_ddt_motor_feedback（launch で
-    # /single_ddt_motor_feedback に remap）へ publish する。旧 String の /motor_status は
-    # deprecated（#87、1リリース並行 publish 後に削除予定）。契約: questix_msgs/README.md。
+    # /single_ddt_motor_feedback に remap）へ publish する。契約: questix_msgs/README.md。
     status_publish_rate: 5.0  # Hz

--- a/motor_control_app/include/motor_control_app/drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/drive_component.hpp
@@ -19,7 +19,6 @@
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
-#include "std_msgs/msg/string.hpp"
 
 namespace motor_control_app {
 
@@ -131,8 +130,6 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
   // lifecycle 状態に依存せず常時生かす（コンストラクタで作成、on_cleanup でも破棄しない）
   rclcpp::Subscription<questix_msgs::msg::EmergencyStop>::SharedPtr emergency_stop_sub_;
-  // 旧 String ステータス（JSON）。1リリース並行 publish 後に削除予定（deprecated, #87）。
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr status_publisher_;
   // 型付きステータス（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
   rclcpp_lifecycle::LifecyclePublisher<questix_msgs::msg::DriveStatus>::SharedPtr
       typed_status_publisher_;
@@ -153,7 +150,6 @@ private:
   int right_motor_id_;
   int max_motor_rpm_;
   double status_publish_rate_;
-  std::string status_topic_;        // 旧 String JSON トピック（deprecated, #87）
   std::string typed_status_topic_;  // 型付き DriveStatus トピック
   // 統一緊急停止トピック（空文字で連動無効）。コンストラクタで一度だけ読む。
   std::string emergency_stop_topic_;

--- a/motor_control_app/include/motor_control_app/joy_axis_drive_component.hpp
+++ b/motor_control_app/include/motor_control_app/joy_axis_drive_component.hpp
@@ -15,7 +15,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "sensor_msgs/msg/joy.hpp"
-#include "std_msgs/msg/string.hpp"
 
 namespace motor_control_app {
 
@@ -74,8 +73,6 @@ private:
 
   // ROS 2パブリッシャー/サブスクライバー
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
-  // 旧 String ステータス（JSON）。1リリース並行 publish 後に削除予定（deprecated, #87）。
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
   // 型付きステータス（questix_msgs/DriveStatus）。契約は questix_msgs/README.md。
   rclcpp::Publisher<questix_msgs::msg::DriveStatus>::SharedPtr drive_status_publisher_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_publisher_;  // デバッグ用

--- a/motor_control_app/include/motor_control_app/single_ddt_motor_component.hpp
+++ b/motor_control_app/include/motor_control_app/single_ddt_motor_component.hpp
@@ -14,7 +14,6 @@
 #include "questix_msgs/msg/motor_feedback.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "std_msgs/msg/string.hpp"
 
 namespace motor_control_app {
 
@@ -69,8 +68,6 @@ private:
 
   // ROS 2 通信
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscription_;
-  // 旧 String ステータス（自由文）。1リリース並行 publish 後に削除予定（deprecated, #87）。
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr status_publisher_;
   // 型付きステータス（questix_msgs/MotorFeedback）。契約は questix_msgs/README.md。
   rclcpp::Publisher<questix_msgs::msg::MotorFeedback>::SharedPtr feedback_publisher_;
   rclcpp::TimerBase::SharedPtr status_timer_;

--- a/motor_control_app/launch/single_ddt_motor.launch.py
+++ b/motor_control_app/launch/single_ddt_motor.launch.py
@@ -33,7 +33,6 @@ def generate_launch_description():
         parameters=[LaunchConfiguration('config_file')],
         remappings=[
             ('cmd_vel', '/cmd_vel'),
-            ('motor_status', '/motor_status'),
             ('single_ddt_motor_feedback', '/single_ddt_motor_feedback'),
         ],
     )

--- a/motor_control_app/launch/single_ddt_motor.launch.xml
+++ b/motor_control_app/launch/single_ddt_motor.launch.xml
@@ -28,7 +28,6 @@
     <param name="status_publish_rate" value="5.0" />
     <param name="watchdog_timeout" value="1.0" />
     <remap from="cmd_vel" to="/cmd_vel" />
-    <remap from="motor_status" to="/motor_status" />
     <remap from="single_ddt_motor_feedback" to="/single_ddt_motor_feedback" />
   </node>
 </launch>

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -14,7 +14,6 @@
     <depend>rclcpp_components</depend>
     <depend>rclcpp_lifecycle</depend>
     <depend>lifecycle_msgs</depend>
-    <depend>std_msgs</depend>
     <depend>geometry_msgs</depend>
     <depend>sensor_msgs</depend>
     <depend>motor_control_lib</depend>

--- a/motor_control_app/src/drive_component.cpp
+++ b/motor_control_app/src/drive_component.cpp
@@ -158,7 +158,6 @@ DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecyc
   RCLCPP_INFO(this->get_logger(), "  right_motor_id: %d", right_motor_id_);
   RCLCPP_INFO(this->get_logger(), "  max_motor_rpm: %d", max_motor_rpm_);
   RCLCPP_INFO(this->get_logger(), "  status_publish_rate: %.1f", status_publish_rate_);
-  RCLCPP_INFO(this->get_logger(), "  status_topic: %s (deprecated)", status_topic_.c_str());
   RCLCPP_INFO(this->get_logger(), "  typed_status_topic: %s", typed_status_topic_.c_str());
   RCLCPP_INFO(this->get_logger(), "  cmd_timeout_sec: %.2f", cmd_timeout_sec_);
   RCLCPP_INFO(this->get_logger(), "  control_mode: %s", control_mode_.c_str());
@@ -175,8 +174,6 @@ DriveComponent::CallbackReturn DriveComponent::on_configure(const rclcpp_lifecyc
       "/target_twist", 1, std::bind(&DriveComponent::twistCallback, this, std::placeholders::_1));
 
   // LifecyclePublisher のため on_activate まで publish は無効
-  // 旧 String JSON（deprecated, #87）と型付き DriveStatus を並行 publish する。
-  status_publisher_ = this->create_publisher<std_msgs::msg::String>(status_topic_, 1);
   typed_status_publisher_ =
       this->create_publisher<questix_msgs::msg::DriveStatus>(typed_status_topic_, 1);
 
@@ -242,7 +239,6 @@ DriveComponent::CallbackReturn DriveComponent::on_cleanup(const rclcpp_lifecycle
   status_timer_.reset();
   watchdog_timer_.reset();
   twist_subscription_.reset();
-  status_publisher_.reset();
   typed_status_publisher_.reset();
   shutdownMotorLib();
   RCLCPP_INFO(this->get_logger(), "Drive component cleaned up");
@@ -256,7 +252,6 @@ DriveComponent::CallbackReturn DriveComponent::on_shutdown(const rclcpp_lifecycl
   status_timer_.reset();
   watchdog_timer_.reset();
   twist_subscription_.reset();
-  status_publisher_.reset();
   typed_status_publisher_.reset();
   shutdownMotorLib();
   RCLCPP_INFO(this->get_logger(), "Drive component shut down");
@@ -269,7 +264,6 @@ DriveComponent::CallbackReturn DriveComponent::on_error(const rclcpp_lifecycle::
   status_timer_.reset();
   watchdog_timer_.reset();
   twist_subscription_.reset();
-  status_publisher_.reset();
   typed_status_publisher_.reset();
   shutdownMotorLib();
   if (auto_start_ && auto_start_timer_) {
@@ -289,8 +283,6 @@ void DriveComponent::declareParameters() {
   this->declare_parameter("right_motor_id", 2);
   this->declare_parameter("max_motor_rpm", 1000);
   this->declare_parameter("status_publish_rate", 10.0);
-  // 旧 String JSON トピック（deprecated, #87。次リリースで削除予定）
-  this->declare_parameter("status_topic", "/drive_motor_status");
   // 型付きステータストピック（questix_msgs/DriveStatus）
   this->declare_parameter("typed_status_topic", "/drive_status");
 
@@ -331,7 +323,6 @@ void DriveComponent::readParameters() {
   right_motor_id_ = this->get_parameter("right_motor_id").as_int();
   max_motor_rpm_ = this->get_parameter("max_motor_rpm").as_int();
   status_publish_rate_ = this->get_parameter("status_publish_rate").as_double();
-  status_topic_ = this->get_parameter("status_topic").as_string();
   typed_status_topic_ = this->get_parameter("typed_status_topic").as_string();
   control_mode_ = this->get_parameter("control_mode").as_string();
   current_kp_ = this->get_parameter("current_kp").as_double();
@@ -567,50 +558,6 @@ void DriveComponent::statusTimerCallback() {
     typed_msg.angular_velocity = status.current_angular_velocity;
     typed_msg.emergency_stop = emergency_stop_active_;
     typed_status_publisher_->publish(typed_msg);
-
-    // 以下は旧 String JSON（deprecated, #87。1リリース並行 publish 後に削除予定）。
-    // ステータス情報をJSON風の文字列として作成
-    std::string status_str =
-        "{"
-        "\"left_motor_id\":" +
-        std::to_string(status.left_motor_id) +
-        ","
-        "\"right_motor_id\":" +
-        std::to_string(status.right_motor_id) +
-        ","
-        "\"left_rpm\":" +
-        std::to_string(status.left_rpm) +
-        ","
-        "\"right_rpm\":" +
-        std::to_string(status.right_rpm) +
-        ","
-        "\"linear_velocity\":" +
-        std::to_string(status.current_linear_velocity) +
-        ","
-        "\"angular_velocity\":" +
-        std::to_string(status.current_angular_velocity) +
-        ","
-        "\"left_temperature\":" +
-        std::to_string(status.left_temperature) +
-        ","
-        "\"right_temperature\":" +
-        std::to_string(status.right_temperature) +
-        ","
-        "\"left_fault_code\":" +
-        std::to_string(status.left_fault_code) +
-        ","
-        "\"right_fault_code\":" +
-        std::to_string(status.right_fault_code) +
-        ","
-        "\"healthy\":" +
-        (status.is_healthy ? "true" : "false") +
-        ","
-        "\"emergency_stop\":" +
-        (emergency_stop_active_ ? "true" : "false") + "}";
-
-    auto status_msg = std_msgs::msg::String();
-    status_msg.data = status_str;
-    status_publisher_->publish(status_msg);
 
     RCLCPP_DEBUG(this->get_logger(), "Current velocity: linear=%.3f, angular=%.3f",
                  status.current_linear_velocity, status.current_angular_velocity);

--- a/motor_control_app/src/joy_axis_drive_component.cpp
+++ b/motor_control_app/src/joy_axis_drive_component.cpp
@@ -31,9 +31,7 @@ JoyAxisDriveComponent::JoyAxisDriveComponent(const rclcpp::NodeOptions& options)
   joy_subscription_ = this->create_subscription<sensor_msgs::msg::Joy>(
       "/joy", 1, std::bind(&JoyAxisDriveComponent::joyCallback, this, std::placeholders::_1));
 
-  // 旧 String（JSON, deprecated #87）と型付き DriveStatus を並行 publish する。
-  // 型付きは相対名を分離し、旧 motor_status との同名衝突を避ける。
-  status_publisher_ = this->create_publisher<std_msgs::msg::String>("motor_status", 10);
+  // 型付きステータス（questix_msgs/DriveStatus）を publish する。
   drive_status_publisher_ =
       this->create_publisher<questix_msgs::msg::DriveStatus>("joy_axis_drive_status", 10);
 
@@ -232,62 +230,8 @@ void JoyAxisDriveComponent::statusTimerCallback() {
     typed_msg.emergency_stop = emergency_stop_active_;
     drive_status_publisher_->publish(typed_msg);
 
-    // 以下は旧 String JSON（deprecated, #87。1リリース並行 publish 後に削除予定）。
-    // 左モータのステータスを取得
-    int left_rpm = 0;
-    uint8_t left_temperature = 0;
-    uint8_t left_fault_code = 0;
-    bool left_ok =
-        motor_lib_->getMotorStatus(left_motor_id_, left_rpm, left_temperature, left_fault_code);
-
-    // 右モータのステータスを取得
-    int right_rpm = 0;
-    uint8_t right_temperature = 0;
-    uint8_t right_fault_code = 0;
-    bool right_ok =
-        motor_lib_->getMotorStatus(right_motor_id_, right_rpm, right_temperature, right_fault_code);
-
-    bool is_healthy = left_ok && right_ok && motor_lib_->isHealthy();
-
-    // ステータス情報をJSON風の文字列として作成
-    std::string status_str =
-        "{"
-        "\"left_motor_id\":" +
-        std::to_string(left_motor_id_) +
-        ","
-        "\"right_motor_id\":" +
-        std::to_string(right_motor_id_) +
-        ","
-        "\"left_rpm\":" +
-        std::to_string(left_rpm) +
-        ","
-        "\"right_rpm\":" +
-        std::to_string(right_rpm) +
-        ","
-        "\"left_temperature\":" +
-        std::to_string(left_temperature) +
-        ","
-        "\"right_temperature\":" +
-        std::to_string(right_temperature) +
-        ","
-        "\"left_fault_code\":" +
-        std::to_string(left_fault_code) +
-        ","
-        "\"right_fault_code\":" +
-        std::to_string(right_fault_code) +
-        ","
-        "\"healthy\":" +
-        (is_healthy ? "true" : "false") +
-        ","
-        "\"emergency_stop\":" +
-        (emergency_stop_active_ ? "true" : "false") + "}";
-
-    auto status_msg = std_msgs::msg::String();
-    status_msg.data = status_str;
-    status_publisher_->publish(status_msg);
-
-    RCLCPP_DEBUG(this->get_logger(), "Motor status: left_rpm=%d, right_rpm=%d", left_rpm,
-                 right_rpm);
+    RCLCPP_DEBUG(this->get_logger(), "Motor status: left_rpm=%d, right_rpm=%d",
+                 typed_msg.left.velocity_rpm, typed_msg.right.velocity_rpm);
 
   } catch (const std::exception& e) {
     RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,

--- a/motor_control_app/src/single_ddt_motor_component.cpp
+++ b/motor_control_app/src/single_ddt_motor_component.cpp
@@ -35,10 +35,7 @@ SingleDdtMotorComponent::SingleDdtMotorComponent(const rclcpp::NodeOptions& opti
       rclcpp::QoS(10),
       std::bind(&SingleDdtMotorComponent::twistCallback, this, std::placeholders::_1));
 
-  // ステータスパブリッシャーを作成
-  // 旧 String（自由文, deprecated #87）と型付き MotorFeedback を並行 publish する。
-  // 型付きは相対名を分離し、旧 motor_status との同名衝突を避ける。
-  status_publisher_ = this->create_publisher<std_msgs::msg::String>("motor_status", 10);
+  // ステータスパブリッシャーを作成（型付き MotorFeedback）。
   feedback_publisher_ =
       this->create_publisher<questix_msgs::msg::MotorFeedback>("single_ddt_motor_feedback", 10);
 
@@ -191,29 +188,15 @@ void SingleDdtMotorComponent::statusTimerCallback() {
   motor_control_lib::DdtMotorLib::MotorFeedbackData fb;
   if (motor_lib_->getMotorFeedbackData(motor_id_, fb)) {
     feedback_publisher_->publish(toMotorFeedbackMsg(fb, this->now()));
-  }
-
-  int velocity_rpm = 0;
-  uint8_t temperature = 0;
-  uint8_t fault_code = 0;
-
-  if (motor_lib_->getMotorStatus(motor_id_, velocity_rpm, temperature, fault_code)) {
-    // 旧 String（自由文, deprecated #87）
-    auto status_msg = std_msgs::msg::String();
-    status_msg.data =
-        "Motor ID: " + std::to_string(motor_id_) + ", RPM: " + std::to_string(velocity_rpm) +
-        ", Temp: " + std::to_string(temperature) + "°C" + ", Fault: " + std::to_string(fault_code);
-
-    status_publisher_->publish(status_msg);
 
     // 故障コードをチェック
-    if (fault_code != 0) {
+    if (fb.fault_code != 0) {
       RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                           "Motor %d fault detected: code %d", motor_id_, fault_code);
+                           "Motor %d fault detected: code %d", motor_id_, fb.fault_code);
     }
   } else {
     RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                         "Failed to get motor status for motor %d", motor_id_);
+                         "Failed to get motor feedback for motor %d", motor_id_);
   }
 }
 

--- a/operation_manager/README.md
+++ b/operation_manager/README.md
@@ -8,9 +8,6 @@ Publishers:
   topic. One `DiagnosticStatus` (name `operation_manager: gpio_controllability`,
   hardware_id `gpio`) with `level` OK/ERROR and per-pin `KeyValue` entries
   (`pin_<N>_state`, `pin_<N>_age_sec`). Consumable by `rqt_runtime_monitor`.
-- `/gpio/controllable_diagnostic` (std_msgs/String): **deprecated (#87)**, replaced
-  by `/diagnostics`. Kept as a parallel free-text publish for one release, removed
-  next release. See `questix_msgs/README.md` 移行メモ.
 - `/emergency_stop` (questix_msgs/EmergencyStop, reliable + transient_local, keep-last(1)):
   unified emergency stop state, `active = !controllable`, published on every
   controllability evaluation (each GPIO update plus the 1 s timer heartbeat).

--- a/operation_manager/config/operation_manager.yaml
+++ b/operation_manager/config/operation_manager.yaml
@@ -3,8 +3,7 @@ operation_manager_node:
     monitored_pins: [27]
     timeout_seconds: 1.0
     # 診断は標準 diagnostic_msgs/DiagnosticArray を /diagnostics へ publish する
-    # （rqt_runtime_monitor が消費可）。旧 String の /gpio/controllable_diagnostic は
-    # deprecated（#87、1リリース並行 publish 後に削除予定）。契約: questix_msgs/README.md。
+    # （rqt_runtime_monitor が消費可）。契約: questix_msgs/README.md。
     # 統一緊急停止トピック (questix_msgs/EmergencyStop, reliable + transient_local)。
     # active = !controllable として毎評価時に発行される。契約: questix_msgs/README.md
     emergency_stop_topic: "/emergency_stop"

--- a/operation_manager/include/operation_manager/operation_manager_component.hpp
+++ b/operation_manager/include/operation_manager/operation_manager_component.hpp
@@ -12,7 +12,6 @@
 #include <questix_msgs/msg/emergency_stop.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
-#include <std_msgs/msg/string.hpp>
 #include <string>
 #include <vector>
 
@@ -32,8 +31,6 @@ private:
   std::map<unsigned int, rclcpp::Time> gpio_last_update_;
 
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr controllable_pub_;
-  // 旧 String 診断（自由文）。1リリース並行 publish 後に削除予定（deprecated, #87）。
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr diagnostic_pub_;
   // 標準診断集約トピック（rqt_runtime_monitor 等がそのまま消費できる）。
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
   rclcpp::Publisher<questix_msgs::msg::EmergencyStop>::SharedPtr emergency_stop_pub_;

--- a/operation_manager/src/operation_manager_component.cpp
+++ b/operation_manager/src/operation_manager_component.cpp
@@ -23,9 +23,6 @@ OperationManagerComponent::OperationManagerComponent(const rclcpp::NodeOptions& 
   emergency_stop_topic_ = this->get_parameter("emergency_stop_topic").as_string();
 
   controllable_pub_ = this->create_publisher<std_msgs::msg::Bool>("/gpio/controllable", 1);
-  // 旧 String 診断（deprecated, #87。次リリースで削除予定）と標準 DiagnosticArray を並行 publish。
-  diagnostic_pub_ =
-      this->create_publisher<std_msgs::msg::String>("/gpio/controllable_diagnostic", 1);
   diagnostics_pub_ =
       this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
   // Latched so late-joining subscribers immediately receive the current state
@@ -98,15 +95,7 @@ void OperationManagerComponent::evaluate_controllability() {
   out.data = controllable;
   controllable_pub_->publish(out);
 
-  std_msgs::msg::String diag_msg;
-  if (controllable) {
-    diag_msg.data = "controllable";
-  } else {
-    diag_msg.data = "not_controllable: " + diagnostic;
-  }
-  diagnostic_pub_->publish(diag_msg);
-
-  // 標準 DiagnosticArray（deprecated な自由文 String の置換, #87）。
+  // 標準 DiagnosticArray（rqt_runtime_monitor が設定なしで消費可）。
   status.level = controllable ? diagnostic_msgs::msg::DiagnosticStatus::OK
                               : diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   status.message = controllable ? "controllable" : "not_controllable: " + diagnostic;

--- a/questix_msgs/README.md
+++ b/questix_msgs/README.md
@@ -91,17 +91,16 @@ DDT M0602C の Protocol 1 応答フレームをデコードした 1 モータ分
 
 ## 移行メモ
 
-- ESC の `/roller_emergency_status`(`std_msgs/Bool`, transient_local)は
-  `/emergency_stop` の `active` のミラーとして 1 リリース並行 publish され、
-  次リリースで削除予定(deprecated)。新規購読は `/emergency_stop` を使うこと。
-- 旧 String ステータストピック(下記)は上表の型付きトピックへ移行済み。
-  互換のため 1 リリース並行 publish し、次リリースで削除予定(deprecated, #87)。
-  | 旧トピック | 型 | 発行元 | 置換先 |
+- 旧 String ステータストピックと ESC の `/roller_emergency_status`(`std_msgs/Bool`)は
+  v2.2.0 で上表の型付きトピックと 1 リリース並行 publish したのち削除済み(#87)。
+  購読は下表の置換先を使うこと。
+  | 削除された旧トピック | 型 | 発行元 | 置換先 |
   |---|---|---|---|
   | `/drive_motor_status` | `std_msgs/String`(JSON) | `drive_component` | `/drive_status` |
   | `motor_status` | `std_msgs/String`(自由文) | `single_ddt_motor` | `single_ddt_motor_feedback` |
   | `motor_status` | `std_msgs/String`(JSON) | `joy_axis_drive` | `joy_axis_drive_status` |
   | `/gpio/controllable_diagnostic` | `std_msgs/String`(自由文) | `operation_manager` | `/diagnostics` |
+  | `/roller_emergency_status` | `std_msgs/Bool`(transient_local) | `esc_motor_control` | `/emergency_stop`(`active`) |
 - `joy_gate` は従来どおり `/gpio/controllable` を購読する(スコープ外)。
 - drive_component の受信 staleness タイムアウトは未実装
   (既存のコマンド watchdog と物理電源断がフェイルセーフを担う)。


### PR DESCRIPTION
## 背景

PR #127 (v2.2.0 収録) で String ステータストピック4本を型付きメッセージへ移行し、互換のため1リリース並行 publish していた。v2.2.0 リリースが完了し削除条件を満たしたため、deprecated トピックを削除する (#87)。

同じ「1リリース並行 publish 後に削除」期限だった ESC の Bool ミラー `/roller_emergency_status` (#125 由来) も、削除タイミングが一致するため同一 PR で削除する。

リポジトリ内にこれら旧トピックの購読者は存在しない (消費者は `ros2 topic echo` / rosbag のみ、#87 で確認済み)。

## 削除したトピック

| 削除した旧トピック | 発行元 | 残した置換先 |
|---|---|---|
| `/drive_motor_status` (`std_msgs/String` JSON) | `drive_component` | `/drive_status` (`DriveStatus`) |
| `motor_status` (`std_msgs/String` 自由文) | `single_ddt_motor` | `single_ddt_motor_feedback` (`MotorFeedback`) |
| `motor_status` (`std_msgs/String` JSON) | `joy_axis_drive` | `joy_axis_drive_status` (`DriveStatus`) |
| `/gpio/controllable_diagnostic` (`std_msgs/String`) | `operation_manager` | `/diagnostics` (`diagnostic_msgs/DiagnosticArray`) |
| `/roller_emergency_status` (`std_msgs/Bool`) | `esc_motor_control` | `/emergency_stop` の `active` (`EmergencyStop`) |

## 変更内容

- 各ノードから旧 String / Bool publisher とその生成・reset・パラメータ宣言・config キー・launch remap・README/コメントを削除。型付きトピックのみを残す。
- `single_ddt_motor` の fault 警告を型付きフィードバック (`fb.fault_code`) ベースへ、`joy_axis_drive` の debug ログを `typed_msg` ベースへ付け替えて機能を維持。
- `operation_manager` は標準 `DiagnosticArray` のみを残す。
- 使用箇所がなくなった `std_msgs` 依存を `motor_control_app/package.xml` から除去 (ESC は Float32、operation_manager は Bool で使用継続のため据え置き)。
- `questix_msgs/README.md` の移行メモを「並行 publish 後に削除済み」の完了形へ更新。

**23 files changed, 16 insertions(+), 216 deletions(-)**

## テスト

- `colcon build --symlink-install`: 6パッケージ成功 (stderr は既存の ament_auto_package 注意のみ)
- `colcon test`: 359 tests, 0 failures
- `ament_clang_format` (変更 C++ 全ファイル): divergence なし
- `git diff --check`: クリーン
- 残存参照 grep: deprecated コードの残りなし

## 実機検証 (Raspberry Pi 5)

- [ ] 起動して `ros2 topic list` で旧トピック (`/drive_motor_status` / `motor_status` / `/gpio/controllable_diagnostic` / `/roller_emergency_status`) が出ないこと
- [ ] 新トピック (`/drive_status` / `single_ddt_motor_feedback` / `joy_axis_drive_status` / `/diagnostics` / `/emergency_stop`) が従来どおり publish され続けること
- [ ] 走行・shot・Launcher 起動・e-stop 連動に副作用がないこと

## 関連

- Closes #87
- ESC ミラーの初出: #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)