### PR TITLE
refactor: inject logger and accumulate modbus response in servo_control

### DIFF
--- a/motor_control_lib/include/motor_control_lib/servo_control.hpp
+++ b/motor_control_lib/include/motor_control_lib/servo_control.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <map>
+#include <rclcpp/logger.hpp>
 #include <string>
 
 namespace motor_control_lib {
@@ -82,8 +83,11 @@ public:
    * @brief コンストラクタ
    * @param port シリアルポート
    * @param baudrate ボーレート
+   * @param logger ログ出力に使用するロガー（呼び出し元ノードの get_logger() を注入可能）
    */
-  FeetechServoController(const std::string& port = "/dev/ttyUSB0", int baudrate = 115200);
+  FeetechServoController(
+      const std::string& port = "/dev/ttyUSB0", int baudrate = 115200,
+      const rclcpp::Logger& logger = rclcpp::get_logger("FeetechServoController"));
 
   virtual ~FeetechServoController();
 
@@ -109,6 +113,9 @@ private:
   int baudrate_;
   int serial_fd_;
   bool connected_;
+
+  // ログ出力用ロガー（デフォルトは "FeetechServoController"、コンストラクタで注入可能）
+  rclcpp::Logger logger_{rclcpp::get_logger("FeetechServoController")};
 
   // 既知のレジスタマップ
   std::map<uint16_t, RegisterInfo> known_registers_;

--- a/motor_control_lib/src/servo_control.cpp
+++ b/motor_control_lib/src/servo_control.cpp
@@ -14,7 +14,9 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
-#include <iostream>
+#include <iomanip>
+#include <rclcpp/logging.hpp>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -22,8 +24,9 @@
 
 namespace motor_control_lib {
 
-FeetechServoController::FeetechServoController(const std::string& port, int baudrate)
-    : port_(port), baudrate_(baudrate), serial_fd_(-1), connected_(false) {
+FeetechServoController::FeetechServoController(const std::string& port, int baudrate,
+                                               const rclcpp::Logger& logger)
+    : port_(port), baudrate_(baudrate), serial_fd_(-1), connected_(false), logger_(logger) {
   initializeRegisterMap();
 }
 
@@ -33,7 +36,7 @@ bool FeetechServoController::connect() {
   // シリアルポートを開く
   serial_fd_ = open(port_.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
   if (serial_fd_ == -1) {
-    std::cerr << "Failed to open serial port: " << port_ << " - " << strerror(errno) << std::endl;
+    RCLCPP_ERROR(logger_, "Failed to open serial port: %s - %s", port_.c_str(), strerror(errno));
     return false;
   }
 
@@ -69,7 +72,7 @@ bool FeetechServoController::connect() {
       speed = B921600;
       break;
     default:
-      std::cerr << "Unsupported baudrate: " << baudrate_ << std::endl;
+      RCLCPP_ERROR(logger_, "Unsupported baudrate: %d", baudrate_);
       close(serial_fd_);
       return false;
   }
@@ -105,7 +108,7 @@ bool FeetechServoController::connect() {
   options.c_cc[VTIME] = 100;  // タイムアウト（0.1秒単位、10秒）
 
   if (tcsetattr(serial_fd_, TCSANOW, &options) != 0) {
-    std::cerr << "Failed to set serial attributes: " << strerror(errno) << std::endl;
+    RCLCPP_ERROR(logger_, "Failed to set serial attributes: %s", strerror(errno));
     close(serial_fd_);
     return false;
   }
@@ -116,25 +119,23 @@ bool FeetechServoController::connect() {
   // RS485設定確認
   int status;
   ioctl(serial_fd_, TIOCMGET, &status);
-  std::cout << "Serial port status: 0x" << std::hex << status << std::dec << std::endl;
+  RCLCPP_DEBUG(logger_, "Serial port status: 0x%x", status);
 
   connected_ = true;
-  std::cout << "Connected to servo controller: " << port_ << " @ " << baudrate_ << " bps"
-            << std::endl;
+  RCLCPP_INFO(logger_, "Connected to servo controller: %s @ %d bps", port_.c_str(), baudrate_);
   return true;
 }
 
 int32_t FeetechServoController::getCurrentPosition(uint8_t servo_id) {
-  std::cout << "Reading current position for servo " << static_cast<int>(servo_id) << "..."
-            << std::endl;
+  RCLCPP_DEBUG(logger_, "Reading current position for servo %d...", static_cast<int>(servo_id));
 
   // Read Present Position (register 257 according to initializeRegisterMap)
   int32_t position = readRegister(servo_id, 257);
 
   if (position != -1) {
-    std::cout << "Position read successfully: " << position << std::endl;
+    RCLCPP_DEBUG(logger_, "Position read successfully: %d", position);
   } else {
-    std::cout << "Failed to read position" << std::endl;
+    RCLCPP_ERROR(logger_, "Failed to read position");
   }
 
   return position;
@@ -145,7 +146,7 @@ void FeetechServoController::disconnect() {
     close(serial_fd_);
     serial_fd_ = -1;
     connected_ = false;
-    std::cout << "Disconnected from servo controller" << std::endl;
+    RCLCPP_INFO(logger_, "Disconnected from servo controller");
   }
 }
 
@@ -155,17 +156,19 @@ int FeetechServoController::sendCommand(const uint8_t* cmd_bytes, size_t cmd_len
                                         uint8_t* response, size_t max_response_length,
                                         bool expect_response) {
   if (!connected_ || serial_fd_ == -1) {
+    RCLCPP_ERROR(logger_, "Not connected to servo controller");
     return -1;
   }
 
   try {
-    // デバッグ: 送信コマンドを表示（高速コマンド時は出力を削減）
+    // デバッグ: 送信コマンドを16進ダンプ（高速コマンド時は出力を削減）
     if (cmd_bytes[1] != 6) {  // 書き込みコマンド以外のみ表示
-      std::cout << "Sending command: ";
+      std::ostringstream oss;
+      oss << std::hex << std::uppercase << std::setfill('0');
       for (size_t i = 0; i < cmd_length; i++) {
-        printf("%02X ", cmd_bytes[i]);
+        oss << std::setw(2) << static_cast<int>(cmd_bytes[i]) << ' ';
       }
-      std::cout << std::endl;
+      RCLCPP_DEBUG(logger_, "Sending command: %s", oss.str().c_str());
     }
 
     // バッファクリア
@@ -175,13 +178,14 @@ int FeetechServoController::sendCommand(const uint8_t* cmd_bytes, size_t cmd_len
     int rts = TIOCM_RTS;
     ioctl(serial_fd_, TIOCMBIS, &rts);  // RTS有効
 
-    // RTS制御後の短い待機（通信安定化）
+    // RTS制御後の短い待機（通信安定化）: RTS 立ち上げ後にドライバが送信方向へ
+    // 切り替わるまでの安定化待ち。挙動維持のため据え置き（500us）。
     std::this_thread::sleep_for(std::chrono::microseconds(500));
 
     // コマンド送信
     ssize_t bytes_written = write(serial_fd_, cmd_bytes, cmd_length);
     if (bytes_written != static_cast<ssize_t>(cmd_length)) {
-      std::cerr << "Failed to write complete command" << std::endl;
+      RCLCPP_ERROR(logger_, "Failed to write complete command");
       ioctl(serial_fd_, TIOCMBIC, &rts);  // RTS無効（エラー時も必ず実行）
       return -1;
     }
@@ -189,7 +193,8 @@ int FeetechServoController::sendCommand(const uint8_t* cmd_bytes, size_t cmd_len
     // 送信完了待機
     tcdrain(serial_fd_);
 
-    // 送信後の待機時間を延長（高速コマンドに対応）
+    // 送信後の待機（tcdrain 後もドライバ側 FIFO が空になるまでのマージン）。
+    // 挙動維持のため据え置き（2ms）。
     std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
     // RS485受信制御
@@ -199,67 +204,113 @@ int FeetechServoController::sendCommand(const uint8_t* cmd_bytes, size_t cmd_len
       return 0;
     }
 
-    // 応答受信待機（高速コマンドに対応して待機時間を調整）
+    // 応答受信待機（サーボが応答を返し始めるまでのターンアラウンド待ち）。
+    // TODO(#89): 読み溜め化により縮小検討可。実機タイミング依存のため据え置き（5ms）。
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
-    // 応答受信（ブロッキング読み取りに変更）
-    ssize_t bytes_read = 0;
-    int retry_count = 0;
-    const int max_retries = 3;  // リトライ回数を削減
+    // 応答受信: RS485 では応答フレームが分割到着し得るため、期待長に達するまで
+    // select() でタイムアウト監視しつつ read() を累積する。
+    // 期待応答長は Modbus ファンクションコードから算出:
+    //   read (0x03) : [ID][03][byte_count][data...][CRC_L][CRC_H] = 3 + byte_count + 2
+    //                 （本コードの read は 1 レジスタ=2 バイトなので既定 7 バイト。
+    //                  3 バイト目 byte_count 受信後に 3 + byte_count + 2 で再確定）
+    //   write(0x06) : [ID][06][addr_H][addr_L][val_H][val_L][CRC_L][CRC_H] = 8 バイト
+    //   error       : [ID][func|0x80][err][CRC_L][CRC_H] = 5 バイト（func の bit7 で検出）
+    const uint8_t function_code = cmd_bytes[1];
+    size_t expected_length = (function_code == 3) ? 7 : 8;  // read=7 / write=8 を初期値
+    if (expected_length > max_response_length) {
+      expected_length = max_response_length;
+    }
 
-    while (retry_count < max_retries && bytes_read <= 0) {
-      // タイムアウト付きブロッキング読み取り
+    // 全体タイムアウト: 従来の 500ms x 最大 3 リトライ相当を上限として維持する。
+    const auto overall_deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1500);
+
+    size_t total = 0;
+    bool timed_out = false;
+    bool error_frame = false;
+
+    while (total < expected_length) {
+      auto now = std::chrono::steady_clock::now();
+      if (now >= overall_deadline) {
+        timed_out = true;
+        break;
+      }
+      auto remaining =
+          std::chrono::duration_cast<std::chrono::microseconds>(overall_deadline - now);
+
       fd_set read_fds;
       struct timeval timeout_val;
       FD_ZERO(&read_fds);
       FD_SET(serial_fd_, &read_fds);
-      timeout_val.tv_sec = 0;
-      timeout_val.tv_usec = 500000;  // 500ms（高速コマンド対応でタイムアウトを短縮）
+      timeout_val.tv_sec = remaining.count() / 1000000;
+      timeout_val.tv_usec = remaining.count() % 1000000;
 
       int select_result = select(serial_fd_ + 1, &read_fds, NULL, NULL, &timeout_val);
       if (select_result > 0 && FD_ISSET(serial_fd_, &read_fds)) {
-        bytes_read = read(serial_fd_, response, max_response_length);
-      } else if (select_result == 0) {
-        std::cout << "Read timeout on attempt " << (retry_count + 1) << std::endl;
-      } else {
-        std::cerr << "Select error: " << strerror(errno) << std::endl;
-      }
+        ssize_t n = read(serial_fd_, response + total, max_response_length - total);
+        if (n > 0) {
+          total += static_cast<size_t>(n);
 
-      if (bytes_read <= 0) {
-        retry_count++;
-        if (retry_count < max_retries) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(20));  // リトライ間隔を短縮
+          // 2 バイト目まで受信したらファンクションコードを確認し、
+          // エラーレスポンス（bit7 立ち）なら期待長を 5 バイトへ切り替える。
+          if (!error_frame && total >= 2 && (response[1] & 0x80)) {
+            error_frame = true;
+            expected_length = 5;
+            if (expected_length > max_response_length) {
+              expected_length = max_response_length;
+            }
+          }
+
+          // read レスポンスは 3 バイト目 byte_count 確定後に期待長を再計算する。
+          if (!error_frame && function_code == 3 && total >= 3) {
+            size_t recalculated = 3 + static_cast<size_t>(response[2]) + 2;
+            expected_length =
+                (recalculated <= max_response_length) ? recalculated : max_response_length;
+          }
+        } else if (n == 0) {
+          // EOF 相当（切断など）。これ以上読めないためループを終了。
+          break;
+        } else {
+          RCLCPP_ERROR(logger_, "Read error: %s", strerror(errno));
+          break;
         }
+      } else if (select_result == 0) {
+        RCLCPP_WARN(logger_, "Read timeout while waiting for response (received %zu/%zu bytes)",
+                    total, expected_length);
+        timed_out = true;
+        break;
+      } else {
+        RCLCPP_ERROR(logger_, "Select error: %s", strerror(errno));
+        break;
       }
     }
-    if (bytes_read > 0) {
-      // デバッグ: 受信レスポンスを表示（読み取りコマンドのみ）
-      if (cmd_bytes[1] == 3) {  // 読み取りコマンドのみ表示
-        std::cout << "Received response (" << bytes_read << " bytes): ";
-        for (ssize_t i = 0; i < bytes_read; i++) {
-          printf("%02X ", response[i]);
-        }
-        std::cout << std::endl;
-      }
 
-      // チェックサム検証
-      if (feetech_protocol::verifyChecksum(response, bytes_read)) {
-        return bytes_read;
-      } else {
-        std::cerr << "Checksum verification failed" << std::endl;
-        return -1;
-      }
-    } else {
-      std::cerr << "No response received after " << max_retries
-                << " attempts. bytes_read = " << bytes_read << std::endl;
-      if (bytes_read < 0) {
-        std::cerr << "Read error: " << strerror(errno) << std::endl;
-      }
+    if (total == 0) {
+      RCLCPP_ERROR(logger_, "No response received (timeout=%s)", timed_out ? "true" : "false");
       return -1;
     }
 
+    // デバッグ: 受信レスポンスを16進ダンプ（読み取りコマンドのみ）
+    if (function_code == 3) {
+      std::ostringstream oss;
+      oss << std::hex << std::uppercase << std::setfill('0');
+      for (size_t i = 0; i < total; i++) {
+        oss << std::setw(2) << static_cast<int>(response[i]) << ' ';
+      }
+      RCLCPP_DEBUG(logger_, "Received response (%zu bytes): %s", total, oss.str().c_str());
+    }
+
+    // チェックサム検証（累積した total バイトに対して実施）
+    if (feetech_protocol::verifyChecksum(response, total)) {
+      return static_cast<int>(total);
+    }
+
+    RCLCPP_ERROR(logger_, "Checksum verification failed (received %zu bytes)", total);
+    return -1;
+
   } catch (const std::exception& e) {
-    std::cerr << "Communication error: " << e.what() << std::endl;
+    RCLCPP_ERROR(logger_, "Communication error: %s", e.what());
     return -1;
   }
 }
@@ -279,16 +330,14 @@ int32_t FeetechServoController::readRegister(uint8_t servo_id, uint16_t address)
     // Modbus読み取りレスポンス: [ID][03][バイト数][データH][データL][CRCL][CRCH]
     // レジスタ値を抽出（ビッグエンディアン）
     uint16_t value = (response[3] << 8) | response[4];
-    std::cout << "Read register " << address << " = " << value << " (0x" << std::hex << value
-              << std::dec << ")" << std::endl;
+    RCLCPP_DEBUG(logger_, "Read register %u = %u (0x%X)", address, value, value);
     return static_cast<int32_t>(value);
   } else if (response_length > 0 && (response[1] & 0x80)) {
     // エラーレスポンス
-    std::cerr << "Error response: 0x" << std::hex << static_cast<int>(response[1]) << std::dec
-              << std::endl;
+    RCLCPP_ERROR(logger_, "Error response: 0x%X", static_cast<int>(response[1]));
     return -1;
   } else {
-    std::cerr << "Invalid response length: " << response_length << std::endl;
+    RCLCPP_ERROR(logger_, "Invalid response length: %d", response_length);
     return -1;
   }
 }
@@ -310,16 +359,15 @@ bool FeetechServoController::writeRegister(uint8_t servo_id, uint16_t address, u
     uint16_t echo_value = (response[4] << 8) | response[5];
 
     bool success = (echo_addr == address && echo_value == value);
-    std::cout << "Write register " << address << " = " << value << " -> "
-              << (success ? "SUCCESS" : "FAILED") << std::endl;
+    RCLCPP_DEBUG(logger_, "Write register %u = %u -> %s", address, value,
+                 success ? "SUCCESS" : "FAILED");
     return success;
   } else if (response_length > 0 && (response[1] & 0x80)) {
     // エラーレスポンス
-    std::cerr << "Write error response: 0x" << std::hex << static_cast<int>(response[1]) << std::dec
-              << std::endl;
+    RCLCPP_ERROR(logger_, "Write error response: 0x%X", static_cast<int>(response[1]));
     return false;
   } else {
-    std::cerr << "Invalid write response length: " << response_length << std::endl;
+    RCLCPP_ERROR(logger_, "Invalid write response length: %d", response_length);
     return false;
   }
 }
@@ -327,27 +375,27 @@ bool FeetechServoController::writeRegister(uint8_t servo_id, uint16_t address, u
 bool FeetechServoController::setPosition(uint8_t servo_id, uint16_t position, bool enable_torque,
                                          double timeout) {
   if (!connected_) {
-    std::cerr << "Not connected to servo controller" << std::endl;
+    RCLCPP_ERROR(logger_, "Not connected to servo controller");
     return false;
   }
 
-  std::cout << "Setting position for servo " << static_cast<int>(servo_id) << " to " << position
-            << std::endl;
+  RCLCPP_DEBUG(logger_, "Setting position for servo %d to %u", static_cast<int>(servo_id),
+               position);
 
   try {
     // 位置コマンド送信（応答確認を簡素化）
     if (!writeRegister(servo_id, 128, position)) {  // Goal Position
-      std::cerr << "Failed to set position for servo " << static_cast<int>(servo_id) << std::endl;
+      RCLCPP_ERROR(logger_, "Failed to set position for servo %d", static_cast<int>(servo_id));
       return false;
     }
 
     // 高速コマンド対応：位置確認は省略して迅速に処理
-    std::cout << "Position set successfully for servo " << static_cast<int>(servo_id) << " to "
-              << position << std::endl;
+    RCLCPP_DEBUG(logger_, "Position set successfully for servo %d to %u",
+                 static_cast<int>(servo_id), position);
     return true;
 
   } catch (const std::exception& e) {
-    std::cerr << "setPosition error: " << e.what() << std::endl;
+    RCLCPP_ERROR(logger_, "setPosition error: %s", e.what());
     return false;
   }
 }


### PR DESCRIPTION
## 背景 (issue #89 PR3)

`motor_control_lib` の `FeetechServoController` は品質面で3点の課題があった。

1. **ロガー化**: 診断出力が `std::cout` / `std::cerr` / `printf` の直接出力で、ROS 2 のログ基盤に乗っていなかった。同 lib の `DdtMotorLib` は既に `rclcpp::Logger logger_` パターンを採用済み。
2. **分割到着バグ (最重要)**: `sendCommand` の受信は `read()` 1回の戻り値を応答フレーム全体とみなしていた。リトライループは「0バイト時のみ再試行」で、`0 < bytes_read < 期待長` の部分受信を継続読み取りしなかった。RS485 半二重ではフレームが分割到着し得るため、`verifyChecksum` が誤って失敗する。
3. **固定スリープ**: RTS 制御・送信完了・応答待ちの固定待機に意図コメントが無く、値の妥当性が追いにくかった。

## 変更点

### ロガー注入
- `servo_control.hpp`: `#include <rclcpp/logger.hpp>` 追加。private メンバ `rclcpp::Logger logger_{rclcpp::get_logger("FeetechServoController")};` を追加。コンストラクタに **optional な logger 引数**を追加（デフォルト `rclcpp::get_logger("FeetechServoController")`）。基底 `ServoControllerBase` は不変。
- `servo_control.cpp`: `<iostream>` を削除し `<rclcpp/logging.hpp>` / `<iomanip>` / `<sstream>` を追加。コンストラクタ初期化子で `logger_(logger)` を設定（AGENTS.md: 新規メンバは初期化子で初期化）。全ての `std::cout` / `std::cerr` / `printf` を `RCLCPP_*` に置換:
  - ERROR: open/tcsetattr/write 失敗、checksum 失敗、select/read error、error response、invalid length、not connected、setPosition 失敗
  - WARN: 応答待ちタイムアウト
  - INFO: 接続 / 切断メッセージ
  - DEBUG: 送受信 HEX ダンプ（`std::ostringstream` で1行の16進文字列に組み立て）、コマンドトレース（Read/Write register、Setting position 等）、port status
- `printf` は残置ゼロ（`grep -n "std::cout\|std::cerr\|printf\|iostream"` が空であることを確認）。
- `motor_control_lib/package.xml` は既に `<depend>rclcpp</depend>` を持つため追加不要（確認のみ）。

### Modbus 応答の期待長読み溜め
`sendCommand` の受信を、**期待長に達するまで `select()` でタイムアウト監視しつつ `read()` を累積**する形へ書き換え。累積バッファへ `response + total` オフセットで追記する。

期待応答長は Modbus ファンクションコード（`cmd_bytes[1]`）から算出:
- **read (0x03) = 7 バイト**: `[ID][03][byte_count][data...][CRC_L][CRC_H]` = `3 + byte_count + 2`。本コードの read は 1 レジスタ (2 バイト) なので既定 7。3 バイト目 `byte_count` 受信後に `3 + resp[2] + 2` で期待長を再確定（汎用化）。
- **write (0x06) = 8 バイト**: `[ID][06][addr_H][addr_L][val_H][val_L][CRC_L][CRC_H]`。既存 `writeRegister` の `response_length >= 6 && response[1] == 6` 判定と整合。
- **error = 5 バイト**: `[ID][func|0x80][err][CRC_L][CRC_H]`。2 バイト目受信後に `response[1] & 0x80` を検出したら期待長を 5 へ切替。
- `length < 3` は `verifyChecksum` が false を返す既存契約に委ねる。

無限ループ防止のため全体タイムアウト（従来の 500ms×最大3リトライ相当を上限とする 1500ms デッドライン）を維持し、期待長到達 or タイムアウトで抜ける（AGENTS.md: retry ループはタイムアウトと明確な終了条件必須）。期待長ちょうどで読み止めることでフレーム境界を明確化。到達後 `feetech_protocol::verifyChecksum(response, total)` で検証し、成功なら `total` を返す。失敗/タイムアウトは `-1`。`sendCommand` の戻り値契約（応答長、失敗 -1）と呼び出し側 `readRegister` / `writeRegister` の応答解釈は不変。

### 固定スリープ (挙動維持)
`sleep_for` の値は変更せず意図コメントを付与:
- 500us: RTS 立ち上げ後の送信方向切替安定化待ち
- 2ms: `tcdrain` 後のドライバ FIFO マージン
- 5ms: 応答ターンアラウンド待ち。`// TODO(#89): 読み溜め化により縮小検討可。実機タイミング依存のため据え置き` を付与

（旧リトライ間隔 20ms は受信ループ書き換えに伴い、単一デッドライン方式へ統合された。）

### コンストラクタ logger 引数について
optional 引数のため、`shot_component.cpp` の既存呼び出し `std::make_shared<FeetechServoController>(port, baudrate)` は無変更で従来どおり動作する。`ShotComponent` は LifecycleNode なので、必要に応じ `this->get_logger()` を第3引数に渡してノード名前空間へログを集約できる。

## PR2 との関係
本 PR と PR2 はどちらも `servo_control.cpp` を編集する。コンフリクト回避のため **本 PR を先にマージする想定**。

## 検証
- `grep -n "std::cout\|std::cerr\|printf\|iostream" motor_control_lib/src/servo_control.cpp` → 空（残置ゼロ確認済み）
- `git diff --check` → クリーン
- `ament_clang_format --config .clang-format --reformat` を対象2ファイルへ適用済み（CI format-check 準拠）
- 期待長ロジックの境界（read=7 / error=5 / write=8 / length<3）とシグネチャ整合を目視確認
- `colcon build` は指示により未実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
