### PR TITLE
docs: record #136 in the 3.1.0 changelog

### DIFF
--- a/motor_control_app/CHANGELOG.rst
+++ b/motor_control_app/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package motor_control_app
 3.1.0 (2026-07-23)
 ------------------
 * feat: publish wheel odometry and odom->base_link tf from drive component (`#132 <https://github.com/scramble-robot/questix/issues/132>`_)
+* feat: add ddt motor feedback monitor cli for tuning (`#136 <https://github.com/scramble-robot/questix/issues/136>`_)
 * refactor: unify drive_component config to launcher single source (`#133 <https://github.com/scramble-robot/questix/issues/133>`_)
 * Contributors: Akihisa Nagata
 

--- a/questix_msgs/CHANGELOG.rst
+++ b/questix_msgs/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog for package questix_msgs
 
 3.1.0 (2026-07-23)
 ------------------
-* Version bump only for package questix_msgs
+* docs: document tuning-time ddt monitoring workflow (`#136 <https://github.com/scramble-robot/questix/issues/136>`_)
+* Contributors: Akihisa Nagata
 
 3.0.0 (2026-07-23)
 ------------------


### PR DESCRIPTION
## Summary

Corrects the 3.1.0 changelog before tagging. PR #136 (ddt motor feedback monitor CLI) merged into `main` after the `release/3.1.0` branch was cut but before the release commit (#137) landed, so #136 is part of the 3.1.0 **code** yet was missing from every `CHANGELOG.rst` `3.1.0` section.

## Changes

- `motor_control_app/CHANGELOG.rst`: add `feat: add ddt motor feedback monitor cli for tuning (#136)` — the new CLI, format helpers, and tests live here.
- `questix_msgs/CHANGELOG.rst`: replace the "Version bump only" line with `docs: document tuning-time ddt monitoring workflow (#136)` — #136 only touched this package's `README.md`.

## Notes

- Changelog/metadata only; no source or behavior changes.
- `3.1.0` is not yet tagged; this lands first so the tag reflects an accurate changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)