### PR TITLE
chore: release 3.0.0

### DIFF
--- a/description_launch/CHANGELOG.rst
+++ b/description_launch/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package description_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package description_launch
+
 2.2.0 (2026-07-23)
 ------------------
 * Version bump only for package description_launch

--- a/description_launch/package.xml
+++ b/description_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>description_launch</name>
-  <version>2.2.0</version>
+  <version>3.0.0</version>
   <description>Questix description package</description>
   <maintainer email="manami.bean14@gmail.com">kajimame</maintainer>
   <license>MIT</license>

--- a/esc_motor_control_cpp/CHANGELOG.rst
+++ b/esc_motor_control_cpp/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package esc_motor_control_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)
+* Contributors: Akihisa Nagata
+
 2.2.0 (2026-07-23)
 ------------------
 * refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)

--- a/esc_motor_control_cpp/package.xml
+++ b/esc_motor_control_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>esc_motor_control_cpp</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>C++ ROS2 ESC motor control node with pigpio/lgpio backend support</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/gpio_reader/CHANGELOG.rst
+++ b/gpio_reader/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package gpio_reader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package gpio_reader
+
 2.2.0 (2026-07-23)
 ------------------
 * Version bump only for package gpio_reader

--- a/gpio_reader/package.xml
+++ b/gpio_reader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>gpio_reader</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>ROS2 package for reading GPIO values on Raspberry Pi 5</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_controller/CHANGELOG.rst
+++ b/joy_controller/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package joy_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package joy_controller
+
 2.2.0 (2026-07-23)
 ------------------
 * Version bump only for package joy_controller

--- a/joy_controller/package.xml
+++ b/joy_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_controller</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>Integrated Joy Controller for ROS2 with enhanced joystick functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_gate/CHANGELOG.rst
+++ b/joy_gate/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package joy_gate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package joy_gate
+
 2.2.0 (2026-07-23)
 ------------------
 * Version bump only for package joy_gate

--- a/joy_gate/package.xml
+++ b/joy_gate/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_gate</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>Joy message gating based on GPIO controllable status</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/launcher/CHANGELOG.rst
+++ b/launcher/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package questix_launcher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)
+* Contributors: Akihisa Nagata
+
 2.2.0 (2026-07-23)
 ------------------
 * refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>questix_launcher</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>Questix system launcher package with XML-based launch files</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/motor_control_app/CHANGELOG.rst
+++ b/motor_control_app/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package motor_control_app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)
+* Contributors: Akihisa Nagata
+
 2.2.0 (2026-07-23)
 ------------------
 * refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_app</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>Refactored motor control application using the new motor_control_lib</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib/CHANGELOG.rst
+++ b/motor_control_lib/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package motor_control_lib
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package motor_control_lib
+
 2.2.0 (2026-07-23)
 ------------------
 * refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)

--- a/motor_control_lib/package.xml
+++ b/motor_control_lib/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_lib</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>Motor control library with common interfaces for drive and shot functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib_simple/CHANGELOG.rst
+++ b/motor_control_lib_simple/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package motor_control_lib_simple
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package motor_control_lib_simple
+
 2.2.0 (2026-07-23)
 ------------------
 * Version bump only for package motor_control_lib_simple

--- a/motor_control_lib_simple/package.xml
+++ b/motor_control_lib_simple/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>motor_control_lib_simple</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>シンプルなモータ制御ライブラリ</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/operation_manager/CHANGELOG.rst
+++ b/operation_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package operation_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)
+* Contributors: Akihisa Nagata
+
 2.2.0 (2026-07-23)
 ------------------
 * refactor: migrate string status topics to typed messages (`#127 <https://github.com/scramble-robot/questix/issues/127>`_)

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>operation_manager</name>
-  <version>2.2.0</version>
+  <version>3.0.0</version>
   <description>Determine whether GPIO IO is controllable by subscribing to GPIO topics.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/questix_msgs/CHANGELOG.rst
+++ b/questix_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package questix_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)
+* Contributors: Akihisa Nagata
+
 2.2.0 (2026-07-23)
 ------------------
 * feat: add MotorFeedback and DriveStatus messages for the typed status-topic

--- a/questix_msgs/package.xml
+++ b/questix_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>questix_msgs</name>
-  <version>2.2.0</version>
+  <version>3.0.0</version>
   <description>Common message definitions for QUESTiX, including the unified emergency stop interface.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="robot-manager",
-    version="2.2.0",
+    version="3.0.0",
     packages=find_packages(),
     include_package_data=True,
     package_data={"robot_manager": ["static/*"]},

--- a/uart_joy_driver/CHANGELOG.rst
+++ b/uart_joy_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package uart_joy_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.0.0 (2026-07-23)
+------------------
+* Version bump only for package uart_joy_driver
+
 2.2.0 (2026-07-23)
 ------------------
 * Version bump only for package uart_joy_driver

--- a/uart_joy_driver/package.xml
+++ b/uart_joy_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>uart_joy_driver</name>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <description>UART serial joystick driver for Switch-style controllers. Reads 7-byte hex protocol from UART and publishes sensor_msgs/Joy.</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>


### PR DESCRIPTION
## リリース 3.0.0

2.2.0 以降にマージされた変更を反映し、全パッケージのバージョンを 2.2.0 → 3.0.0 に更新する。

### メジャーバンプの理由

deprecated だった並行 publish トピックの削除 (#130) は公開トピックインターフェイスの破壊的変更のため、メジャーバージョンを上げる。

削除されたトピック:
- `/drive_motor_status` (`drive_component`)
- `motor_status` (`single_ddt_motor` / `joy_axis_drive`)
- `/gpio/controllable_diagnostic` (`operation_manager`)
- `/roller_emergency_status` (`esc_motor_control`)

購読は型付き置換先 (`/drive_status` / `single_ddt_motor_feedback` / `joy_axis_drive_status` / `/diagnostics` / `/emergency_stop`) へ移行済み。詳細は `questix_msgs/README.md` の移行メモを参照。

### 変更内容

- 全 `package.xml` と `scripts/setup.py` のバージョンを 2.2.0 → 3.0.0 に更新
- 各 `CHANGELOG.rst` に 3.0.0 セクションを追加
  - 直接変更されたパッケージ (`motor_control_app` / `operation_manager` / `esc_motor_control_cpp` / `questix_launcher` / `questix_msgs`): #130 のエントリを記載
  - その他 (`description_launch` / `gpio_reader` / `joy_controller` / `joy_gate` / `motor_control_lib` / `motor_control_lib_simple` / `uart_joy_driver`): version bump only

25 files changed。バージョン文字列と CHANGELOG のみの変更で、コードの変更はなし。

### マージ後の手順

1. このPRをマージ
2. マージコミットに `3.0.0` タグを作成・push (過去リリースと同様、タグはマージコミットを指す)
3. 必要に応じて `Build ROS2 Robotics Kit ISO` ワークフロー (workflow_dispatch) を実行し ISO ビルド + GitHub Release を作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)