### PR TITLE
chore: release 3.1.0

### DIFF
--- a/description_launch/CHANGELOG.rst
+++ b/description_launch/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package description_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package description_launch
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package description_launch

--- a/description_launch/package.xml
+++ b/description_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>description_launch</name>
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <description>Questix description package</description>
   <maintainer email="manami.bean14@gmail.com">kajimame</maintainer>
   <license>MIT</license>

--- a/esc_motor_control_cpp/CHANGELOG.rst
+++ b/esc_motor_control_cpp/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package esc_motor_control_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package esc_motor_control_cpp
+
 3.0.0 (2026-07-23)
 ------------------
 * refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)

--- a/esc_motor_control_cpp/package.xml
+++ b/esc_motor_control_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>esc_motor_control_cpp</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>C++ ROS2 ESC motor control node with pigpio/lgpio backend support</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/gpio_reader/CHANGELOG.rst
+++ b/gpio_reader/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package gpio_reader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package gpio_reader
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package gpio_reader

--- a/gpio_reader/package.xml
+++ b/gpio_reader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>gpio_reader</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>ROS2 package for reading GPIO values on Raspberry Pi 5</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_controller/CHANGELOG.rst
+++ b/joy_controller/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package joy_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package joy_controller
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package joy_controller

--- a/joy_controller/package.xml
+++ b/joy_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_controller</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>Integrated Joy Controller for ROS2 with enhanced joystick functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/joy_gate/CHANGELOG.rst
+++ b/joy_gate/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package joy_gate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package joy_gate
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package joy_gate

--- a/joy_gate/package.xml
+++ b/joy_gate/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>joy_gate</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>Joy message gating based on GPIO controllable status</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/launcher/CHANGELOG.rst
+++ b/launcher/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package questix_launcher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* feat: publish wheel odometry and odom->base_link tf from drive component (`#132 <https://github.com/scramble-robot/questix/issues/132>`_)
+* refactor: unify drive_component config to launcher single source (`#133 <https://github.com/scramble-robot/questix/issues/133>`_)
+* Contributors: Akihisa Nagata
+
 3.0.0 (2026-07-23)
 ------------------
 * refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>questix_launcher</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>Questix system launcher package with XML-based launch files</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/motor_control_app/CHANGELOG.rst
+++ b/motor_control_app/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package motor_control_app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* feat: publish wheel odometry and odom->base_link tf from drive component (`#132 <https://github.com/scramble-robot/questix/issues/132>`_)
+* refactor: unify drive_component config to launcher single source (`#133 <https://github.com/scramble-robot/questix/issues/133>`_)
+* Contributors: Akihisa Nagata
+
 3.0.0 (2026-07-23)
 ------------------
 * refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)

--- a/motor_control_app/package.xml
+++ b/motor_control_app/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_app</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>Refactored motor control application using the new motor_control_lib</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib/CHANGELOG.rst
+++ b/motor_control_lib/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package motor_control_lib
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* refactor: inject logger and accumulate modbus response in servo_control (`#135 <https://github.com/scramble-robot/questix/issues/135>`_)
+* refactor: extract serial port initialization into serial_utils package (`#134 <https://github.com/scramble-robot/questix/issues/134>`_)
+* Contributors: Akihisa Nagata
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package motor_control_lib

--- a/motor_control_lib/package.xml
+++ b/motor_control_lib/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>motor_control_lib</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>Motor control library with common interfaces for drive and shot functionality</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/motor_control_lib_simple/CHANGELOG.rst
+++ b/motor_control_lib_simple/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package motor_control_lib_simple
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package motor_control_lib_simple
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package motor_control_lib_simple

--- a/motor_control_lib_simple/package.xml
+++ b/motor_control_lib_simple/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>motor_control_lib_simple</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>シンプルなモータ制御ライブラリ</description>
 
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>

--- a/operation_manager/CHANGELOG.rst
+++ b/operation_manager/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package operation_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package operation_manager
+
 3.0.0 (2026-07-23)
 ------------------
 * refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>operation_manager</name>
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <description>Determine whether GPIO IO is controllable by subscribing to GPIO topics.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/questix_msgs/CHANGELOG.rst
+++ b/questix_msgs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package questix_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* Version bump only for package questix_msgs
+
 3.0.0 (2026-07-23)
 ------------------
 * refactor: remove deprecated string status topics and esc bool mirror (`#130 <https://github.com/scramble-robot/questix/issues/130>`_)

--- a/questix_msgs/package.xml
+++ b/questix_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>questix_msgs</name>
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <description>Common message definitions for QUESTiX, including the unified emergency stop interface.</description>
   <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
   <license>MIT</license>

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="robot-manager",
-    version="3.0.0",
+    version="3.1.0",
     packages=find_packages(),
     include_package_data=True,
     package_data={"robot_manager": ["static/*"]},

--- a/serial_utils/CHANGELOG.rst
+++ b/serial_utils/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package serial_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+3.1.0 (2026-07-23)
+------------------
+* refactor: extract serial port initialization into serial_utils package (`#134 <https://github.com/scramble-robot/questix/issues/134>`_)
+* Contributors: Akihisa Nagata

--- a/serial_utils/package.xml
+++ b/serial_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>serial_utils</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>Shared serial port initialization helpers (open + baud + 8N1 raw termios) for QUESTiX motor and input packages</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>

--- a/uart_joy_driver/CHANGELOG.rst
+++ b/uart_joy_driver/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package uart_joy_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+3.1.0 (2026-07-23)
+------------------
+* refactor: extract serial port initialization into serial_utils package (`#134 <https://github.com/scramble-robot/questix/issues/134>`_)
+* Contributors: Akihisa Nagata
+
 3.0.0 (2026-07-23)
 ------------------
 * Version bump only for package uart_joy_driver

--- a/uart_joy_driver/package.xml
+++ b/uart_joy_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>uart_joy_driver</name>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <description>UART serial joystick driver for Switch-style controllers. Reads 7-byte hex protocol from UART and publishes sensor_msgs/Joy.</description>
     <maintainer email="aki.grade2580@outlook.jp">asa-naki</maintainer>
     <license>MIT</license>


### PR DESCRIPTION
## Summary

Release **QUESTiX 3.1.0**. Bumps all package versions from `3.0.0` to `3.1.0` (`package.xml` + `scripts/setup.py`) and adds `3.1.0` changelog sections summarizing the changes merged since the `3.0.0` baseline.

Minor bump: adds wheel odometry / `odom`->`base_link` tf publishing; no breaking interface changes.

## Highlights

- feat: publish wheel odometry and `odom`->`base_link` tf from drive component (#132)
- refactor: unify `drive_component` config to launcher single source (#133)
- refactor: inject logger and accumulate modbus response in `servo_control` (#135)
- refactor: extract serial port initialization into `serial_utils` package (#134)

## Notes

- `serial_utils` was introduced after the `3.0.0` tag; this release adds its initial `CHANGELOG.rst` and brings it to `3.1.0` under unified versioning.
- Packages with no code changes this cycle get a "Version bump only" changelog entry, matching the `3.0.0` release convention.

## Validation

- `package.xml` (13 packages) and `scripts/setup.py` all read `3.1.0`.
- Changelog entries cross-checked against the four merged commits (#132, #133, #135, #134).
- No source/behavior changes in this PR — version metadata and changelogs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)