### PR TITLE
fix: integrate physical e-stop and competition auto-referee input

### DIFF
--- a/ansible/roles/robot_autostart/README.md
+++ b/ansible/roles/robot_autostart/README.md
@@ -4,7 +4,7 @@ systemd による ROS2 ノードの自動起動を設定するロール。
 
 ## 動作概要
 
-- `/etc/questix_robot/mode` が `competition` の時のみ、ブート時に `ros2 launch questix_launcher questix_core.launch.xml` を自動実行
+- `/etc/questix_robot/mode` が `competition` の時のみ、ブート時に `ros2 launch questix_launcher questix_core.launch.xml` を `enable_autoreferee:=true` 付きで自動実行
 - `practice`（デフォルト）の時はサービスは即正常終了し、ノードは起動しない
 - Launch 引数は `/etc/questix_robot/launch.env` で制御
 

--- a/ansible/roles/robot_autostart/README.md
+++ b/ansible/roles/robot_autostart/README.md
@@ -1,12 +1,13 @@
 # robot_autostart
 
-systemd による ROS2 ノードの自動起動を設定するロール。
+systemd による ROS 2 ノードの自動起動を設定するロール。
 
 ## 動作概要
 
-- `/etc/questix_robot/mode` が `competition` の時のみ、ブート時に `ros2 launch questix_launcher questix_core.launch.xml` を `enable_autoreferee:=true` 付きで自動実行
+- `/etc/questix_robot/mode` が `competition` の時のみ、ブート時に `ros2 launch questix_launcher questix_core.launch.xml` を `enable_gpio_ref:=true`、`enable_autoreferee:=true` 付きで自動実行
 - `practice`（デフォルト）の時はサービスは即正常終了し、ノードは起動しない
-- Launch 引数は `/etc/questix_robot/launch.env` で制御
+- その他の Launch 引数は `/etc/questix_robot/launch.env` で制御
+- competition では GPIO5 physical E-stop と GPIO27 AutoReferee が必須のため、`launch.env` の `ENABLE_GPIO_REF` は無視して GPIO 安全系を常時有効化
 
 ## 変数
 
@@ -52,8 +53,14 @@ sudo systemctl restart questix_robot
 | `ENABLE_LIDAR` | `true` | YDLiDAR の有効化 |
 | `ENABLE_SHOT` | `true` | 射出コンポーネントの有効化 |
 | `ENABLE_DRIVE` | `true` | 駆動コンポーネントの有効化 |
-| `ENABLE_GPIO_REF` | `true` | GPIO レフェリーシステムの有効化 |
+| `ENABLE_GPIO_REF` | `true` | 手動開発・診断用の GPIO 安全系設定。competition systemd 起動では値を無視して常に有効 |
 | `ENABLE_RVIZ` | `false` | RViz 可視化の有効化 |
+
+Ansible は `launch.env` を `force: false` で配置するため、既存ファイルを上書きしません。
+既存環境に `ENABLE_GPIO_REF=false` が残っていても、competition ランチャーは
+`enable_gpio_ref:=true` を固定で渡すため安全系を無効化できません。
+`enable_autoreferee:=true` かつ `enable_gpio_ref:=false` は通常運用上の無効な
+組合せです。後者を明示的に無効化する操作は手動の開発・診断に限定してください。
 
 ## 手動デプロイ
 

--- a/ansible/roles/robot_autostart/files/questix_robot_launcher.sh
+++ b/ansible/roles/robot_autostart/files/questix_robot_launcher.sh
@@ -28,7 +28,7 @@ if [ -f "${ENV_FILE}" ]; then
   set +a
 fi
 
-# Determine ROS2 distro and workspace
+# Determine ROS2 distro and workspace (env vars or defaults)
 ROS_DISTRO="${ROS_DISTRO:-jazzy}"
 ROBOT_WS="${ROBOT_WS:-/home/ubuntu/robot_ws}"
 
@@ -48,6 +48,7 @@ LAUNCH_ARGS="${LAUNCH_ARGS} enable_lidar:=${ENABLE_LIDAR:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_shot:=${ENABLE_SHOT:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_drive:=${ENABLE_DRIVE:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=${ENABLE_GPIO_REF:-true}"
+LAUNCH_ARGS="${LAUNCH_ARGS} enable_autoreferee:=true"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_rviz:=${ENABLE_RVIZ:-false}"
 LAUNCH_ARGS="${LAUNCH_ARGS} controller_type:=${CONTROLLER_TYPE:-uart}"
 

--- a/ansible/roles/robot_autostart/files/questix_robot_launcher.sh
+++ b/ansible/roles/robot_autostart/files/questix_robot_launcher.sh
@@ -47,7 +47,9 @@ LAUNCH_ARGS=""
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_lidar:=${ENABLE_LIDAR:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_shot:=${ENABLE_SHOT:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_drive:=${ENABLE_DRIVE:-true}"
-LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=${ENABLE_GPIO_REF:-true}"
+# Competition always requires both physical E-stop and AutoReferee GPIO safety inputs.
+# ENABLE_GPIO_REF from launch.env is intentionally ignored in this mode.
+LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=true"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_autoreferee:=true"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_rviz:=${ENABLE_RVIZ:-false}"
 LAUNCH_ARGS="${LAUNCH_ARGS} controller_type:=${CONTROLLER_TYPE:-uart}"

--- a/ansible/roles/robot_autostart/templates/launch.env.j2
+++ b/ansible/roles/robot_autostart/templates/launch.env.j2
@@ -1,17 +1,18 @@
-# Questix Robot Launch Configuration
+# QUESTiX Robot Launch Configuration
 # Managed by Ansible - manual edits will be preserved (force: false)
 
-# ROS2 distro and workspace path
+# ROS 2 distro and workspace path
 ROS_DISTRO={{ ros2_distro }}
 ROBOT_WS={{ workspace_path }}
 
-# ROS2 Domain ID (change per robot to avoid conflicts when running multiple robots)
+# ROS 2 Domain ID (change per robot to avoid conflicts when running multiple robots)
 ROS_DOMAIN_ID={{ ros_domain_id }}
 
 # Launch component toggles
 ENABLE_LIDAR=true
 ENABLE_SHOT=true
 ENABLE_DRIVE=true
+# The competition systemd launcher always enables GPIO safety regardless of this value.
 ENABLE_GPIO_REF=true
 ENABLE_RVIZ=false
 

--- a/gpio_reader/README.md
+++ b/gpio_reader/README.md
@@ -139,11 +139,18 @@ complete QUESTiX Raspberry Pi 5 HAT allocation in BCM order.
 | 24 | 18 | CN9 pin 3 / IO2 | Unassigned |
 | 25 | 22 | CN8 pin 3 / IO1 | Unassigned |
 | 26 | 37 | HAT SW1-3 | DIP Switch 3 |
-| 27 | 13 | AutoReferee AR_in, U2/R2; client connector CN7 | Competition AutoReferee; true=permission, false=stop |
+| 27 | 13 | AutoReferee AR_in, U2/R2; client connector CN7 | Competition AutoReferee; CN7 0 V becomes true/permission, CN7 5 V becomes false/stop |
 
 Connector pin assignments:
 
-- CN2--CN11: pin 1 = +3.3 V, pin 2 = GND, pin 3 = signal
+- CN2–CN6 and CN8–CN11: pin 1 = +3.3 V, pin 2 = GND, pin 3 = signal
+- CN7: AutoReferee client input
+  - pin 1 = defeat-state input
+    - 0 V: not defeated
+    - 5 V: defeated / operation prohibited
+  - pin 2 = GND
+  - The HAT optocoupler inverts this signal before passing it to GPIO27/`AR_in`.
+  - CN7 is not a normal three-pin GPIO breakout.
 - CN13/CN14: pin 1 = +3.3 V, pin 2 = GND, pin 3 = SDA, pin 4 = SCL
 - CN15/CN16: pin 1 = SCK, pin 2 = MISO, pin 3 = MOSI, pin 4 = GND
 - CN12: pin 1 = ConVcc, pin 2 = GND, pin 3 = TXD, pin 4 = RXD

--- a/gpio_reader/README.md
+++ b/gpio_reader/README.md
@@ -33,13 +33,42 @@ gpiodetect
 
 ## Configuration
 
-Edit `config/gpio_reader.yaml` to configure:
+The launch profiles are the single source of truth for monitored pins:
+
+- `config/gpio_reader.practice.yaml`: GPIO5 only
+- `config/gpio_reader.competition.yaml`: GPIO5 and GPIO27
+- `config/gpio_reader.yaml`: backward-compatible safe default, identical to
+  the practice profile
+
+`questix_core.launch.xml` selects the practice profile by default and the
+competition profile only when `enable_autoreferee:=true`.
+
+GPIO values are published as raw electrical Bool values; this package does not
+invert either input:
+
+- GPIO5: physical emergency-stop indication, `false` = released/safe and
+  `true` = pressed/stop (safe-low, stop-high)
+- GPIO27: AutoReferee `AR_in`, `true` = permission/safe and `false` =
+  stop (safe-high, stop-low), competition only
+
+The AutoReferee client defeat output is 5 V when defeated and 0 V otherwise.
+The HAT optocoupler inverts it: defeated turns the optocoupler on and produces
+GPIO27 `false`; not defeated leaves it off and R2 (10 kΩ) pulls GPIO27 to
+3.3 V/`true`. AutoReferee disconnected, client unpowered, and a primary-side
+open circuit also produce `true`. Current hardware cannot distinguish those
+conditions from a genuine not-defeated/permission state.
+
+The physical emergency-stop circuit cuts actuator power in hardware through
+RLY1. It removes power from both DDT drive motors, the roller ESC, the Shot
+servo, and the Tilt servo. Raspberry Pi, 5 V I/O, and 3.3 V I/O remain powered,
+so GPIO5 continues reporting the physical E-stop state to ROS. Hardware power
+removal and the independent ROS software stop are two separate safety paths.
+
+Each YAML configures:
 
 - `chip_name`: GPIO chip name (default: "gpiochip4" for Raspberry Pi 5)
 - `gpio_pins`: List of GPIO pins to monitor (BCM numbering)
 - `publish_rate`: Publishing frequency in Hz
-- `publish_individual`: Publish individual Bool topics for each pin
-- `publish_joy`: Publish combined Joy message
 
 ## Building
 
@@ -78,13 +107,10 @@ ros2 launch gpio_reader gpio_reader.launch.py config_file:=/path/to/custom_confi
 
 ## GPIO Pin Numbering
 
-This package uses BCM (Broadcom) GPIO numbering. Common pins on Raspberry Pi 5:
+This package uses BCM (Broadcom) GPIO numbering. QUESTiX safety inputs:
 
-- GPIO 17 (Physical pin 11)
-- GPIO 27 (Physical pin 13)
-- GPIO 22 (Physical pin 15)
-- GPIO 23 (Physical pin 16)
-- GPIO 24 (Physical pin 18)
+- GPIO5: physical emergency stop (HAT CN10 pin 3 / IO3)
+- GPIO27: competition AutoReferee `AR_in`
 
 ## Permissions
 
@@ -99,11 +125,11 @@ Then log out and log back in for the changes to take effect.
 ## Example: Reading GPIO States
 
 ```bash
-# Monitor combined GPIO state
-ros2 topic echo /gpio/state
+# GPIO5 is present in both profiles
+ros2 topic echo /gpio_5
 
-# Monitor individual GPIO pin
-ros2 topic echo /gpio_17
+# GPIO27 is present only in the competition profile
+ros2 topic echo /gpio_27
 ```
 
 ## Component Composition

--- a/gpio_reader/README.md
+++ b/gpio_reader/README.md
@@ -1,13 +1,12 @@
 # GPIO Reader
 
-ROS2 package for reading GPIO values on Raspberry Pi 5 using libgpiod.
+ROS 2 package for reading GPIO values on Raspberry Pi 5 using libgpiod.
 
 ## Features
 
 - Read multiple GPIO pins simultaneously
-- Publish GPIO states as individual Bool topics
-- Publish combined GPIO states as Joy message (for compatibility with other nodes)
-- Implemented as ROS2 component for better performance and composability
+- Publish each configured GPIO pin as a raw `std_msgs/msg/Bool` topic
+- Implemented as a ROS 2 component for composability
 - Configurable publish rate and GPIO pins
 
 ## Dependencies
@@ -56,7 +55,8 @@ The HAT optocoupler inverts it: defeated turns the optocoupler on and produces
 GPIO27 `false`; not defeated leaves it off and R2 (10 kΩ) pulls GPIO27 to
 3.3 V/`true`. AutoReferee disconnected, client unpowered, and a primary-side
 open circuit also produce `true`. Current hardware cannot distinguish those
-conditions from a genuine not-defeated/permission state.
+conditions from a genuine not-defeated/permission state. Diagnostics therefore
+report this hardware limitation but cannot detect those three failure modes.
 
 The physical emergency-stop circuit cuts actuator power in hardware through
 RLY1. It removes power from both DDT drive motors, the roller ESC, the Shot
@@ -66,14 +66,14 @@ removal and the independent ROS software stop are two separate safety paths.
 
 Each YAML configures:
 
-- `chip_name`: GPIO chip name (default: "gpiochip4" for Raspberry Pi 5)
-- `gpio_pins`: List of GPIO pins to monitor (BCM numbering)
-- `publish_rate`: Publishing frequency in Hz
+- `chip_name`: GPIO chip device path (default: `/dev/gpiochip4`)
+- `gpio_pins`: list of GPIO pins to monitor (BCM numbering)
+- `publish_rate`: publishing frequency in Hz
 
 ## Building
 
 ```bash
-cd ~/workspace/shr_ws/questy
+cd <questix-workspace>
 colcon build --packages-select gpio_reader
 source install/setup.bash
 ```
@@ -100,24 +100,60 @@ ros2 launch gpio_reader gpio_reader.launch.py config_file:=/path/to/custom_confi
 
 ## Topics
 
-### Published Topics
-
-- `gpio/state` (sensor_msgs/Joy): Combined state of all GPIO pins as Joy message
-- `gpio_<PIN>` (std_msgs/Bool): Individual topic for each GPIO pin (if enabled)
+For every pin listed in `gpio_pins`, the node publishes exactly one raw electrical
+topic named `/gpio_<PIN>` with type `std_msgs/msg/Bool`. For example, the practice
+profile publishes `/gpio_5`; the competition profile publishes `/gpio_5` and
+`/gpio_27`. The node does not publish a combined GPIO-state topic.
 
 ## GPIO Pin Numbering
 
-This package uses BCM (Broadcom) GPIO numbering. QUESTiX safety inputs:
+This package uses BCM (Broadcom) GPIO numbering. The following table documents the
+complete QUESTiX Raspberry Pi 5 HAT allocation in BCM order.
 
-- GPIO5: physical emergency stop (HAT CN10 pin 3 / IO3)
-- GPIO27: competition AutoReferee `AR_in`
+| BCM GPIO | Raspberry Pi physical pin | HAT signal / location | Assignment / notes |
+|---:|---:|---|---|
+| 0 | 27 | ID_SD | Reserved for HAT ID EEPROM; not used by QUESTiX |
+| 1 | 28 | ID_SC | Reserved for HAT ID EEPROM; not used by QUESTiX |
+| 2 | 3 | SDA; CN13/CN14 pin 3 | I2C SDA |
+| 3 | 5 | SCL; CN13/CN14 pin 4; CN6 pin 3 / POW-SW | I2C SCL and power-switch input; shared net |
+| 4 | 7 | J1 only | Unassigned |
+| 5 | 29 | CN10 pin 3 / IO3 | Physical emergency stop; false=released, true=pressed |
+| 6 | 31 | CN11 pin 3 / IO4 | Unassigned |
+| 7 | 26 | CN5 pin 3 / CE1 | SPI CE1 |
+| 8 | 24 | CN4 pin 3 / CE0 | SPI CE0 |
+| 9 | 21 | CN15/CN16 pin 2 / MISO | SPI MISO |
+| 10 | 19 | CN15/CN16 pin 3 / MOSI | SPI MOSI |
+| 11 | 23 | CN15/CN16 pin 1 / SCK | SPI SCLK |
+| 12 | 32 | CN2 pin 3 / PWM0 | Unassigned PWM output |
+| 13 | 33 | CN3 pin 3 / PWM1 | Roller ESC motor control PWM output |
+| 14 | 8 | CN12 pin 3 / TXD through level shifter | UART TXD |
+| 15 | 10 | CN12 pin 4 / RXD through level shifter | UART RXD |
+| 16 | 36 | HAT SW1-4 | DIP Switch 4 |
+| 17 | 11 | J1 only | Unassigned |
+| 18 | 12 | J1 only | Unassigned |
+| 19 | 35 | J1 only | Unassigned |
+| 20 | 38 | HAT SW1-2 | DIP Switch 2 |
+| 21 | 40 | HAT SW1-1 | DIP Switch 1 |
+| 22 | 15 | J1 only | Unassigned |
+| 23 | 16 | J1 only | Unassigned |
+| 24 | 18 | CN9 pin 3 / IO2 | Unassigned |
+| 25 | 22 | CN8 pin 3 / IO1 | Unassigned |
+| 26 | 37 | HAT SW1-3 | DIP Switch 3 |
+| 27 | 13 | AutoReferee AR_in, U2/R2; client connector CN7 | Competition AutoReferee; true=permission, false=stop |
+
+Connector pin assignments:
+
+- CN2--CN11: pin 1 = +3.3 V, pin 2 = GND, pin 3 = signal
+- CN13/CN14: pin 1 = +3.3 V, pin 2 = GND, pin 3 = SDA, pin 4 = SCL
+- CN15/CN16: pin 1 = SCK, pin 2 = MISO, pin 3 = MOSI, pin 4 = GND
+- CN12: pin 1 = ConVcc, pin 2 = GND, pin 3 = TXD, pin 4 = RXD
 
 ## Permissions
 
-To access GPIO without root privileges, add your user to the gpio group:
+To access GPIO without root privileges, add your user to the `gpio` group:
 
 ```bash
-sudo usermod -a -G gpio $USER
+sudo usermod -a -G gpio "$USER"
 ```
 
 Then log out and log back in for the changes to take effect.
@@ -134,7 +170,7 @@ ros2 topic echo /gpio_27
 
 ## Component Composition
 
-You can compose this component with other ROS2 components for better performance:
+You can compose this component with other ROS 2 components:
 
 ```python
 from launch_ros.descriptions import ComposableNode
@@ -151,15 +187,15 @@ ComposableNode(
 
 ### Cannot open GPIO chip
 
-- Make sure you're using the correct chip name (gpiochip4 for Raspberry Pi 5)
+- Confirm that the configured device path is `/dev/gpiochip4` on Raspberry Pi 5
 - Check available chips: `gpiodetect`
 - Verify permissions: `ls -l /dev/gpiochip*`
 
 ### GPIO pin not found
 
 - Verify the pin number using BCM numbering
-- Check pin availability: `gpioinfo gpiochip4`
-- Some pins may be reserved by the system
+- Check line information: `gpioinfo /dev/gpiochip4`
+- Some pins may be reserved or claimed by the system
 
 ## License
 

--- a/gpio_reader/config/gpio_reader.competition.yaml
+++ b/gpio_reader/config/gpio_reader.competition.yaml
@@ -1,0 +1,11 @@
+gpio_reader_node:
+  ros__parameters:
+    # Competition profile:
+    # GPIO5 = physical E-stop raw input (safe-low, stop-high).
+    # GPIO27 = AutoReferee AR_in raw input (safe-high, stop-low).
+    # true also represents disconnected, client unpowered, or primary-side open;
+    # current hardware cannot distinguish those states from permission.
+    use_sim_time: false
+    chip_name: "/dev/gpiochip4"
+    gpio_pins: [5, 27]
+    publish_rate: 20.0

--- a/gpio_reader/config/gpio_reader.practice.yaml
+++ b/gpio_reader/config/gpio_reader.practice.yaml
@@ -1,0 +1,8 @@
+gpio_reader_node:
+  ros__parameters:
+    # Practice profile. GPIO5 is the raw physical E-stop indication:
+    # false = released/safe, true = pressed/stop.
+    use_sim_time: false
+    chip_name: "/dev/gpiochip4"
+    gpio_pins: [5]
+    publish_rate: 20.0

--- a/gpio_reader/config/gpio_reader.yaml
+++ b/gpio_reader/config/gpio_reader.yaml
@@ -6,8 +6,10 @@ gpio_reader_node:
     # GPIO chip device path (for Raspberry Pi 5, use /dev/gpiochip4)
     chip_name: "/dev/gpiochip4"
 
-    # GPIO pins to monitor (BCM numbering)
-    gpio_pins: [27]
+    # Safe standalone/default profile: practice mode.
+    # GPIO5 is the raw physical E-stop indication (safe-low, stop-high).
+    # Keep this compatibility config identical to gpio_reader.practice.yaml.
+    gpio_pins: [5]
 
     # Publishing rate in Hz
     publish_rate: 20.0

--- a/gpio_reader/src/gpio_reader_component.cpp
+++ b/gpio_reader/src/gpio_reader_component.cpp
@@ -13,7 +13,7 @@ GpioReaderComponent::GpioReaderComponent(const rclcpp::NodeOptions& options)
     : Node("gpio_reader_node", options), chip_(nullptr) {
   // Declare parameters
   this->declare_parameter<std::string>("chip_name", "/dev/gpiochip4");
-  this->declare_parameter<std::vector<int64_t>>("gpio_pins", std::vector<int64_t>{17, 27, 22});
+  this->declare_parameter<std::vector<int64_t>>("gpio_pins", std::vector<int64_t>{5});
   this->declare_parameter<double>("publish_rate", 20.0);
 
   // Get parameters

--- a/joy_controller/launch/joy_controller_referee.launch.xml
+++ b/joy_controller/launch/joy_controller_referee.launch.xml
@@ -21,6 +21,9 @@ GPIO ref モードでは joy_topic = /joy_gated をデフォルトとする (唯
     <arg name="operation_manager_config_file"
          default="$(find-pkg-share operation_manager)/config/operation_manager.yaml"
          description="Path to the operation_manager configuration YAML" />
+    <arg name="enable_operation_manager"
+         default="true"
+         description="Start operation_manager (disable when an integrated parent launch owns it)" />
     <arg name="controller_type" default="uart" description="Controller type: dualshock or uart" />
     <arg name="joy_topic" default="/joy_gated" description="Joy input topic (override only)" />
 
@@ -56,7 +59,11 @@ GPIO ref モードでは joy_topic = /joy_gated をデフォルトとする (唯
     </node>
 
     <!-- Operation Manager Node -->
-    <node pkg="operation_manager" exec="operation_manager_node" name="operation_manager_node" output="screen">
+    <node pkg="operation_manager"
+          exec="operation_manager_node"
+          name="operation_manager_node"
+          output="screen"
+          if="$(var enable_operation_manager)">
         <param from="$(var operation_manager_config_file)" />
     </node>
 </launch>

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -49,6 +49,9 @@ if(BUILD_TESTING)
   ament_add_pytest_test(test_gpio_safety_launch test/test_gpio_safety_launch.py
     ENV "QUESTIX_SOURCE_ROOT=${CMAKE_CURRENT_SOURCE_DIR}/.."
   )
+  ament_add_pytest_test(test_gpio_safety_runtime test/test_gpio_safety_runtime.py
+    TIMEOUT 90
+  )
 endif()
 
 ament_auto_package()

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -36,6 +36,7 @@ install(DIRECTORY
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
   set(ament_cmake_copyright_FOUND TRUE)
@@ -44,6 +45,10 @@ if(BUILD_TESTING)
   # a copyright and license is added to all source files
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(test_gpio_safety_launch test/test_gpio_safety_launch.py
+    ENV "QUESTIX_SOURCE_ROOT=${CMAKE_CURRENT_SOURCE_DIR}/.."
+  )
 endif()
 
 ament_auto_package()

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,12 +1,59 @@
-# Questix Launcher
+# QUESTiX Launcher
 
-Questixシステムの各ノードを起動するためのlauncherファイル群です。XMLベースのROS2 launchファイルを使用しており、Pythonよりも読みやすく設定が直感的です。
+QUESTiXシステムの各ノードを起動するためのlauncherファイル群です。XMLベースのROS 2 launchファイルを使用します。
+
+## GPIO安全系
+
+`questix_core.launch.xml` の `enable_gpio_ref:=true` は、drive/shot の有無に
+関係なく `gpio_reader` と `operation_manager` をそれぞれ1プロセス起動します。
+drive が使う `joy_controller_referee.launch.xml` 内の operation_manager は統合時に
+無効化されるため、同名ノードは重複しません。standalone referee launch は互換性の
+ため既定で operation_manager を起動します。
+
+`enable_autoreferee` の既定値は `false` です。
+
+- `false` (practice): GPIO5だけを読み、physical E-stopをsafe-lowとして判定
+- `true` (competition): GPIO5とGPIO27を読み、GPIO27 AutoRefereeを
+  safe-highとして追加判定
+
+`/etc/questix_robot/mode` が `competition` のときだけ実行される
+`questix_robot_launcher.sh` は、必ず `enable_autoreferee:=true` を渡します。
+
+GPIO5の物理非常停止回路はRLY1で左右DDT駆動モーター、ローラー用ESC、Shot用サーボ、
+Tilt用サーボの動力をハードウェア遮断します。Raspberry Pi、5 V I/O、3.3 V I/Oは
+通電を維持するため、GPIO5は状態をROSへ通知し続けます。GPIO5のraw値は解除時
+`false`、押下時 `true` です。物理遮断とROSソフトウェア停止は独立した二重の
+安全経路です。
+
+GPIO27は大会用AutoReferee `AR_in` で、クライアント撃破出力（撃破時5 V、
+非撃破時0 V）をHATのフォトカプラで反転します。撃破時は `false`/停止、
+非撃破時はR2（10 kΩ）の3.3 Vプルアップにより `true`/許可です。ただし
+AutoReferee未接続、クライアント無通電、一次側断線も `true` となり、現行
+ハードウェアでは非撃破と区別できません。この制約は `/diagnostics` の
+`pin_27_signal_limit` にも表示されます。
+
+| Mode | GPIO5 physical E-stop | GPIO27 AutoReferee | Controllable |
+|---|---:|---:|---:|
+| practice | false | not monitored | true |
+| practice | true | not monitored | false |
+| competition | false | true | true |
+| competition | true | any | false |
+| competition | any | false | false |
+| any | missing or stale required input | - | false |
+
+安全系だけを非通電で起動するコマンド例:
+
+```bash
+ros2 launch questix_launcher questix_core.launch.xml \
+  enable_lidar:=false enable_shot:=false enable_drive:=false \
+  enable_gpio_ref:=true enable_autoreferee:=false enable_rviz:=false
+```
 
 ## ファイル構成
 
 ### メインlaunchファイル
 
-- `launch/questix_core_launch.xml` - 全システムを起動するメインファイル
+- `launch/questix_core.launch.xml` - 全システムを起動するメインファイル
 - `launch/navigation_launch.xml` - ナビゲーション用システム（LiDAR + モータ + Joy）
 - `launch/test_launch.xml` - テスト・デバッグ用の最小構成
 - `launch/servo_system_launch.xml` - サーボ制御システム
@@ -41,7 +88,7 @@ LiDARなど実機依存のパッケージは追加取得とJazzy互換性確認�
 
 ```bash
 # 全システムを起動
-ros2 launch questix_launcher questix_core_launch.xml
+ros2 launch questix_launcher questix_core.launch.xml
 
 # ナビゲーションシステムを起動
 ros2 launch questix_launcher navigation_launch.xml

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -17,7 +17,13 @@ drive が使う `joy_controller_referee.launch.xml` 内の operation_manager は
   safe-highとして追加判定
 
 `/etc/questix_robot/mode` が `competition` のときだけ実行される
-`questix_robot_launcher.sh` は、必ず `enable_autoreferee:=true` を渡します。
+`questix_robot_launcher.sh` は、必ず `enable_gpio_ref:=true` と
+`enable_autoreferee:=true` を固定値で渡します。既存の `launch.env` に
+`ENABLE_GPIO_REF=false` が残っていても competition 起動では無視され、GPIO5と
+GPIO27の安全系は常時有効です。`enable_gpio_ref:=false` は手動の開発・診断用途に
+限定されます。`enable_autoreferee:=true` と `enable_gpio_ref:=false` の組合せは
+通常運用上無効であり、`questix_core.launch.xml` はその組合せを検出して起動を
+中止します。
 
 GPIO5の物理非常停止回路はRLY1で左右DDT駆動モーター、ローラー用ESC、Shot用サーボ、
 Tilt用サーボの動力をハードウェア遮断します。Raspberry Pi、5 V I/O、3.3 V I/Oは

--- a/launcher/launch/drive_component.launch.xml
+++ b/launcher/launch/drive_component.launch.xml
@@ -7,11 +7,11 @@ YAML を Single Source of Truth とし、個別パラメータの launch 引数�
 <launch>
   <arg name="joy_config_file" default="$(find-pkg-share joy_controller)/config/joy_controller_params.yaml" description="joy_controller configuration YAML" />
   <arg name="drive_config_file" default="$(find-pkg-share questix_launcher)/config/drive_component.yaml" description="drive_component configuration YAML" />
-  <arg name="enable_gpio_ref" default="false" description="Enable GPIO reference system (gpio_reader + joy_gate)" />
+  <arg name="enable_gpio_ref" default="false" description="Use the GPIO-gated controller path (joy_gate and optional operation_manager)" />
   <arg name="enable_operation_manager" default="true" description="Start operation_manager in standalone referee launch" />
   <arg name="controller_type" default="uart" description="Controller type: dualshock or uart" />
 
-  <!-- Joy Controller component launch (without GPIO ref) -->
+  <!-- Joy Controller component launch (without GPIO gating) -->
   <group unless="$(var enable_gpio_ref)">
     <include file="$(find-pkg-share joy_controller)/launch/joy_controller.launch.xml">
       <arg name="config_file" value="$(var joy_config_file)" />
@@ -19,7 +19,7 @@ YAML を Single Source of Truth とし、個別パラメータの launch 引数�
     </include>
   </group>
 
-  <!-- Joy Controller with GPIO reference system (gpio_reader + joy_gate + operation_manager) -->
+  <!-- GPIO-gated Joy Controller path; gpio_reader is owned by the integrated parent. -->
   <group if="$(var enable_gpio_ref)">
     <include file="$(find-pkg-share joy_controller)/launch/joy_controller_referee.launch.xml">
       <arg name="config_file" value="$(var joy_config_file)" />

--- a/launcher/launch/drive_component.launch.xml
+++ b/launcher/launch/drive_component.launch.xml
@@ -8,6 +8,7 @@ YAML を Single Source of Truth とし、個別パラメータの launch 引数�
   <arg name="joy_config_file" default="$(find-pkg-share joy_controller)/config/joy_controller_params.yaml" description="joy_controller configuration YAML" />
   <arg name="drive_config_file" default="$(find-pkg-share questix_launcher)/config/drive_component.yaml" description="drive_component configuration YAML" />
   <arg name="enable_gpio_ref" default="false" description="Enable GPIO reference system (gpio_reader + joy_gate)" />
+  <arg name="enable_operation_manager" default="true" description="Start operation_manager in standalone referee launch" />
   <arg name="controller_type" default="uart" description="Controller type: dualshock or uart" />
 
   <!-- Joy Controller component launch (without GPIO ref) -->
@@ -23,6 +24,7 @@ YAML を Single Source of Truth とし、個別パラメータの launch 引数�
     <include file="$(find-pkg-share joy_controller)/launch/joy_controller_referee.launch.xml">
       <arg name="config_file" value="$(var joy_config_file)" />
       <arg name="controller_type" value="$(var controller_type)" />
+      <arg name="enable_operation_manager" value="$(var enable_operation_manager)" />
     </include>
   </group>
 

--- a/launcher/launch/questix_core.launch.xml
+++ b/launcher/launch/questix_core.launch.xml
@@ -6,8 +6,23 @@
   <arg name="enable_shot" default="$(env ENABLE_SHOT true)" description="Enable Shot component"/>
   <arg name="enable_drive" default="$(env ENABLE_DRIVE true)" description="Enable drive component"/>
   <arg name="enable_gpio_ref" default="$(env ENABLE_GPIO_REF true)" description="Enable GPIO reference system (gpio_reader + joy_gate)"/>
+  <arg name="enable_autoreferee" default="false" description="Use competition GPIO profile with AutoReferee GPIO27"/>
   <arg name="controller_type" default="$(env CONTROLLER_TYPE dualshock)" description="Controller type: dualshock or uart" />
   <arg name="enable_rviz" default="$(env ENABLE_RVIZ false)" description="Enable RViz visualization" />
+
+  <!-- Profile YAML files are the single source of truth for GPIO pins and polarity. -->
+  <let name="gpio_reader_config_file"
+       value="$(find-pkg-share gpio_reader)/config/gpio_reader.practice.yaml"
+       unless="$(var enable_autoreferee)" />
+  <let name="gpio_reader_config_file"
+       value="$(find-pkg-share gpio_reader)/config/gpio_reader.competition.yaml"
+       if="$(var enable_autoreferee)" />
+  <let name="operation_manager_config_file"
+       value="$(find-pkg-share operation_manager)/config/operation_manager.practice.yaml"
+       unless="$(var enable_autoreferee)" />
+  <let name="operation_manager_config_file"
+       value="$(find-pkg-share operation_manager)/config/operation_manager.competition.yaml"
+       if="$(var enable_autoreferee)" />
 
   <group if="$(var enable_shot)">
     <include file="$(find-pkg-share questix_launcher)/launch/shot_component.launch.xml">
@@ -19,6 +34,8 @@
   <group if="$(var enable_drive)">
     <include file="$(find-pkg-share questix_launcher)/launch/drive_component.launch.xml">
       <arg name="enable_gpio_ref" value="$(var enable_gpio_ref)"/>
+      <!-- questix_core owns the single integrated operation_manager process. -->
+      <arg name="enable_operation_manager" value="false"/>
       <arg name="controller_type" value="$(var controller_type)"/>
     </include>
   </group>
@@ -26,7 +43,12 @@
     <include file="$(find-pkg-share ydlidar_ros2_driver)/launch/ydlidar_launch.py"/>
   </group>
   <group if="$(var enable_gpio_ref)">
-    <include file="$(find-pkg-share gpio_reader)/launch/gpio_reader.launch.xml"/>
+    <include file="$(find-pkg-share gpio_reader)/launch/gpio_reader.launch.xml">
+      <arg name="config_file" value="$(var gpio_reader_config_file)" />
+    </include>
+    <include file="$(find-pkg-share operation_manager)/launch/operation_manager.launch.xml">
+      <arg name="config_file" value="$(var operation_manager_config_file)" />
+    </include>
   </group>
   <!-- RViz Visualization -->
   <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" if="$(var enable_rviz)" args="-d $(find-pkg-share ydlidar_ros2_driver)/config/ydlidar.rviz">

--- a/launcher/launch/questix_core.launch.xml
+++ b/launcher/launch/questix_core.launch.xml
@@ -1,67 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <!-- Launch Arguments -->
-  <arg name="use_sim_time" default="false" description="Use simulation time" />
-  <arg name="enable_lidar" default="$(env ENABLE_LIDAR false)" description="Enable YDLiDAR" />
+  <arg name="use_sim_time" default="false" description="Use simulation time"/>
+  <arg name="enable_lidar" default="$(env ENABLE_LIDAR false)" description="Enable YDLiDAR"/>
   <arg name="enable_shot" default="$(env ENABLE_SHOT true)" description="Enable Shot component"/>
   <arg name="enable_drive" default="$(env ENABLE_DRIVE true)" description="Enable drive component"/>
   <arg name="enable_gpio_ref" default="$(env ENABLE_GPIO_REF true)" description="Enable GPIO safety path (gpio_reader, operation_manager, and joy gating)"/>
   <arg name="enable_autoreferee" default="false" description="Use competition GPIO profile with AutoReferee GPIO27"/>
-  <arg name="controller_type" default="$(env CONTROLLER_TYPE dualshock)" description="Controller type: dualshock or uart" />
-  <arg name="enable_rviz" default="$(env ENABLE_RVIZ false)" description="Enable RViz visualization" />
-
+  <arg name="controller_type" default="$(env CONTROLLER_TYPE dualshock)" description="Controller type: dualshock or uart"/>
+  <arg name="enable_rviz" default="$(env ENABLE_RVIZ false)" description="Enable RViz visualization"/>
   <!-- AutoReferee operation without the GPIO safety path is an invalid configuration. -->
   <group if="$(and $(var enable_autoreferee) $(not $(var enable_gpio_ref)))">
-    <log message="ERROR: enable_autoreferee=true requires enable_gpio_ref=true" />
+    <log message="ERROR: enable_autoreferee=true requires enable_gpio_ref=true"/>
     <!-- Defer shutdown briefly so the operator-facing error is emitted first. -->
     <timer period="0.01">
-      <shutdown reason="Invalid configuration: enable_autoreferee=true requires enable_gpio_ref=true" />
+      <shutdown reason="Invalid configuration: enable_autoreferee=true requires enable_gpio_ref=true"/>
     </timer>
   </group>
-
   <!-- Profile YAML files are the single source of truth for GPIO pins and polarity. -->
-  <let name="gpio_reader_config_file"
-       value="$(find-pkg-share gpio_reader)/config/gpio_reader.practice.yaml"
-       unless="$(var enable_autoreferee)" />
-  <let name="gpio_reader_config_file"
-       value="$(find-pkg-share gpio_reader)/config/gpio_reader.competition.yaml"
-       if="$(var enable_autoreferee)" />
-  <let name="operation_manager_config_file"
-       value="$(find-pkg-share operation_manager)/config/operation_manager.practice.yaml"
-       unless="$(var enable_autoreferee)" />
-  <let name="operation_manager_config_file"
-       value="$(find-pkg-share operation_manager)/config/operation_manager.competition.yaml"
-       if="$(var enable_autoreferee)" />
-
-  <group if="$(var enable_shot)">
-    <include file="$(find-pkg-share questix_launcher)/launch/shot_component.launch.xml">
-      <arg name="enable_gpio_ref" value="$(var enable_gpio_ref)"/>
-      <arg name="controller_type" value="$(var controller_type)"/>
-    </include>
+  <let name="gpio_reader_config_file" value="$(find-pkg-share gpio_reader)/config/gpio_reader.practice.yaml" unless="$(var enable_autoreferee)"/>
+  <let name="gpio_reader_config_file" value="$(find-pkg-share gpio_reader)/config/gpio_reader.competition.yaml" if="$(var enable_autoreferee)"/>
+  <let name="operation_manager_config_file" value="$(find-pkg-share operation_manager)/config/operation_manager.practice.yaml" unless="$(var enable_autoreferee)"/>
+  <let name="operation_manager_config_file" value="$(find-pkg-share operation_manager)/config/operation_manager.competition.yaml" if="$(var enable_autoreferee)"/>
+  <!-- All child processes stay disabled while the invalid branch reports and exits. -->
+  <group unless="$(and $(var enable_autoreferee) $(not $(var enable_gpio_ref)))">
+    <group if="$(var enable_shot)">
+      <include file="$(find-pkg-share questix_launcher)/launch/shot_component.launch.xml">
+        <arg name="enable_gpio_ref" value="$(var enable_gpio_ref)"/>
+        <arg name="controller_type" value="$(var controller_type)"/>
+      </include>
+    </group>
+    <group if="$(var enable_drive)">
+      <include file="$(find-pkg-share questix_launcher)/launch/drive_component.launch.xml">
+        <arg name="enable_gpio_ref" value="$(var enable_gpio_ref)"/>
+        <!-- questix_core owns the single integrated operation_manager process. -->
+        <arg name="enable_operation_manager" value="false"/>
+        <arg name="controller_type" value="$(var controller_type)"/>
+      </include>
+    </group>
+    <group if="$(var enable_lidar)">
+      <include file="$(find-pkg-share ydlidar_ros2_driver)/launch/ydlidar_launch.py"/>
+    </group>
+    <group if="$(var enable_gpio_ref)">
+      <include file="$(find-pkg-share gpio_reader)/launch/gpio_reader.launch.xml">
+        <arg name="config_file" value="$(var gpio_reader_config_file)"/>
+      </include>
+      <include file="$(find-pkg-share operation_manager)/launch/operation_manager.launch.xml">
+        <arg name="config_file" value="$(var operation_manager_config_file)"/>
+      </include>
+    </group>
+    <!-- RViz Visualization -->
+    <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" if="$(var enable_rviz)" args="-d $(find-pkg-share ydlidar_ros2_driver)/config/ydlidar.rviz">
+      <param name="use_sim_time" value="$(var use_sim_time)"/>
+    </node>
   </group>
-
-  <group if="$(var enable_drive)">
-    <include file="$(find-pkg-share questix_launcher)/launch/drive_component.launch.xml">
-      <arg name="enable_gpio_ref" value="$(var enable_gpio_ref)"/>
-      <!-- questix_core owns the single integrated operation_manager process. -->
-      <arg name="enable_operation_manager" value="false"/>
-      <arg name="controller_type" value="$(var controller_type)"/>
-    </include>
-  </group>
-  <group if="$(var enable_lidar)">
-    <include file="$(find-pkg-share ydlidar_ros2_driver)/launch/ydlidar_launch.py"/>
-  </group>
-  <group if="$(var enable_gpio_ref)">
-    <include file="$(find-pkg-share gpio_reader)/launch/gpio_reader.launch.xml">
-      <arg name="config_file" value="$(var gpio_reader_config_file)" />
-    </include>
-    <include file="$(find-pkg-share operation_manager)/launch/operation_manager.launch.xml">
-      <arg name="config_file" value="$(var operation_manager_config_file)" />
-    </include>
-  </group>
-  <!-- RViz Visualization -->
-  <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" if="$(var enable_rviz)" args="-d $(find-pkg-share ydlidar_ros2_driver)/config/ydlidar.rviz">
-    <param name="use_sim_time" value="$(var use_sim_time)" />
-  </node>
-
 </launch>

--- a/launcher/launch/questix_core.launch.xml
+++ b/launcher/launch/questix_core.launch.xml
@@ -5,10 +5,19 @@
   <arg name="enable_lidar" default="$(env ENABLE_LIDAR false)" description="Enable YDLiDAR" />
   <arg name="enable_shot" default="$(env ENABLE_SHOT true)" description="Enable Shot component"/>
   <arg name="enable_drive" default="$(env ENABLE_DRIVE true)" description="Enable drive component"/>
-  <arg name="enable_gpio_ref" default="$(env ENABLE_GPIO_REF true)" description="Enable GPIO reference system (gpio_reader + joy_gate)"/>
+  <arg name="enable_gpio_ref" default="$(env ENABLE_GPIO_REF true)" description="Enable GPIO safety path (gpio_reader, operation_manager, and joy gating)"/>
   <arg name="enable_autoreferee" default="false" description="Use competition GPIO profile with AutoReferee GPIO27"/>
   <arg name="controller_type" default="$(env CONTROLLER_TYPE dualshock)" description="Controller type: dualshock or uart" />
   <arg name="enable_rviz" default="$(env ENABLE_RVIZ false)" description="Enable RViz visualization" />
+
+  <!-- AutoReferee operation without the GPIO safety path is an invalid configuration. -->
+  <group if="$(and $(var enable_autoreferee) $(not $(var enable_gpio_ref)))">
+    <log message="ERROR: enable_autoreferee=true requires enable_gpio_ref=true" />
+    <!-- Defer shutdown briefly so the operator-facing error is emitted first. -->
+    <timer period="0.01">
+      <shutdown reason="Invalid configuration: enable_autoreferee=true requires enable_gpio_ref=true" />
+    </timer>
+  </group>
 
   <!-- Profile YAML files are the single source of truth for GPIO pins and polarity. -->
   <let name="gpio_reader_config_file"

--- a/launcher/launch/shot_component.launch.xml
+++ b/launcher/launch/shot_component.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <!-- Launch Arguments -->
   <arg name="controller_type" default="dualshock" description="Controller type: dualshock or uart" />
-  <arg name="enable_gpio_ref" default="false" description="Enable GPIO reference system (gpio_reader + joy_gate)" />
+  <arg name="enable_gpio_ref" default="false" description="Use the gated joy topic supplied by the parent GPIO safety path" />
   <arg name="use_sim_time" default="false" description="Use simulation time" />
 
   <!-- Per-controller YAML profiles (auto-selected from controller_type).

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -23,6 +23,7 @@
     <exec_depend>gpio_reader</exec_depend>
     <exec_depend>joy_controller</exec_depend>
     <exec_depend>motor_control_app</exec_depend>
+    <exec_depend>operation_manager</exec_depend>
     <exec_depend>ydlidar_ros2_driver</exec_depend>
 
     <!-- Standard ROS2 packages -->
@@ -36,6 +37,8 @@
     <!-- Test dependencies -->
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
+    <test_depend>ament_cmake_pytest</test_depend>
+    <test_depend>python3-yaml</test_depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/launcher/package.xml
+++ b/launcher/package.xml
@@ -39,6 +39,11 @@
     <test_depend>ament_lint_common</test_depend>
     <test_depend>ament_cmake_pytest</test_depend>
     <test_depend>python3-yaml</test_depend>
+    <test_depend>ros2launch</test_depend>
+    <test_depend>ros2node</test_depend>
+    <test_depend>ros2param</test_depend>
+    <test_depend>ros2pkg</test_depend>
+    <test_depend>ros2run</test_depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/launcher/test/test_gpio_safety_launch.py
+++ b/launcher/test/test_gpio_safety_launch.py
@@ -1,0 +1,153 @@
+# Copyright 2026 scramble-robot
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import os
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+import yaml
+
+
+SOURCE_ROOT = Path(os.environ['QUESTIX_SOURCE_ROOT'])
+
+
+def load_xml(relative_path):
+    return ET.parse(SOURCE_ROOT / relative_path).getroot()
+
+
+def load_yaml(relative_path):
+    with (SOURCE_ROOT / relative_path).open(encoding='utf-8') as stream:
+        return yaml.safe_load(stream)
+
+
+def find_arg(root, name):
+    return next(arg for arg in root.findall('./arg') if arg.get('name') == name)
+
+
+def test_profiles_select_the_expected_gpio_inputs_and_polarities():
+    practice_reader = load_yaml('gpio_reader/config/gpio_reader.practice.yaml')
+    competition_reader = load_yaml('gpio_reader/config/gpio_reader.competition.yaml')
+    default_reader = load_yaml('gpio_reader/config/gpio_reader.yaml')
+    practice_manager = load_yaml(
+        'operation_manager/config/operation_manager.practice.yaml')
+    competition_manager = load_yaml(
+        'operation_manager/config/operation_manager.competition.yaml')
+    default_manager = load_yaml('operation_manager/config/operation_manager.yaml')
+
+    assert practice_reader['gpio_reader_node']['ros__parameters']['gpio_pins'] == [5]
+    assert competition_reader['gpio_reader_node']['ros__parameters']['gpio_pins'] == [5, 27]
+    assert default_reader == practice_reader
+
+    practice_parameters = practice_manager['operation_manager_node']['ros__parameters']
+    competition_parameters = competition_manager[
+        'operation_manager_node']['ros__parameters']
+    assert practice_parameters['safe_low_pins'] == [5]
+    assert practice_parameters['safe_high_pins'] == []
+    assert competition_parameters['safe_low_pins'] == [5]
+    assert competition_parameters['safe_high_pins'] == [27]
+    assert default_manager == practice_manager
+
+
+def test_core_defaults_to_practice_and_selects_both_profile_files():
+    core = load_xml('launcher/launch/questix_core.launch.xml')
+    assert find_arg(core, 'enable_autoreferee').get('default') == 'false'
+
+    lets = {(
+        item.get('name'),
+        item.get('if'),
+        item.get('unless'),
+        item.get('value'),
+    ) for item in core.findall('./let')}
+    assert (
+        'gpio_reader_config_file',
+        None,
+        '$(var enable_autoreferee)',
+        '$(find-pkg-share gpio_reader)/config/gpio_reader.practice.yaml',
+    ) in lets
+    assert (
+        'gpio_reader_config_file',
+        '$(var enable_autoreferee)',
+        None,
+        '$(find-pkg-share gpio_reader)/config/gpio_reader.competition.yaml',
+    ) in lets
+    assert (
+        'operation_manager_config_file',
+        None,
+        '$(var enable_autoreferee)',
+        '$(find-pkg-share operation_manager)/config/operation_manager.practice.yaml',
+    ) in lets
+    assert (
+        'operation_manager_config_file',
+        '$(var enable_autoreferee)',
+        None,
+        '$(find-pkg-share operation_manager)/config/operation_manager.competition.yaml',
+    ) in lets
+
+
+def test_core_owns_exactly_one_operation_manager_when_gpio_ref_is_enabled():
+    core = load_xml('launcher/launch/questix_core.launch.xml')
+    manager_includes = [
+        include for include in core.findall('.//include')
+        if 'find-pkg-share operation_manager' in include.get('file', '')
+    ]
+    assert len(manager_includes) == 1
+    manager_group = next(
+        group for group in core.findall('./group')
+        if manager_includes[0] in list(group)
+    )
+    assert manager_group.get('if') == '$(var enable_gpio_ref)'
+
+    drive_include = next(
+        include for include in core.findall('.//include')
+        if 'drive_component.launch.xml' in include.get('file', '')
+    )
+    manager_arg = next(
+        arg for arg in drive_include.findall('./arg')
+        if arg.get('name') == 'enable_operation_manager'
+    )
+    assert manager_arg.get('value') == 'false'
+
+    drive = load_xml('launcher/launch/drive_component.launch.xml')
+    assert find_arg(drive, 'enable_operation_manager').get('default') == 'true'
+    referee_include = next(
+        include for include in drive.findall('.//include')
+        if 'joy_controller_referee.launch.xml' in include.get('file', '')
+    )
+    forwarded_arg = next(
+        arg for arg in referee_include.findall('./arg')
+        if arg.get('name') == 'enable_operation_manager'
+    )
+    assert forwarded_arg.get('value') == '$(var enable_operation_manager)'
+
+    referee = load_xml('joy_controller/launch/joy_controller_referee.launch.xml')
+    assert find_arg(referee, 'enable_operation_manager').get('default') == 'true'
+    nested_managers = [
+        node for node in referee.findall('.//node')
+        if node.get('pkg') == 'operation_manager'
+    ]
+    assert len(nested_managers) == 1
+    assert nested_managers[0].get('if') == '$(var enable_operation_manager)'
+
+    def integrated_manager_count(enable_drive, enable_shot, enable_gpio_ref):
+        del enable_shot  # operation_manager ownership is independent of shot.
+        core_manager_count = int(enable_gpio_ref)
+        nested_manager_enabled = manager_arg.get('value') != 'false'
+        nested_manager_count = int(
+            enable_drive and enable_gpio_ref and nested_manager_enabled)
+        return core_manager_count + nested_manager_count
+
+    assert integrated_manager_count(False, False, True) == 1
+    assert integrated_manager_count(True, True, True) == 1
+
+
+def test_competition_service_launchers_always_enable_autoreferee():
+    for relative_path in (
+        'systemd/questix_robot_launcher.sh',
+        'ansible/roles/robot_autostart/files/questix_robot_launcher.sh',
+    ):
+        text = (SOURCE_ROOT / relative_path).read_text(encoding='utf-8')
+        assert 'enable_autoreferee:=true' in text
+        assert 'if [ "${MODE}" != "competition" ]' in text

--- a/launcher/test/test_gpio_safety_launch.py
+++ b/launcher/test/test_gpio_safety_launch.py
@@ -54,6 +54,25 @@ def test_profiles_select_the_expected_gpio_inputs_and_polarities():
 def test_core_defaults_to_practice_and_selects_both_profile_files():
     core = load_xml('launcher/launch/questix_core.launch.xml')
     assert find_arg(core, 'enable_autoreferee').get('default') == 'false'
+    invalid_condition = (
+        '$(and $(var enable_autoreferee) $(not $(var enable_gpio_ref)))')
+    fail_fast_group = next(
+        group for group in core.findall('./group')
+        if group.find('./timer/shutdown') is not None
+    )
+    assert fail_fast_group.get('if') == invalid_condition
+    warning = fail_fast_group.find('./log')
+    assert warning is not None
+    assert warning.get('message') == (
+        'ERROR: enable_autoreferee=true requires enable_gpio_ref=true')
+    timer = fail_fast_group.find('./timer')
+    assert timer is not None
+    assert timer.get('period') == '0.01'
+    shutdown = timer.find('./shutdown')
+    assert shutdown is not None
+    assert shutdown.get('reason') == (
+        'Invalid configuration: enable_autoreferee=true requires '
+        'enable_gpio_ref=true')
 
     lets = {(
         item.get('name'),
@@ -143,11 +162,53 @@ def test_core_owns_exactly_one_operation_manager_when_gpio_ref_is_enabled():
     assert integrated_manager_count(True, True, True) == 1
 
 
-def test_competition_service_launchers_always_enable_autoreferee():
-    for relative_path in (
+def test_competition_service_launchers_always_enable_gpio_safety():
+    launcher_paths = (
         'systemd/questix_robot_launcher.sh',
         'ansible/roles/robot_autostart/files/questix_robot_launcher.sh',
-    ):
+    )
+    launcher_texts = []
+    for relative_path in launcher_paths:
         text = (SOURCE_ROOT / relative_path).read_text(encoding='utf-8')
-        assert 'enable_autoreferee:=true' in text
+        launcher_texts.append(text)
+        assert 'LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=true"' in text
+        assert 'LAUNCH_ARGS="${LAUNCH_ARGS} enable_autoreferee:=true"' in text
+        assert 'enable_gpio_ref:=${ENABLE_GPIO_REF' not in text
         assert 'if [ "${MODE}" != "competition" ]' in text
+
+    safety_lines = [
+        [
+            line.strip() for line in text.splitlines()
+            if 'enable_gpio_ref:=' in line or 'enable_autoreferee:=' in line
+        ]
+        for text in launcher_texts
+    ]
+    assert safety_lines[0] == safety_lines[1]
+
+
+def test_launch_environment_defaults_enable_gpio_safety():
+    systemd_env = (
+        SOURCE_ROOT / 'systemd/questix_robot.env').read_text(encoding='utf-8')
+    ansible_env = (
+        SOURCE_ROOT / 'ansible/roles/robot_autostart/templates/launch.env.j2'
+    ).read_text(encoding='utf-8')
+
+    assert 'ENABLE_GPIO_REF=true' in systemd_env.splitlines()
+    assert 'ENABLE_GPIO_REF=true' in ansible_env.splitlines()
+
+
+def test_installers_preserve_existing_environment_but_launcher_is_safe():
+    installer = (
+        SOURCE_ROOT / 'scripts/install-robot-manager.sh'
+    ).read_text(encoding='utf-8')
+    ansible_tasks = (
+        SOURCE_ROOT / 'ansible/roles/robot_autostart/tasks/main.yaml'
+    ).read_text(encoding='utf-8')
+
+    assert (
+        '"${REPO_DIR}/systemd/questix_robot.env" > '
+        '/etc/questix_robot/launch.env'
+    ) in installer
+    assert 'launch.env already exists, skipping' in installer
+    assert 'src: launch.env.j2' in ansible_tasks
+    assert 'force: false' in ansible_tasks

--- a/launcher/test/test_gpio_safety_launch.py
+++ b/launcher/test/test_gpio_safety_launch.py
@@ -58,6 +58,7 @@ def test_core_defaults_to_practice_and_selects_both_profile_files():
     assert find_arg(core, 'enable_autoreferee').get('default') == 'false'
     invalid_condition = (
         '$(and $(var enable_autoreferee) $(not $(var enable_gpio_ref)))')
+
     fail_fast_group = next(
         group for group in core.findall('./group')
         if group.find('./timer/shutdown') is not None
@@ -75,6 +76,24 @@ def test_core_defaults_to_practice_and_selects_both_profile_files():
     assert shutdown.get('reason') == (
         'Invalid configuration: enable_autoreferee=true requires '
         'enable_gpio_ref=true')
+
+    valid_group = next(
+        group for group in core.findall('./group')
+        if group.get('unless') == invalid_condition
+    )
+    assert fail_fast_group.find('.//include') is None
+    assert fail_fast_group.find('.//node') is None
+    assert len(valid_group.findall('.//include')) == len(core.findall('.//include'))
+    assert len(valid_group.findall('.//node')) == len(core.findall('.//node'))
+    guarded_files = {
+        include.get('file') for include in valid_group.findall('.//include')
+    }
+    assert any('shot_component.launch.xml' in path for path in guarded_files)
+    assert any('drive_component.launch.xml' in path for path in guarded_files)
+    assert any('ydlidar_launch.py' in path for path in guarded_files)
+    assert any('gpio_reader.launch.xml' in path for path in guarded_files)
+    assert any('operation_manager.launch.xml' in path for path in guarded_files)
+    assert valid_group.find(".//node[@name='rviz2']") is not None
 
     lets = {(
         item.get('name'),
@@ -116,7 +135,7 @@ def test_core_owns_exactly_one_operation_manager_when_gpio_ref_is_enabled():
     ]
     assert len(manager_includes) == 1
     manager_group = next(
-        group for group in core.findall('./group')
+        group for group in core.findall('.//group')
         if manager_includes[0] in list(group)
     )
     assert manager_group.get('if') == '$(var enable_gpio_ref)'

--- a/launcher/test/test_gpio_safety_launch.py
+++ b/launcher/test/test_gpio_safety_launch.py
@@ -45,9 +45,11 @@ def test_profiles_select_the_expected_gpio_inputs_and_polarities():
     competition_parameters = competition_manager[
         'operation_manager_node']['ros__parameters']
     assert practice_parameters['safe_low_pins'] == [5]
-    assert practice_parameters['safe_high_pins'] == []
+    assert 'safe_high_pins' not in practice_parameters
     assert competition_parameters['safe_low_pins'] == [5]
     assert competition_parameters['safe_high_pins'] == [27]
+    assert 'safe_high_pins' not in default_manager[
+        'operation_manager_node']['ros__parameters']
     assert default_manager == practice_manager
 
 

--- a/launcher/test/test_gpio_safety_runtime.py
+++ b/launcher/test/test_gpio_safety_runtime.py
@@ -1,0 +1,166 @@
+# Copyright 2026 scramble-robot
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""ROS 2 runtime smoke tests for installed GPIO safety parameter profiles."""
+
+import os
+from pathlib import Path
+import signal
+import subprocess
+import time
+
+import pytest
+
+
+STARTUP_TIMEOUT_SECONDS = 15.0
+COMMAND_TIMEOUT_SECONDS = 5.0
+
+
+def isolated_ros_environment(offset):
+    """Return an environment using a test-specific local ROS domain."""
+    environment = os.environ.copy()
+    environment['ROS_DOMAIN_ID'] = str(100 + ((os.getpid() + offset) % 100))
+    environment['ROS_AUTOMATIC_DISCOVERY_RANGE'] = 'LOCALHOST'
+    environment.pop('ROS_LOCALHOST_ONLY', None)
+    return environment
+
+
+def run_command(command, environment, timeout=COMMAND_TIMEOUT_SECONDS):
+    """Run a ROS command and capture text output."""
+    return subprocess.run(
+        command,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def start_process(command, environment):
+    """Start a ROS process in its own group for scoped cleanup."""
+    return subprocess.Popen(
+        command,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def stop_process(process):
+    """Stop only the process group created by this test and return its output."""
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGINT)
+    try:
+        output, _ = process.communicate(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        try:
+            output, _ = process.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            output, _ = process.communicate(timeout=5.0)
+    return output
+
+
+def wait_for_parameter(node_name, parameter_name, environment):
+    """Wait until a node is alive and returns a parameter value."""
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    last_result = None
+    while time.monotonic() < deadline:
+        last_result = run_command(
+            ['ros2', 'param', 'get', node_name, parameter_name], environment)
+        if last_result.returncode == 0:
+            value_lines = [
+                line for line in last_result.stdout.splitlines()
+                if 'values are:' in line
+            ]
+            assert value_lines, last_result.stdout
+            return value_lines[-1]
+        time.sleep(0.2)
+    output = last_result.stdout if last_result is not None else 'command not run'
+    pytest.fail(f'{node_name} did not provide {parameter_name}: {output}')
+
+
+def installed_profile_path(profile_name, environment):
+    """Resolve a profile from the installed operation_manager package share."""
+    result = run_command(['ros2', 'pkg', 'prefix', 'operation_manager'], environment)
+    assert result.returncode == 0, result.stdout
+    path = (
+        Path(result.stdout.strip()) / 'share' / 'operation_manager' / 'config' /
+        profile_name
+    )
+    assert path.is_file(), f'installed profile not found: {path}'
+    return path
+
+
+@pytest.mark.parametrize(
+    ('profile_name', 'expected_safe_high'),
+    [
+        ('operation_manager.practice.yaml', 'Integer values are: []'),
+        ('operation_manager.competition.yaml', 'Integer values are: [27]'),
+    ],
+)
+def test_installed_profiles_load_with_typed_integer_arrays(profile_name, expected_safe_high):
+    """Load installed YAML through rclcpp and verify both polarity arrays."""
+    environment = isolated_ros_environment(0 if 'practice' in profile_name else 1)
+    profile_path = installed_profile_path(profile_name, environment)
+    node_name = '/operation_manager_node'
+    process = start_process(
+        [
+            'ros2', 'run', 'operation_manager', 'operation_manager_node',
+            '--ros-args', '--params-file', str(profile_path),
+        ],
+        environment,
+    )
+    try:
+        safe_low = wait_for_parameter(node_name, 'safe_low_pins', environment)
+        safe_high = wait_for_parameter(node_name, 'safe_high_pins', environment)
+        assert process.poll() is None, 'operation_manager exited after loading its profile'
+        assert safe_low == 'Integer values are: [5]'
+        assert safe_high == expected_safe_high
+    finally:
+        output = stop_process(process)
+    assert 'InvalidParameterValueException' not in output
+    assert 'parameter_value_from failed' not in output
+
+
+def test_practice_core_launch_keeps_gpio_safety_nodes_alive():
+    """Start the installed practice safety-only launch and verify both nodes survive."""
+    environment = isolated_ros_environment(2)
+    process = start_process(
+        [
+            'ros2', 'launch', 'questix_launcher', 'questix_core.launch.xml',
+            'enable_lidar:=false',
+            'enable_shot:=false',
+            'enable_drive:=false',
+            'enable_gpio_ref:=true',
+            'enable_autoreferee:=false',
+            'enable_rviz:=false',
+        ],
+        environment,
+    )
+    expected_nodes = {'/gpio_reader_node', '/operation_manager_node'}
+    observed_nodes = set()
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    try:
+        while time.monotonic() < deadline:
+            assert process.poll() is None, 'questix_core exited during practice startup'
+            result = run_command(['ros2', 'node', 'list', '--no-daemon'], environment)
+            if result.returncode == 0:
+                observed_nodes = set(result.stdout.splitlines())
+                if expected_nodes <= observed_nodes:
+                    break
+            time.sleep(0.2)
+        assert expected_nodes <= observed_nodes
+        assert process.poll() is None
+    finally:
+        output = stop_process(process)
+    assert 'InvalidParameterValueException' not in output
+    assert 'parameter_value_from failed' not in output

--- a/launcher/test/test_gpio_safety_runtime.py
+++ b/launcher/test/test_gpio_safety_runtime.py
@@ -131,6 +131,49 @@ def test_installed_profiles_load_with_typed_integer_arrays(profile_name, expecte
     assert 'parameter_value_from failed' not in output
 
 
+def test_invalid_autoreferee_configuration_starts_no_child_processes():
+    """Reject the invalid profile before any hardware-facing child can start."""
+    environment = isolated_ros_environment(3)
+    process = start_process(
+        [
+            'ros2', 'launch', 'questix_launcher', 'questix_core.launch.xml',
+            'enable_lidar:=true',
+            'enable_shot:=true',
+            'enable_drive:=true',
+            'enable_gpio_ref:=false',
+            'enable_autoreferee:=true',
+            'enable_rviz:=true',
+        ],
+        environment,
+    )
+    forbidden_nodes = {
+        '/gpio_reader_node',
+        '/operation_manager_node',
+        '/drive_component',
+        '/shot_component',
+        '/esc_motor_control',
+        '/ydlidar_ros2_driver_node',
+        '/rviz2',
+    }
+    observed_nodes = set()
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    while process.poll() is None and time.monotonic() < deadline:
+        result = run_command(['ros2', 'node', 'list', '--no-daemon'], environment)
+        if result.returncode == 0:
+            observed_nodes.update(result.stdout.splitlines())
+        time.sleep(0.02)
+
+    try:
+        assert process.poll() is not None, 'invalid questix_core launch did not exit'
+        assert process.returncode == 0
+    finally:
+        output = stop_process(process)
+
+    assert 'ERROR: enable_autoreferee=true requires enable_gpio_ref=true' in output
+    assert forbidden_nodes.isdisjoint(observed_nodes)
+    assert 'process started with pid' not in output
+
+
 def test_practice_core_launch_keeps_gpio_safety_nodes_alive():
     """Start the installed practice safety-only launch and verify both nodes survive."""
     environment = isolated_ros_environment(2)

--- a/operation_manager/CMakeLists.txt
+++ b/operation_manager/CMakeLists.txt
@@ -4,9 +4,14 @@ project(operation_manager)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+ament_auto_add_library(operation_manager_safety_logic SHARED
+  src/gpio_safety_evaluator.cpp
+)
+
 ament_auto_add_library(operation_manager_component SHARED
   src/operation_manager_component.cpp
 )
+target_link_libraries(operation_manager_component operation_manager_safety_logic)
 
 rclcpp_components_register_nodes(operation_manager_component
   "operation_manager::OperationManagerComponent")
@@ -16,5 +21,17 @@ ament_auto_add_executable(operation_manager_node
 )
 
 target_link_libraries(operation_manager_node operation_manager_component)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_gpio_safety_evaluator test/test_gpio_safety_evaluator.cpp)
+  target_link_libraries(test_gpio_safety_evaluator operation_manager_safety_logic)
+
+  ament_auto_add_gtest(test_operation_manager_node test/test_operation_manager_node.cpp)
+  target_link_libraries(test_operation_manager_node operation_manager_component)
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/operation_manager/README.md
+++ b/operation_manager/README.md
@@ -1,25 +1,72 @@
 # operation_manager
 
-ROS2 package that subscribes to GPIO topics (published by `gpio_reader`) and decides whether GPIO IO is "controllable".
+ROS 2 package that subscribes to raw GPIO topics from `gpio_reader` and
+produces the robot-wide fail-safe controllability state.
 
 Publishers:
 - `/gpio/controllable` (std_msgs/Bool): true if controllable
 - `/diagnostics` (diagnostic_msgs/DiagnosticArray): standard diagnostic aggregation
   topic. One `DiagnosticStatus` (name `operation_manager: gpio_controllability`,
   hardware_id `gpio`) with `level` OK/ERROR and per-pin `KeyValue` entries
-  (`pin_<N>_state`, `pin_<N>_age_sec`). Consumable by `rqt_runtime_monitor`.
+  (`pin_<N>_state`, `pin_<N>_expected`, `pin_<N>_received`,
+  `pin_<N>_age_sec`). GPIO27 also includes `pin_27_signal_limit`, which
+  records that a high input cannot distinguish permission from disconnected,
+  client-unpowered, or primary-side-open states. Consumable by
+  `rqt_runtime_monitor`.
 - `/emergency_stop` (questix_msgs/EmergencyStop, reliable + transient_local, keep-last(1)):
   unified emergency stop state, `active = !controllable`, published on every
-  controllability evaluation (each GPIO update plus the 1 s timer heartbeat).
+  controllability evaluation (each GPIO update plus the 100 ms watchdog timer).
   See `questix_msgs/README.md` for the full topic contract and recovery semantics.
 
-Parameters (config/operation_manager.yaml):
-- `monitored_pins`: list of GPIO pin numbers to subscribe to (`gpio_<PIN>` topics)
+Parameters:
+
+- `safe_low_pins`: pins whose safe value is `false` (stop on `true`)
+- `safe_high_pins`: pins whose safe value is `true` (stop on `false`)
 - `timeout_seconds`: maximum allowed age of GPIO update before marking not controllable
 - `emergency_stop_topic`: topic name for the unified emergency stop state (default `/emergency_stop`)
+
+The two pin lists define the monitored pins; no separate parallel
+`monitored_pins` array exists. Startup fails for an empty configuration,
+duplicates, overlap between lists, BCM values outside 0--53, or a non-positive
+timeout.
+
+Profiles:
+
+- `config/operation_manager.practice.yaml`: `safe_low_pins: [5]`,
+  `safe_high_pins: []`
+- `config/operation_manager.competition.yaml`: `safe_low_pins: [5]`,
+  `safe_high_pins: [27]`
+- `config/operation_manager.yaml`: backward-compatible safe practice default
+
+GPIO5 is the raw indication from the physical emergency-stop circuit. The
+circuit independently removes motor power through RLY1; GPIO5 reports its state
+to ROS. RLY1 cuts power to both DDT drive motors, the roller ESC, Shot servo,
+and Tilt servo while Raspberry Pi, 5 V I/O, and 3.3 V I/O remain powered. The
+hardware cutoff and ROS software stop are independent, redundant safety paths.
+
+GPIO27 is the competition-only AutoReferee `AR_in`. The client defeat output
+is 5 V when defeated and 0 V otherwise; the HAT optocoupler inverts it, so
+defeated is `false`/stop and R2 (10 kΩ) pulls the not-defeated state to
+3.3 V/`true`. Disconnected AutoReferee, unpowered client, and primary-side
+open circuit also read `true`. This hardware ambiguity cannot be detected by
+operation_manager and is reported in diagnostics as `pin_27_signal_limit`.
+
+No pin is considered safe until its first message has arrived. Every required
+pin must be received, fresh, and equal to its configured safe value. Reasons
+distinguish `not received`, `timeout`, and actual/expected value mismatch.
+`/emergency_stop.active` is always the inverse of `/gpio/controllable`.
+
+| Mode | GPIO5 physical E-stop | GPIO27 AutoReferee | Controllable |
+|---|---:|---:|---:|
+| practice | false | not monitored | true |
+| practice | true | not monitored | false |
+| competition | false | true | true |
+| competition | true | any | false |
+| competition | any | false | false |
+| any | missing or stale required input | - | false |
 
 Build:
 - colcon build --packages-select operation_manager
 
 Run (with config):
-- ros2 launch operation_manager operation_manager.launch.py
+- `ros2 launch operation_manager operation_manager.launch.xml`

--- a/operation_manager/README.md
+++ b/operation_manager/README.md
@@ -33,10 +33,13 @@ timeout.
 Profiles:
 
 - `config/operation_manager.practice.yaml`: `safe_low_pins: [5]`,
-  `safe_high_pins: []`
+  with `safe_high_pins` omitted so the node uses its typed empty integer-array
+  default. Do not write an untyped YAML `[]`: the ROS 2 parameter parser treats
+  it as `PARAMETER_NOT_SET` rather than an empty integer array.
 - `config/operation_manager.competition.yaml`: `safe_low_pins: [5]`,
   `safe_high_pins: [27]`
-- `config/operation_manager.yaml`: backward-compatible safe practice default
+- `config/operation_manager.yaml`: backward-compatible safe practice default,
+  also omitting `safe_high_pins`
 
 GPIO5 is the raw indication from the physical emergency-stop circuit. The
 circuit independently removes motor power through RLY1; GPIO5 reports its state

--- a/operation_manager/README.md
+++ b/operation_manager/README.md
@@ -53,8 +53,16 @@ operation_manager and is reported in diagnostics as `pin_27_signal_limit`.
 
 No pin is considered safe until its first message has arrived. Every required
 pin must be received, fresh, and equal to its configured safe value. Reasons
-distinguish `not received`, `timeout`, and actual/expected value mismatch.
+distinguish `not received`, `timeout`, actual/expected value mismatch,
+non-finite time, and time moving backwards.
 `/emergency_stop.active` is always the inverse of `/gpio/controllable`.
+
+GPIO freshness uses `std::chrono::steady_clock`, which is monotonic and is
+independent of ROS or system-clock adjustments. ROS time remains in the
+`/diagnostics` and `/emergency_stop` message header stamps. The evaluator also
+treats a backwards or NaN/infinite freshness timestamp as not controllable,
+with an infinite diagnostic age, so an invalid time source cannot extend the
+fresh period.
 
 | Mode | GPIO5 physical E-stop | GPIO27 AutoReferee | Controllable |
 |---|---:|---:|---:|

--- a/operation_manager/config/operation_manager.competition.yaml
+++ b/operation_manager/config/operation_manager.competition.yaml
@@ -1,0 +1,13 @@
+operation_manager_node:
+  ros__parameters:
+    # Competition profile:
+    # safe_low_pins are safe when false (GPIO5 physical E-stop).
+    # safe_high_pins are safe when true (GPIO27 AutoReferee AR_in).
+    # Hardware also reads true when AutoReferee is disconnected/unpowered or
+    # its primary side is open, so software cannot distinguish those states.
+    safe_low_pins: [5]
+    safe_high_pins: [27]
+    timeout_seconds: 1.0
+    # questix_msgs/EmergencyStop, reliable + transient_local + keep-last 1.
+    # active is always the inverse of /gpio/controllable.
+    emergency_stop_topic: "/emergency_stop"

--- a/operation_manager/config/operation_manager.practice.yaml
+++ b/operation_manager/config/operation_manager.practice.yaml
@@ -2,8 +2,9 @@ operation_manager_node:
   ros__parameters:
     # Practice profile. GPIO5 is the physical E-stop indication:
     # false = released/safe, true = pressed/stop.
+    # safe_high_pins is intentionally omitted. ROS 2 cannot infer an integer-array
+    # type from YAML []; use the node's typed empty integer-array default instead.
     safe_low_pins: [5]
-    safe_high_pins: []
     timeout_seconds: 1.0
     # questix_msgs/EmergencyStop, reliable + transient_local + keep-last 1.
     # active is always the inverse of /gpio/controllable.

--- a/operation_manager/config/operation_manager.practice.yaml
+++ b/operation_manager/config/operation_manager.practice.yaml
@@ -1,0 +1,10 @@
+operation_manager_node:
+  ros__parameters:
+    # Practice profile. GPIO5 is the physical E-stop indication:
+    # false = released/safe, true = pressed/stop.
+    safe_low_pins: [5]
+    safe_high_pins: []
+    timeout_seconds: 1.0
+    # questix_msgs/EmergencyStop, reliable + transient_local + keep-last 1.
+    # active is always the inverse of /gpio/controllable.
+    emergency_stop_topic: "/emergency_stop"

--- a/operation_manager/config/operation_manager.yaml
+++ b/operation_manager/config/operation_manager.yaml
@@ -2,9 +2,10 @@ operation_manager_node:
   ros__parameters:
     # Safe standalone/default profile: practice mode.
     # false is safe for GPIO5; GPIO27 is not subscribed to or evaluated.
+    # safe_high_pins is intentionally omitted. ROS 2 cannot infer an integer-array
+    # type from YAML []; use the node's typed empty integer-array default instead.
     # Keep this compatibility config identical to operation_manager.practice.yaml.
     safe_low_pins: [5]
-    safe_high_pins: []
     timeout_seconds: 1.0
     # 診断は標準 diagnostic_msgs/DiagnosticArray を /diagnostics へ publish する
     # （rqt_runtime_monitor が消費可）。契約: questix_msgs/README.md。

--- a/operation_manager/config/operation_manager.yaml
+++ b/operation_manager/config/operation_manager.yaml
@@ -1,6 +1,10 @@
 operation_manager_node:
   ros__parameters:
-    monitored_pins: [27]
+    # Safe standalone/default profile: practice mode.
+    # false is safe for GPIO5; GPIO27 is not subscribed to or evaluated.
+    # Keep this compatibility config identical to operation_manager.practice.yaml.
+    safe_low_pins: [5]
+    safe_high_pins: []
     timeout_seconds: 1.0
     # 診断は標準 diagnostic_msgs/DiagnosticArray を /diagnostics へ publish する
     # （rqt_runtime_monitor が消費可）。契約: questix_msgs/README.md。

--- a/operation_manager/include/operation_manager/gpio_safety_evaluator.hpp
+++ b/operation_manager/include/operation_manager/gpio_safety_evaluator.hpp
@@ -36,8 +36,10 @@ public:
   GpioSafetyEvaluator(const std::vector<int64_t>& safe_low_pins,
                       const std::vector<int64_t>& safe_high_pins, double timeout_seconds);
 
-  void update(unsigned int pin, bool value, double now_seconds);
-  GpioSafetyEvaluation evaluate(double now_seconds) const;
+  // Timestamps must use the same monotonic time source. The evaluator fails safe
+  // if a received pin has a non-finite timestamp or time moves backwards.
+  void update(unsigned int pin, bool value, double monotonic_now_seconds);
+  GpioSafetyEvaluation evaluate(double monotonic_now_seconds) const;
   std::vector<unsigned int> monitored_pins() const;
 
 private:

--- a/operation_manager/include/operation_manager/gpio_safety_evaluator.hpp
+++ b/operation_manager/include/operation_manager/gpio_safety_evaluator.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef OPERATION_MANAGER__GPIO_SAFETY_EVALUATOR_HPP_
+#define OPERATION_MANAGER__GPIO_SAFETY_EVALUATOR_HPP_
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace operation_manager {
+
+struct GpioPinEvaluation {
+  unsigned int pin;
+  bool expected_value;
+  bool received;
+  bool value;
+  double age_seconds;
+};
+
+struct GpioSafetyEvaluation {
+  bool controllable;
+  std::string reason;
+  std::vector<GpioPinEvaluation> pins;
+};
+
+class GpioSafetyEvaluator {
+public:
+  static constexpr int64_t kMinBcmPin = 0;
+  static constexpr int64_t kMaxBcmPin = 53;
+
+  GpioSafetyEvaluator(const std::vector<int64_t>& safe_low_pins,
+                      const std::vector<int64_t>& safe_high_pins, double timeout_seconds);
+
+  void update(unsigned int pin, bool value, double now_seconds);
+  GpioSafetyEvaluation evaluate(double now_seconds) const;
+  std::vector<unsigned int> monitored_pins() const;
+
+private:
+  struct PinState {
+    bool expected_value;
+    bool received{false};
+    bool value{false};
+    double last_update_seconds{0.0};
+  };
+
+  void add_pins(const std::vector<int64_t>& pins, bool expected_value,
+                const std::string& parameter_name);
+
+  std::map<unsigned int, PinState> pins_;
+  double timeout_seconds_;
+};
+
+}  // namespace operation_manager
+
+#endif  // OPERATION_MANAGER__GPIO_SAFETY_EVALUATOR_HPP_

--- a/operation_manager/include/operation_manager/operation_manager_component.hpp
+++ b/operation_manager/include/operation_manager/operation_manager_component.hpp
@@ -8,12 +8,14 @@
 #define OPERATION_MANAGER__OPERATION_MANAGER_COMPONENT_HPP_
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
-#include <map>
+#include <map>     // NOLINT(build/include_order)
+#include <memory>  // NOLINT(build/include_order)
 #include <questix_msgs/msg/emergency_stop.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
-#include <string>
-#include <vector>
+#include <string>  // NOLINT(build/include_order)
+
+#include "operation_manager/gpio_safety_evaluator.hpp"
 
 namespace operation_manager {
 
@@ -21,14 +23,14 @@ class OperationManagerComponent : public rclcpp::Node {
 public:
   explicit OperationManagerComponent(const rclcpp::NodeOptions& options);
   virtual ~OperationManagerComponent();
+  static rclcpp::QoS emergency_stop_qos();
 
 private:
   void gpio_callback(const std_msgs::msg::Bool::SharedPtr msg, unsigned int pin);
   void evaluate_controllability();
 
-  std::map<unsigned int, bool> gpio_states_;
   std::map<unsigned int, rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr> gpio_subs_;
-  std::map<unsigned int, rclcpp::Time> gpio_last_update_;
+  std::unique_ptr<GpioSafetyEvaluator> safety_evaluator_;
 
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr controllable_pub_;
   // 標準診断集約トピック（rqt_runtime_monitor 等がそのまま消費できる）。
@@ -37,8 +39,6 @@ private:
 
   rclcpp::TimerBase::SharedPtr eval_timer_;
 
-  double timeout_seconds_;
-  std::vector<int64_t> monitored_pins_;
   std::string emergency_stop_topic_;
 };
 

--- a/operation_manager/package.xml
+++ b/operation_manager/package.xml
@@ -13,6 +13,10 @@
   <depend>std_msgs</depend>
   <depend>diagnostic_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/operation_manager/src/gpio_safety_evaluator.cpp
+++ b/operation_manager/src/gpio_safety_evaluator.cpp
@@ -67,9 +67,9 @@ GpioSafetyEvaluation GpioSafetyEvaluator::evaluate(double monotonic_now_seconds)
   for (const auto& pair : pins_) {
     const auto pin = pair.first;
     const auto& state = pair.second;
-    const bool invalid_time =
-        state.received &&
-        (!std::isfinite(monotonic_now_seconds) || !std::isfinite(state.last_update_seconds));
+    const bool invalid_time = state.received &&
+        (!std::isfinite(monotonic_now_seconds) ||
+                                                 !std::isfinite(state.last_update_seconds));
     const bool time_moved_backwards =
         state.received && !invalid_time && monotonic_now_seconds < state.last_update_seconds;
     const double age_seconds =

--- a/operation_manager/src/gpio_safety_evaluator.cpp
+++ b/operation_manager/src/gpio_safety_evaluator.cpp
@@ -1,0 +1,100 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "operation_manager/gpio_safety_evaluator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <set>
+#include <stdexcept>
+
+namespace operation_manager {
+
+GpioSafetyEvaluator::GpioSafetyEvaluator(const std::vector<int64_t>& safe_low_pins,
+                                         const std::vector<int64_t>& safe_high_pins,
+                                         double timeout_seconds)
+    : timeout_seconds_(timeout_seconds) {
+  if (!std::isfinite(timeout_seconds_) || timeout_seconds_ <= 0.0) {
+    throw std::invalid_argument("timeout_seconds must be finite and greater than zero");
+  }
+
+  add_pins(safe_low_pins, false, "safe_low_pins");
+  add_pins(safe_high_pins, true, "safe_high_pins");
+  if (pins_.empty()) {
+    throw std::invalid_argument("at least one safe GPIO pin must be configured");
+  }
+}
+
+void GpioSafetyEvaluator::add_pins(const std::vector<int64_t>& pins, bool expected_value,
+                                   const std::string& parameter_name) {
+  std::set<int64_t> parameter_pins;
+  for (const auto pin : pins) {
+    if (pin < kMinBcmPin || pin > kMaxBcmPin) {
+      throw std::invalid_argument(parameter_name + " contains out-of-range BCM pin " +
+                                  std::to_string(pin));
+    }
+    if (!parameter_pins.insert(pin).second) {
+      throw std::invalid_argument(parameter_name + " contains duplicate pin " +
+                                  std::to_string(pin));
+    }
+
+    const auto result =
+        pins_.emplace(static_cast<unsigned int>(pin), PinState{expected_value, false, false, 0.0});
+    if (!result.second) {
+      throw std::invalid_argument("pin " + std::to_string(pin) +
+                                  " is configured as both safe-low and safe-high");
+    }
+  }
+}
+
+void GpioSafetyEvaluator::update(unsigned int pin, bool value, double now_seconds) {
+  auto it = pins_.find(pin);
+  if (it == pins_.end()) {
+    throw std::invalid_argument("received update for unmonitored pin " + std::to_string(pin));
+  }
+  it->second.received = true;
+  it->second.value = value;
+  it->second.last_update_seconds = now_seconds;
+}
+
+GpioSafetyEvaluation GpioSafetyEvaluator::evaluate(double now_seconds) const {
+  GpioSafetyEvaluation result{true, "", {}};
+  result.pins.reserve(pins_.size());
+
+  for (const auto& pair : pins_) {
+    const auto pin = pair.first;
+    const auto& state = pair.second;
+    const double age_seconds =
+        state.received ? std::max(0.0, now_seconds - state.last_update_seconds) : 0.0;
+    result.pins.push_back(
+        GpioPinEvaluation{pin, state.expected_value, state.received, state.value, age_seconds});
+
+    if (!state.received) {
+      result.controllable = false;
+      result.reason += "pin " + std::to_string(pin) + " not received; ";
+    } else if (age_seconds > timeout_seconds_) {
+      result.controllable = false;
+      result.reason += "pin " + std::to_string(pin) + " timeout; ";
+    } else if (state.value != state.expected_value) {
+      result.controllable = false;
+      result.reason += "pin " + std::to_string(pin) + " is " + (state.value ? "true" : "false") +
+                       ", expected " + (state.expected_value ? "true" : "false") + "; ";
+    }
+  }
+
+  return result;
+}
+
+std::vector<unsigned int> GpioSafetyEvaluator::monitored_pins() const {
+  std::vector<unsigned int> pins;
+  pins.reserve(pins_.size());
+  for (const auto& pair : pins_) {
+    pins.push_back(pair.first);
+  }
+  return pins;
+}
+
+}  // namespace operation_manager

--- a/operation_manager/src/gpio_safety_evaluator.cpp
+++ b/operation_manager/src/gpio_safety_evaluator.cpp
@@ -67,8 +67,7 @@ GpioSafetyEvaluation GpioSafetyEvaluator::evaluate(double monotonic_now_seconds)
   for (const auto& pair : pins_) {
     const auto pin = pair.first;
     const auto& state = pair.second;
-    const bool invalid_time = state.received &&
-        (!std::isfinite(monotonic_now_seconds) ||
+    const bool invalid_time = state.received && (!std::isfinite(monotonic_now_seconds) ||
                                                  !std::isfinite(state.last_update_seconds));
     const bool time_moved_backwards =
         state.received && !invalid_time && monotonic_now_seconds < state.last_update_seconds;

--- a/operation_manager/src/gpio_safety_evaluator.cpp
+++ b/operation_manager/src/gpio_safety_evaluator.cpp
@@ -6,8 +6,8 @@
 
 #include "operation_manager/gpio_safety_evaluator.hpp"
 
-#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <set>
 #include <stdexcept>
 
@@ -50,31 +50,44 @@ void GpioSafetyEvaluator::add_pins(const std::vector<int64_t>& pins, bool expect
   }
 }
 
-void GpioSafetyEvaluator::update(unsigned int pin, bool value, double now_seconds) {
+void GpioSafetyEvaluator::update(unsigned int pin, bool value, double monotonic_now_seconds) {
   auto it = pins_.find(pin);
   if (it == pins_.end()) {
     throw std::invalid_argument("received update for unmonitored pin " + std::to_string(pin));
   }
   it->second.received = true;
   it->second.value = value;
-  it->second.last_update_seconds = now_seconds;
+  it->second.last_update_seconds = monotonic_now_seconds;
 }
 
-GpioSafetyEvaluation GpioSafetyEvaluator::evaluate(double now_seconds) const {
+GpioSafetyEvaluation GpioSafetyEvaluator::evaluate(double monotonic_now_seconds) const {
   GpioSafetyEvaluation result{true, "", {}};
   result.pins.reserve(pins_.size());
 
   for (const auto& pair : pins_) {
     const auto pin = pair.first;
     const auto& state = pair.second;
+    const bool invalid_time =
+        state.received &&
+        (!std::isfinite(monotonic_now_seconds) || !std::isfinite(state.last_update_seconds));
+    const bool time_moved_backwards =
+        state.received && !invalid_time && monotonic_now_seconds < state.last_update_seconds;
     const double age_seconds =
-        state.received ? std::max(0.0, now_seconds - state.last_update_seconds) : 0.0;
+        state.received && !invalid_time && !time_moved_backwards
+            ? monotonic_now_seconds - state.last_update_seconds
+            : (state.received ? std::numeric_limits<double>::infinity() : 0.0);
     result.pins.push_back(
         GpioPinEvaluation{pin, state.expected_value, state.received, state.value, age_seconds});
 
     if (!state.received) {
       result.controllable = false;
       result.reason += "pin " + std::to_string(pin) + " not received; ";
+    } else if (invalid_time) {
+      result.controllable = false;
+      result.reason += "pin " + std::to_string(pin) + " time is not finite; ";
+    } else if (time_moved_backwards) {
+      result.controllable = false;
+      result.reason += "pin " + std::to_string(pin) + " time moved backwards; ";
     } else if (age_seconds > timeout_seconds_) {
       result.controllable = false;
       result.reason += "pin " + std::to_string(pin) + " timeout; ";

--- a/operation_manager/src/operation_manager_component.cpp
+++ b/operation_manager/src/operation_manager_component.cpp
@@ -13,8 +13,7 @@
 namespace {
 
 double steady_now_seconds() {
-  return std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch())
-      .count();
+  return std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
 }  // namespace

--- a/operation_manager/src/operation_manager_component.cpp
+++ b/operation_manager/src/operation_manager_component.cpp
@@ -10,6 +10,15 @@
 #include <functional>
 #include <rclcpp_components/register_node_macro.hpp>
 
+namespace {
+
+double steady_now_seconds() {
+  return std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+}  // namespace
+
 namespace operation_manager {
 
 OperationManagerComponent::OperationManagerComponent(const rclcpp::NodeOptions& options)
@@ -59,14 +68,16 @@ rclcpp::QoS OperationManagerComponent::emergency_stop_qos() {
 
 void OperationManagerComponent::gpio_callback(const std_msgs::msg::Bool::SharedPtr msg,
                                               unsigned int pin) {
-  safety_evaluator_->update(pin, msg->data, this->now().seconds());
+  safety_evaluator_->update(pin, msg->data, steady_now_seconds());
   // Immediately evaluate on update
   evaluate_controllability();
 }
 
 void OperationManagerComponent::evaluate_controllability() {
+  // ROS time remains authoritative for message stamps. Freshness uses a monotonic
+  // clock so a ROS/system-clock adjustment cannot make stale GPIO data look fresh.
   rclcpp::Time now = this->now();
-  const auto evaluation = safety_evaluator_->evaluate(now.seconds());
+  const auto evaluation = safety_evaluator_->evaluate(steady_now_seconds());
 
   // 標準 DiagnosticArray 用に、ピンごとの状態を KeyValue として収集する。
   diagnostic_msgs::msg::DiagnosticStatus status;

--- a/operation_manager/src/operation_manager_component.cpp
+++ b/operation_manager/src/operation_manager_component.cpp
@@ -14,13 +14,17 @@ namespace operation_manager {
 
 OperationManagerComponent::OperationManagerComponent(const rclcpp::NodeOptions& options)
     : Node("operation_manager_node", options) {
-  this->declare_parameter<std::vector<int64_t>>("monitored_pins", std::vector<int64_t>{27});
+  this->declare_parameter<std::vector<int64_t>>("safe_low_pins", std::vector<int64_t>{5});
+  this->declare_parameter<std::vector<int64_t>>("safe_high_pins", std::vector<int64_t>{});
   this->declare_parameter<double>("timeout_seconds", 1.0);
   this->declare_parameter<std::string>("emergency_stop_topic", "/emergency_stop");
 
-  monitored_pins_ = this->get_parameter("monitored_pins").as_integer_array();
-  timeout_seconds_ = this->get_parameter("timeout_seconds").as_double();
+  const auto safe_low_pins = this->get_parameter("safe_low_pins").as_integer_array();
+  const auto safe_high_pins = this->get_parameter("safe_high_pins").as_integer_array();
+  const auto timeout_seconds = this->get_parameter("timeout_seconds").as_double();
   emergency_stop_topic_ = this->get_parameter("emergency_stop_topic").as_string();
+  safety_evaluator_ =
+      std::make_unique<GpioSafetyEvaluator>(safe_low_pins, safe_high_pins, timeout_seconds);
 
   controllable_pub_ = this->create_publisher<std_msgs::msg::Bool>("/gpio/controllable", 1);
   diagnostics_pub_ =
@@ -28,77 +32,83 @@ OperationManagerComponent::OperationManagerComponent(const rclcpp::NodeOptions& 
   // Latched so late-joining subscribers immediately receive the current state
   // (topic contract: see questix_msgs/README.md).
   emergency_stop_pub_ = this->create_publisher<questix_msgs::msg::EmergencyStop>(
-      emergency_stop_topic_, rclcpp::QoS(1).reliable().transient_local());
+      emergency_stop_topic_, emergency_stop_qos());
 
-  for (const auto& pin : monitored_pins_) {
-    unsigned int p = static_cast<unsigned int>(pin);
-    gpio_states_[p] = false;
-    gpio_last_update_[p] = this->now();
-    std::string topic_name = "gpio_" + std::to_string(p);
-    gpio_subs_[p] = this->create_subscription<std_msgs::msg::Bool>(
+  for (const auto pin : safety_evaluator_->monitored_pins()) {
+    std::string topic_name = "gpio_" + std::to_string(pin);
+    gpio_subs_[pin] = this->create_subscription<std_msgs::msg::Bool>(
         topic_name, 1,
-        [this, p](const std_msgs::msg::Bool::SharedPtr msg) { this->gpio_callback(msg, p); });
+        [this, pin](const std_msgs::msg::Bool::SharedPtr msg) { this->gpio_callback(msg, pin); });
     RCLCPP_INFO(this->get_logger(), "Subscribed to %s", topic_name.c_str());
   }
 
   eval_timer_ = this->create_wall_timer(
-      std::chrono::milliseconds(1000),
+      std::chrono::milliseconds(100),
       std::bind(&OperationManagerComponent::evaluate_controllability, this));
 
+  // Publish an explicit fail-safe state before any GPIO message has arrived.
+  evaluate_controllability();
   RCLCPP_INFO(this->get_logger(), "Operation Manager Component started");
 }
 
 OperationManagerComponent::~OperationManagerComponent() {}
 
+rclcpp::QoS OperationManagerComponent::emergency_stop_qos() {
+  return rclcpp::QoS(1).reliable().transient_local();
+}
+
 void OperationManagerComponent::gpio_callback(const std_msgs::msg::Bool::SharedPtr msg,
                                               unsigned int pin) {
-  gpio_states_[pin] = msg->data;
-  gpio_last_update_[pin] = this->now();
+  safety_evaluator_->update(pin, msg->data, this->now().seconds());
   // Immediately evaluate on update
   evaluate_controllability();
 }
 
 void OperationManagerComponent::evaluate_controllability() {
-  bool controllable = true;
-  std::string diagnostic = "";
   rclcpp::Time now = this->now();
+  const auto evaluation = safety_evaluator_->evaluate(now.seconds());
 
   // 標準 DiagnosticArray 用に、ピンごとの状態を KeyValue として収集する。
   diagnostic_msgs::msg::DiagnosticStatus status;
   status.name = "operation_manager: gpio_controllability";
   status.hardware_id = "gpio";
 
-  for (const auto& pair : gpio_states_) {
-    unsigned int pin = pair.first;
-    bool state = pair.second;
-    double elapsed = (now - gpio_last_update_[pin]).seconds();
-
-    if (elapsed > timeout_seconds_) {
-      controllable = false;
-      diagnostic += "pin " + std::to_string(pin) + " timeout; ";
-    } else if (!state) {  // GPIO値がfalseの場合
-      controllable = false;
-      diagnostic += "pin " + std::to_string(pin) + " is false; ";
-    }
-
+  for (const auto& pin : evaluation.pins) {
     diagnostic_msgs::msg::KeyValue kv_state;
-    kv_state.key = "pin_" + std::to_string(pin) + "_state";
-    kv_state.value = state ? "true" : "false";
+    kv_state.key = "pin_" + std::to_string(pin.pin) + "_state";
+    kv_state.value = pin.received ? (pin.value ? "true" : "false") : "not_received";
     status.values.push_back(kv_state);
+    diagnostic_msgs::msg::KeyValue kv_expected;
+    kv_expected.key = "pin_" + std::to_string(pin.pin) + "_expected";
+    kv_expected.value = pin.expected_value ? "true" : "false";
+    status.values.push_back(kv_expected);
+    diagnostic_msgs::msg::KeyValue kv_received;
+    kv_received.key = "pin_" + std::to_string(pin.pin) + "_received";
+    kv_received.value = pin.received ? "true" : "false";
+    status.values.push_back(kv_received);
     diagnostic_msgs::msg::KeyValue kv_age;
-    kv_age.key = "pin_" + std::to_string(pin) + "_age_sec";
-    kv_age.value = std::to_string(elapsed);
+    kv_age.key = "pin_" + std::to_string(pin.pin) + "_age_sec";
+    kv_age.value = pin.received ? std::to_string(pin.age_seconds) : "not_received";
     status.values.push_back(kv_age);
+    if (pin.pin == 27U) {
+      diagnostic_msgs::msg::KeyValue kv_signal_limit;
+      kv_signal_limit.key = "pin_27_signal_limit";
+      kv_signal_limit.value =
+          "true cannot distinguish permission, disconnected, client unpowered, or "
+          "primary-side open";
+      status.values.push_back(kv_signal_limit);
+    }
   }
 
   std_msgs::msg::Bool out;
-  out.data = controllable;
+  out.data = evaluation.controllable;
   controllable_pub_->publish(out);
 
   // 標準 DiagnosticArray（rqt_runtime_monitor が設定なしで消費可）。
-  status.level = controllable ? diagnostic_msgs::msg::DiagnosticStatus::OK
-                              : diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-  status.message = controllable ? "controllable" : "not_controllable: " + diagnostic;
+  status.level = evaluation.controllable ? diagnostic_msgs::msg::DiagnosticStatus::OK
+                                         : diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  status.message =
+      evaluation.controllable ? "controllable" : "not_controllable: " + evaluation.reason;
   diagnostic_msgs::msg::DiagnosticArray diag_array;
   diag_array.header.stamp = now;
   diag_array.status.push_back(status);
@@ -106,9 +116,9 @@ void OperationManagerComponent::evaluate_controllability() {
 
   questix_msgs::msg::EmergencyStop estop_msg;
   estop_msg.header.stamp = now;
-  estop_msg.active = !controllable;
+  estop_msg.active = !evaluation.controllable;
   estop_msg.source = "operation_manager";
-  estop_msg.reason = controllable ? "released" : diagnostic;
+  estop_msg.reason = evaluation.controllable ? "released" : evaluation.reason;
   emergency_stop_pub_->publish(estop_msg);
 }
 

--- a/operation_manager/test/test_gpio_safety_evaluator.cpp
+++ b/operation_manager/test/test_gpio_safety_evaluator.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -87,6 +89,36 @@ TEST(GpioSafetyEvaluatorTest, AnyStaleInputStopsCompetitionMode) {
   EXPECT_GT(stale.pins[0].age_seconds, 1.0);
 }
 
+TEST(GpioSafetyEvaluatorTest, TimeMovingBackwardsIsFailSafe) {
+  GpioSafetyEvaluator evaluator({5}, {}, 1.0);
+  evaluator.update(5, false, 10.0);
+
+  const auto backwards = evaluator.evaluate(9.0);
+  EXPECT_FALSE(backwards.controllable);
+  EXPECT_EQ(backwards.reason, "pin 5 time moved backwards; ");
+  ASSERT_EQ(backwards.pins.size(), 1U);
+  EXPECT_TRUE(std::isinf(backwards.pins[0].age_seconds));
+}
+
+TEST(GpioSafetyEvaluatorTest, NonFiniteTimeIsFailSafe) {
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  constexpr double infinity = std::numeric_limits<double>::infinity();
+
+  GpioSafetyEvaluator update_nan({5}, {}, 1.0);
+  update_nan.update(5, false, nan);
+  EXPECT_EQ(update_nan.evaluate(1.0).reason, "pin 5 time is not finite; ");
+
+  GpioSafetyEvaluator evaluate_nan({5}, {}, 1.0);
+  evaluate_nan.update(5, false, 1.0);
+  EXPECT_EQ(evaluate_nan.evaluate(nan).reason, "pin 5 time is not finite; ");
+
+  const auto evaluate_infinity = evaluate_nan.evaluate(infinity);
+  EXPECT_FALSE(evaluate_infinity.controllable);
+  EXPECT_EQ(evaluate_infinity.reason, "pin 5 time is not finite; ");
+  ASSERT_EQ(evaluate_infinity.pins.size(), 1U);
+  EXPECT_TRUE(std::isinf(evaluate_infinity.pins[0].age_seconds));
+}
+
 TEST(GpioSafetyEvaluatorTest, RejectsOverlappingPolarity) {
   EXPECT_THROW(GpioSafetyEvaluator({5}, {5}, 1.0), std::invalid_argument);
 }
@@ -105,6 +137,10 @@ TEST(GpioSafetyEvaluatorTest, RejectsUnsafeEmptyOrInvalidTimeoutConfiguration) {
   EXPECT_THROW(GpioSafetyEvaluator({}, {}, 1.0), std::invalid_argument);
   EXPECT_THROW(GpioSafetyEvaluator({5}, {}, 0.0), std::invalid_argument);
   EXPECT_THROW(GpioSafetyEvaluator({5}, {}, -1.0), std::invalid_argument);
+  EXPECT_THROW(GpioSafetyEvaluator({5}, {}, std::numeric_limits<double>::quiet_NaN()),
+               std::invalid_argument);
+  EXPECT_THROW(GpioSafetyEvaluator({5}, {}, std::numeric_limits<double>::infinity()),
+               std::invalid_argument);
 }
 
 }  // namespace

--- a/operation_manager/test/test_gpio_safety_evaluator.cpp
+++ b/operation_manager/test/test_gpio_safety_evaluator.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "operation_manager/gpio_safety_evaluator.hpp"
+
+namespace {
+
+using operation_manager::GpioSafetyEvaluator;
+
+TEST(GpioSafetyEvaluatorTest, SafeLowPinUsesFalseAsSafeState) {
+  GpioSafetyEvaluator evaluator({5}, {}, 1.0);
+  EXPECT_FALSE(evaluator.evaluate(0.0).controllable);
+
+  evaluator.update(5, false, 0.0);
+  EXPECT_TRUE(evaluator.evaluate(0.5).controllable);
+
+  evaluator.update(5, true, 0.6);
+  const auto stopped = evaluator.evaluate(0.7);
+  EXPECT_FALSE(stopped.controllable);
+  EXPECT_EQ(stopped.reason, "pin 5 is true, expected false; ");
+}
+
+TEST(GpioSafetyEvaluatorTest, SafeHighPinUsesTrueAsSafeState) {
+  GpioSafetyEvaluator evaluator({}, {27}, 1.0);
+  evaluator.update(27, true, 0.0);
+  EXPECT_TRUE(evaluator.evaluate(0.5).controllable);
+
+  evaluator.update(27, false, 0.6);
+  const auto stopped = evaluator.evaluate(0.7);
+  EXPECT_FALSE(stopped.controllable);
+  EXPECT_EQ(stopped.reason, "pin 27 is false, expected true; ");
+}
+
+TEST(GpioSafetyEvaluatorTest, PracticeMonitorsOnlyPhysicalEstop) {
+  GpioSafetyEvaluator evaluator({5}, {}, 1.0);
+  EXPECT_EQ(evaluator.monitored_pins(), std::vector<unsigned int>({5}));
+
+  evaluator.update(5, false, 0.0);
+  EXPECT_TRUE(evaluator.evaluate(0.5).controllable);
+}
+
+TEST(GpioSafetyEvaluatorTest, CompetitionRequiresBothSafeInputs) {
+  GpioSafetyEvaluator evaluator({5}, {27}, 1.0);
+  evaluator.update(5, false, 0.0);
+  const auto partial = evaluator.evaluate(0.1);
+  EXPECT_FALSE(partial.controllable);
+  EXPECT_EQ(partial.reason, "pin 27 not received; ");
+
+  evaluator.update(27, true, 0.1);
+  EXPECT_TRUE(evaluator.evaluate(0.2).controllable);
+
+  evaluator.update(5, true, 0.3);
+  EXPECT_FALSE(evaluator.evaluate(0.4).controllable);
+  evaluator.update(5, false, 0.5);
+  evaluator.update(27, false, 0.5);
+  EXPECT_FALSE(evaluator.evaluate(0.6).controllable);
+}
+
+TEST(GpioSafetyEvaluatorTest, StartupReportsEveryUnreceivedPin) {
+  GpioSafetyEvaluator evaluator({5}, {27}, 1.0);
+  const auto initial = evaluator.evaluate(0.0);
+  EXPECT_FALSE(initial.controllable);
+  EXPECT_EQ(initial.reason, "pin 5 not received; pin 27 not received; ");
+  ASSERT_EQ(initial.pins.size(), 2U);
+  EXPECT_FALSE(initial.pins[0].received);
+  EXPECT_FALSE(initial.pins[1].received);
+}
+
+TEST(GpioSafetyEvaluatorTest, AnyStaleInputStopsCompetitionMode) {
+  GpioSafetyEvaluator evaluator({5}, {27}, 1.0);
+  evaluator.update(5, false, 0.0);
+  evaluator.update(27, true, 0.5);
+  EXPECT_TRUE(evaluator.evaluate(0.9).controllable);
+
+  const auto stale = evaluator.evaluate(1.1);
+  EXPECT_FALSE(stale.controllable);
+  EXPECT_EQ(stale.reason, "pin 5 timeout; ");
+  EXPECT_GT(stale.pins[0].age_seconds, 1.0);
+}
+
+TEST(GpioSafetyEvaluatorTest, RejectsOverlappingPolarity) {
+  EXPECT_THROW(GpioSafetyEvaluator({5}, {5}, 1.0), std::invalid_argument);
+}
+
+TEST(GpioSafetyEvaluatorTest, RejectsDuplicatePins) {
+  EXPECT_THROW(GpioSafetyEvaluator({5, 5}, {}, 1.0), std::invalid_argument);
+  EXPECT_THROW(GpioSafetyEvaluator({}, {27, 27}, 1.0), std::invalid_argument);
+}
+
+TEST(GpioSafetyEvaluatorTest, RejectsInvalidPinValues) {
+  EXPECT_THROW(GpioSafetyEvaluator({-1}, {}, 1.0), std::invalid_argument);
+  EXPECT_THROW(GpioSafetyEvaluator({}, {54}, 1.0), std::invalid_argument);
+}
+
+TEST(GpioSafetyEvaluatorTest, RejectsUnsafeEmptyOrInvalidTimeoutConfiguration) {
+  EXPECT_THROW(GpioSafetyEvaluator({}, {}, 1.0), std::invalid_argument);
+  EXPECT_THROW(GpioSafetyEvaluator({5}, {}, 0.0), std::invalid_argument);
+  EXPECT_THROW(GpioSafetyEvaluator({5}, {}, -1.0), std::invalid_argument);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/operation_manager/test/test_operation_manager_node.cpp
+++ b/operation_manager/test/test_operation_manager_node.cpp
@@ -1,0 +1,170 @@
+// Copyright 2026 scramble-robot
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <functional>  // NOLINT(build/include_order)
+#include <memory>      // NOLINT(build/include_order)
+#include <questix_msgs/msg/emergency_stop.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <string>  // NOLINT(build/include_order)
+#include <thread>  // NOLINT(build/include_order)
+#include <vector>  // NOLINT(build/include_order)
+
+#include "operation_manager/operation_manager_component.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+
+bool spin_until(rclcpp::executors::SingleThreadedExecutor& executor,
+                const std::function<bool()>& condition,
+                std::chrono::milliseconds timeout = 1000ms) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    executor.spin_some();
+    if (condition()) {
+      return true;
+    }
+    std::this_thread::sleep_for(5ms);
+  }
+  executor.spin_some();
+  return condition();
+}
+
+std::string diagnostic_value(const diagnostic_msgs::msg::DiagnosticStatus& status,
+                             const std::string& key) {
+  for (const auto& value : status.values) {
+    if (value.key == key) {
+      return value.value;
+    }
+  }
+  return "";
+}
+
+TEST(OperationManagerNodeTest, PublishesFailSafeStatesDiagnosticsAndContractQos) {
+  const std::string estop_topic = "/test_operation_manager/emergency_stop";
+  auto observer = std::make_shared<rclcpp::Node>("operation_manager_test_observer");
+
+  questix_msgs::msg::EmergencyStop::SharedPtr last_estop;
+  diagnostic_msgs::msg::DiagnosticArray::SharedPtr last_diagnostic;
+  std_msgs::msg::Bool::SharedPtr last_controllable;
+  auto estop_sub = observer->create_subscription<questix_msgs::msg::EmergencyStop>(
+      estop_topic, rclcpp::QoS(1).reliable().transient_local(),
+      [&last_estop](questix_msgs::msg::EmergencyStop::SharedPtr msg) { last_estop = msg; });
+  auto diagnostic_sub = observer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      "/diagnostics", 10, [&last_diagnostic](diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
+        last_diagnostic = msg;
+      });
+  auto controllable_sub = observer->create_subscription<std_msgs::msg::Bool>(
+      "/gpio/controllable", 10,
+      [&last_controllable](std_msgs::msg::Bool::SharedPtr msg) { last_controllable = msg; });
+  auto gpio5_pub = observer->create_publisher<std_msgs::msg::Bool>("/gpio_5", 10);
+  auto gpio27_pub = observer->create_publisher<std_msgs::msg::Bool>("/gpio_27", 10);
+
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+      rclcpp::Parameter("safe_low_pins", std::vector<int64_t>{5}),
+      rclcpp::Parameter("safe_high_pins", std::vector<int64_t>{27}),
+      rclcpp::Parameter("timeout_seconds", 0.2),
+      rclcpp::Parameter("emergency_stop_topic", estop_topic),
+  });
+  auto manager = std::make_shared<operation_manager::OperationManagerComponent>(options);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(observer);
+  executor.add_node(manager);
+
+  ASSERT_TRUE(spin_until(executor, [&]() {
+    return last_estop && last_diagnostic && last_controllable &&
+           gpio5_pub->get_subscription_count() == 1U && gpio27_pub->get_subscription_count() == 1U;
+  }));
+  ASSERT_TRUE(last_estop->active);
+  EXPECT_EQ(last_estop->source, "operation_manager");
+  EXPECT_EQ(last_estop->reason, "pin 5 not received; pin 27 not received; ");
+  EXPECT_FALSE(last_controllable->data);
+  ASSERT_EQ(last_diagnostic->status.size(), 1U);
+  EXPECT_EQ(last_diagnostic->status[0].level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(diagnostic_value(last_diagnostic->status[0], "pin_5_state"), "not_received");
+  EXPECT_EQ(diagnostic_value(last_diagnostic->status[0], "pin_5_age_sec"), "not_received");
+  EXPECT_EQ(diagnostic_value(last_diagnostic->status[0], "pin_27_signal_limit"),
+            "true cannot distinguish permission, disconnected, client unpowered, or "
+            "primary-side open");
+
+  const auto publisher_info = observer->get_publishers_info_by_topic(estop_topic);
+  ASSERT_EQ(publisher_info.size(), 1U);
+  EXPECT_EQ(publisher_info[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  EXPECT_EQ(publisher_info[0].qos_profile().durability(), rclcpp::DurabilityPolicy::TransientLocal);
+  const auto contract_qos = operation_manager::OperationManagerComponent::emergency_stop_qos();
+  EXPECT_EQ(contract_qos.history(), rclcpp::HistoryPolicy::KeepLast);
+  EXPECT_EQ(contract_qos.get_rmw_qos_profile().depth, 1U);
+
+  std_msgs::msg::Bool gpio5;
+  gpio5.data = false;
+  gpio5_pub->publish(gpio5);
+  ASSERT_TRUE(spin_until(
+      executor, [&]() { return last_estop && last_estop->reason == "pin 27 not received; "; }));
+  EXPECT_TRUE(last_estop->active);
+
+  std_msgs::msg::Bool gpio27;
+  gpio27.data = true;
+  gpio27_pub->publish(gpio27);
+  ASSERT_TRUE(spin_until(executor, [&]() { return last_estop && !last_estop->active; }));
+  EXPECT_TRUE(last_controllable->data);
+  EXPECT_EQ(last_estop->reason, "released");
+  ASSERT_EQ(last_diagnostic->status.size(), 1U);
+  EXPECT_EQ(last_diagnostic->status[0].level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(diagnostic_value(last_diagnostic->status[0], "pin_5_state"), "false");
+  EXPECT_EQ(diagnostic_value(last_diagnostic->status[0], "pin_27_state"), "true");
+
+  gpio5.data = true;
+  gpio5_pub->publish(gpio5);
+  ASSERT_TRUE(spin_until(executor, [&]() {
+    return last_estop && last_estop->reason == "pin 5 is true, expected false; ";
+  }));
+  EXPECT_TRUE(last_estop->active);
+  EXPECT_EQ(last_diagnostic->status[0].level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+
+  gpio5.data = false;
+  gpio27.data = false;
+  gpio5_pub->publish(gpio5);
+  gpio27_pub->publish(gpio27);
+  ASSERT_TRUE(spin_until(executor, [&]() {
+    return last_estop && last_estop->reason == "pin 27 is false, expected true; ";
+  }));
+  EXPECT_TRUE(last_estop->active);
+
+  gpio27.data = true;
+  gpio5_pub->publish(gpio5);
+  gpio27_pub->publish(gpio27);
+  ASSERT_TRUE(spin_until(executor, [&]() { return last_estop && !last_estop->active; }));
+  ASSERT_TRUE(spin_until(
+      executor,
+      [&]() {
+        return last_estop && last_estop->active &&
+               last_estop->reason.find("timeout") != std::string::npos;
+      },
+      1000ms));
+  EXPECT_FALSE(last_controllable->data);
+  EXPECT_EQ(last_diagnostic->status[0].level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+
+  (void)estop_sub;
+  (void)diagnostic_sub;
+  (void)controllable_sub;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/questix_msgs/README.md
+++ b/questix_msgs/README.md
@@ -12,7 +12,7 @@ QUESTiX 共通メッセージ定義パッケージ。統一緊急停止インタ
 | `header` | `std_msgs/Header` | `stamp` = 判定時刻。`frame_id` は未使用(`""`) |
 | `active` | `bool` | `true` = 緊急停止発動 |
 | `source` | `string` | 発行元識別子(例: `"operation_manager"`) |
-| `reason` | `string` | 原因(例: `"pin 27 is false; "`、`"pin 27 timeout; "`)。解除時は `"released"` |
+| `reason` | `string` | 原因(例: `"pin 5 not received; "`、`"pin 27 is false, expected true; "`、`"pin 27 timeout; "`)。解除時は `"released"` |
 
 ### `MotorFeedback.msg`
 
@@ -57,10 +57,11 @@ DDT M0602C の Protocol 1 応答フレームをデコードした 1 モータ分
   購読側も同一 QoS を使うこと。late-join した購読者は最新のラッチ状態を即時受信する。
 - **発行元**: `operation_manager`。GPIO controllability 判定
   (`evaluate_controllability()`)の毎回実行時に発行する。
-  すなわち GPIO 更新毎(公称 ~20 Hz)+ 1 秒周期タイマーがハートビート下限。
+  すなわち GPIO 更新毎(公称 ~20 Hz)+ 100 ms watchdog timer。
   `active = !controllable`。
 - **発行者不在環境**: operation_manager は `enable_gpio_ref=true` の構成
-  (`joy_controller_referee.launch.xml`)でのみ起動する。購読側は
+  でdrive/shotの有無に依存せず `questix_core.launch.xml` から起動する。
+  standalone `joy_controller_referee.launch.xml` も互換性のため起動できる。購読側は
   メッセージを一度も受信していない間は通常動作を継続しなければならない
   (発行者不在で停止してはならない)。
 - **staleness 検出**: 購読側は「一度以上受信した後に」タイムアウト
@@ -88,6 +89,10 @@ DDT M0602C の Protocol 1 応答フレームをデコードした 1 モータ分
 | `single_ddt_motor_feedback` | `MotorFeedback` | `single_ddt_motor` | 相対名。launch で `/single_ddt_motor_feedback` に remap |
 | `joy_axis_drive_status` | `DriveStatus` | `joy_axis_drive` | 相対名。`linear/angular_velocity = 0.0` |
 | `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | `operation_manager` | 標準集約トピック。rqt_runtime_monitor が設定なしで表示 |
+
+`operation_manager` の GPIO27 診断には `pin_27_signal_limit` が含まれる。
+GPIO27=`true` は許可だけでなく、AutoReferee未接続、クライアント無通電、
+一次側断線でも発生し、現行ハードウェアでは区別できないことを示す。
 
 ## モータ調整時のフィードバック監視
 

--- a/questix_msgs/msg/EmergencyStop.msg
+++ b/questix_msgs/msg/EmergencyStop.msg
@@ -4,7 +4,7 @@
 # Subscribers: drive_component, shot_component, esc_motor_control
 #
 # QoS contract: reliable + transient_local + keep-last(1); published on every
-# controllability evaluation (each GPIO update plus a 1 s heartbeat timer).
+# controllability evaluation (each GPIO update plus a 100 ms watchdog timer).
 #
 # active=true  -> emergency stop engaged; each subscriber performs its own stop
 # active=false -> released; subscribers resume accepting commands, motors stay
@@ -16,5 +16,5 @@
 std_msgs/Header header  # stamp = evaluation time; frame_id unused ("")
 bool active             # true = emergency stop engaged
 string source           # origin identifier, e.g. "operation_manager"
-string reason           # human-readable cause, e.g. "pin 27 is false; ";
+string reason           # human-readable cause, e.g. "pin 27 is false, expected true; ";
                         # "released" when active=false

--- a/scripts/robot_manager/README.md
+++ b/scripts/robot_manager/README.md
@@ -8,6 +8,16 @@ uvicorn on `127.0.0.1:8888`.
 - `logs.py` — log collection console (`/api/logs/*`).
 - `static/` — vanilla HTML/CSS/JS frontend (no build step).
 
+## Competition GPIO safety
+
+The `ENABLE_GPIO_REF` field in `launch.env` is retained for manual development and
+diagnostics. When `/etc/questix_robot/mode` is `competition`, the production launcher
+ignores that field and always passes `enable_gpio_ref:=true` together with
+`enable_autoreferee:=true`. Therefore an existing `launch.env` containing
+`ENABLE_GPIO_REF=false` cannot disable the GPIO5 physical E-stop and GPIO27
+AutoReferee safety path. `enable_autoreferee:=true` with `enable_gpio_ref:=false` is
+not a valid operational configuration.
+
 ## Running (dev)
 
 ```bash

--- a/scripts/robot_manager/static/index.html
+++ b/scripts/robot_manager/static/index.html
@@ -93,7 +93,7 @@
           </label>
         </div>
         <div class="config-item">
-          <label>GPIO Ref</label>
+          <label title="Competition always enables GPIO safety">GPIO safety (manual only)</label>
           <label class="toggle-switch small">
             <input type="checkbox" data-config="ENABLE_GPIO_REF">
             <span class="slider"></span>

--- a/systemd/questix_robot.env
+++ b/systemd/questix_robot.env
@@ -1,18 +1,19 @@
-# Questix Robot Launch Configuration
+# QUESTiX Robot Launch Configuration
 # Edit these values to control which components are launched
 
-# Robot workspace path and ROS2 distro (change to match your environment)
+# Robot workspace path and ROS 2 distro (change to match your environment)
 ROS_DISTRO=jazzy
 ROBOT_WS=/home/ubuntu/robot_ws
 
-# ROS2 Domain ID (change per robot to avoid conflicts when running multiple robots)
+# ROS 2 Domain ID (change per robot to avoid conflicts when running multiple robots)
 ROS_DOMAIN_ID=42
 
 # Launch component toggles
 ENABLE_LIDAR=true
 ENABLE_SHOT=true
 ENABLE_DRIVE=true
-ENABLE_GPIO_REF=false
+# The competition systemd launcher always enables GPIO safety regardless of this value.
+ENABLE_GPIO_REF=true
 ENABLE_RVIZ=false
 
 # Controller type: uart or dualshock

--- a/systemd/questix_robot_launcher.sh
+++ b/systemd/questix_robot_launcher.sh
@@ -48,6 +48,7 @@ LAUNCH_ARGS="${LAUNCH_ARGS} enable_lidar:=${ENABLE_LIDAR:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_shot:=${ENABLE_SHOT:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_drive:=${ENABLE_DRIVE:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=${ENABLE_GPIO_REF:-true}"
+LAUNCH_ARGS="${LAUNCH_ARGS} enable_autoreferee:=true"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_rviz:=${ENABLE_RVIZ:-false}"
 LAUNCH_ARGS="${LAUNCH_ARGS} controller_type:=${CONTROLLER_TYPE:-uart}"
 

--- a/systemd/questix_robot_launcher.sh
+++ b/systemd/questix_robot_launcher.sh
@@ -47,7 +47,9 @@ LAUNCH_ARGS=""
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_lidar:=${ENABLE_LIDAR:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_shot:=${ENABLE_SHOT:-true}"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_drive:=${ENABLE_DRIVE:-true}"
-LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=${ENABLE_GPIO_REF:-true}"
+# Competition always requires both physical E-stop and AutoReferee GPIO safety inputs.
+# ENABLE_GPIO_REF from launch.env is intentionally ignored in this mode.
+LAUNCH_ARGS="${LAUNCH_ARGS} enable_gpio_ref:=true"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_autoreferee:=true"
 LAUNCH_ARGS="${LAUNCH_ARGS} enable_rviz:=${ENABLE_RVIZ:-false}"
 LAUNCH_ARGS="${LAUNCH_ARGS} controller_type:=${CONTROLLER_TYPE:-uart}"


### PR DESCRIPTION
## 問題

QUESTiX 3.1.0 では `gpio_reader` と `operation_manager` が GPIO27 のみを監視し、全入力の `true` を正常としていました。このため、safe-low の物理非常停止 GPIO5を表現できず、GPIO未受信と初期値 `false` も区別できませんでした。また、`operation_manager` の起動が drive/referee launch に依存し、drive と shot を無効にした安全系単独構成では起動しませんでした。

追加レビューでは、`systemd/questix_robot.env` に `ENABLE_GPIO_REF=false` が残っていることも判明しました。production launcher がこの値を展開していたため、competition 起動で `enable_autoreferee=true` にもかかわらず GPIO5/GPIO27 の安全経路全体を無効化できる状態でした。

## 実機で確定したGPIO仕様

- GPIO5（物理非常停止）
  - 押下時: 3.3 V、`/gpio_5=true`、動作禁止
  - 解除時: 約70 mV、`/gpio_5=false`、動作許可
  - safe-low / stop-high
  - RLY1は左右DDT駆動モーター、ローラー用ESC、Shot用サーボ、Tilt用サーボの動力をハードウェア遮断します。
  - Raspberry Pi、5 V I/O、3.3 V I/Oは通電を維持し、GPIO5は非常停止状態をROSへ通知し続けます。
  - 物理遮断とROSソフトウェア停止は独立した二重の安全経路です。
- GPIO27（大会用AutoReferee `AR_in`）
  - クライアント撃破出力は撃破時5 V、非撃破時0 Vです。
  - HATのフォトカプラで反転され、撃破時はGPIO27=`false`（停止）、非撃破時はR2 10 kΩの3.3 VプルアップでGPIO27=`true`（許可）になります。
  - safe-high / stop-low、competitionのみ監視します。
  - 未接続、クライアント無通電、一次側断線もGPIO27=`true`となり、現行ハードウェアでは非撃破と区別できません。この制約をREADME、YAMLコメント、`/diagnostics` の `pin_27_signal_limit` に明記しました。

## 変更内容

### GPIO判定とモード切替

- `gpio_reader` と `operation_manager` に practice / competition のモード別YAMLを追加しました。
  - practice: GPIO5のみ
  - competition: GPIO5とGPIO27
  - 互換用の汎用YAMLとコード内既定値は安全なpractice構成（GPIO5のみ）です。
- `operation_manager` の監視設定を `safe_low_pins` / `safe_high_pins` で表現しました。
  - 空構成、BCM範囲外（0–53）、リスト内重複、両リスト間重複、非正値・非有限timeoutは起動時エラーです。
- ROS非依存の `GpioSafetyEvaluator` へ判定を分離しました。
  - 各pinの未受信、最新raw値、受信時刻を個別管理します。
  - すべての必須pinが受信済み、fresh、期待値一致の場合だけ `controllable=true` です。
  - reasonは not received / timeout / actual-expected mismatchを区別します。
- `/emergency_stop.active = !controllable` を維持しました。
  - QoSは reliable + transient_local + keep-last 1 のままです。
  - GPIO5とGPIO27は反転せずraw Boolをpublishします。

### Competition production起動の強制安全化

- systemd版とAnsible配布版の両 `questix_robot_launcher.sh` は、competition時に次を固定値で必ず渡します。
  - `enable_gpio_ref:=true`
  - `enable_autoreferee:=true`
- competition では `launch.env` の `ENABLE_GPIO_REF` を意図的に無視します。Ansibleの `force: false` やinstallerの「既存ならskip」により既存ファイルへ `false` が残っていても、安全系を無効化できません。
- `systemd/questix_robot.env` とAnsible templateの既定値を `ENABLE_GPIO_REF=true` に統一しました。
- `enable_gpio_ref=false` は手動開発・診断用途に限定し、`enable_autoreferee=true` かつ `enable_gpio_ref=false` は通常運用上の無効な組合せとして文書化しました。
- `questix_core.launch.xml` はこの不正な組合せを検出し、operator向けERRORを表示して起動を中止します。
- Robot Manager UIにも、competitionではGPIO安全系が常時有効であることを明示しました。

### Launch ownership

- `questix_core.launch.xml` で `enable_gpio_ref=true` の場合、`gpio_reader` と `operation_manager` をdrive/shotから独立して起動します。
- 統合構成では `questix_core` が `operation_manager` を1プロセスだけ所有し、nested referee launch側を無効化します。
- standalone referee launchは互換性のため `operation_manager` 起動を既定trueのまま維持します。
- `enable_gpio_ref` の説明を、integrated/standaloneそれぞれの実際の構成に合わせて修正しました。

### Monotonic watchdog

- GPIO freshness/timeout判定をROS clockから `std::chrono::steady_clock` へ変更しました。
- ROS timeは従来どおり `/diagnostics` と `/emergency_stop` のheader stampに使用します。
- evaluator単体でも時刻後退、NaN、Infをfail-safe（`controllable=false`）として扱い、診断ageをinfiniteにします。
- 時刻後退、update/evaluateのNaN、evaluateのInf、非有限timeoutの単体テストを追加しました。

### HAT pinout・README整合

- `gpio_reader/README.md` に、ID_SD/ID_SCを含むBCM 0–27のQUESTiX Raspberry Pi 5 HAT全GPIO割当表とCN2–CN16のコネクタpin構成を追加しました。
- PWM portはGPIO12/CN2/PWM0=`Unassigned PWM output`、GPIO13/CN3/PWM1=`Roller ESC motor control PWM output`として記載しました。
- 実装に存在しないJoy combined topic、`gpio/state`、`publish_individual`を示唆する表現を削除しました。
- publisherを `/gpio_<PIN>` (`std_msgs/msg/Bool`) のraw電気値だけとして記載し、`chip_name`既定値を `/dev/gpiochip4`、build例とtroubleshootingを現行構成へ訂正しました。

### ROS 2 typed empty profile修正

- practice/default YAMLから型情報のない `safe_high_pins: []` を削除し、C++で宣言済みのtyped empty integer-array defaultを使用します。
- install済みpractice/competition YAMLを実際のrclcpp nodeへ渡し、parameter値とnode生存を確認するruntime smoke testを追加しました。
- practiceの `questix_core` safety-only launchで `gpio_reader_node` と `operation_manager_node` の生存を確認します。

## 真理値

| Mode | GPIO5 physical E-stop | GPIO27 AutoReferee | Controllable |
|---|---:|---:|---:|
| practice | false | not monitored | true |
| practice | true | not monitored | false |
| competition | false | true | true |
| competition | true | any | false |
| competition | any | false | false |
| any | missing or stale required input | - | false |

## テスト結果

- `colcon build --symlink-install`: exit 0（15 packages）
- `colcon test --packages-skip ydlidar_ros2_driver ydlidar_sdk_vendor --return-code-on-test-failure`: exit 0（13 packages）
- `colcon test-result --verbose`: exit 0、515 tests、0 errors、0 failures、89 skipped
- ROS 2 runtime smoke: 4 passed（install済みpractice/competition profile、practice core safety-only launch、不正構成の子プロセス未起動）
- `launcher/test/test_gpio_safety_launch.py`: 6 passed
  - practice/competition profile
  - safety-only/full構成の `operation_manager` 単一起動
  - production launcherの固定 `enable_gpio_ref:=true` / `enable_autoreferee:=true`
  - 可変 `ENABLE_GPIO_REF` 展開の不存在
  - systemd/Ansible env既定値とlauncher安全引数の一致
  - installer/Ansibleによる既存 `launch.env` 保持経路
  - 不正なAutoReferee/GPIO組合せのfail-fast
- 不正構成runtime確認: 全機能を有効指定してもoperator向けERRORだけを表示して終了し、子プロセス起動ログなし・対象node未観測
- `git diff --check`、両launcherの `bash -n` と完全一致、変更XMLの `xmllint`: exit 0
- 変更Pythonのflake8/pydocstyle、Robot Manager 10 unit testsとscripts全体lint: exit 0
- Ansible `setup_dev.yaml` / `setup_kit.yaml` syntax check: exit 0
- ローカル環境には `ament_clang_format`、`clang-format`、`yamllint`、`ansible-lint` が未導入でしたが、GitHub Actionsのformat-check、Ansible lint、amd64/arm64 build-and-testを含む全checksがpassしました。

## 本日のRaspberry Pi 5実機検証（practice）

検証commit: `074085afed539ded62ea14e808b0e4f751ff0006`

- 環境: Raspberry Pi 5、Ubuntu 24.04.4 aarch64、ROS 2 Jazzy、`ROS_DOMAIN_ID=53`
- systemd service: inactive、robot mode: practice
- Drive、Shot、ESC、LiDARは無効、アクチュエータ動力系は非通電
- safety-only launchで `/gpio_reader_node` と `/operation_manager_node` が各1個、`/gpio_5`あり、`/gpio_27`なし
- `safe_low_pins=[5]`、`safe_high_pins=[]`、GPIO5 publish rateは約20 Hz
- `/emergency_stop` publisherは1個、QoSはRELIABLE + TRANSIENT_LOCAL

| 操作／状態 | `/gpio_5` | `/gpio/controllable` | `/emergency_stop.active` | diagnostics |
|---|---:|---:|---:|---|
| E-stop押下 | true | false | true | ERROR、`pin_5_state=true`、`pin_5_expected=false`、`pin_5_received=true` |
| E-stop解除 | false | true | false | OK、`message=controllable`、期待値・受信状態も正常 |
| 再押下 | true | false | true | stop reasonを再確認 |

押下時のsourceは `operation_manager`、reasonは `pin 5 is true, expected false; `、解除時reasonは `released` でした。解除後2秒間はすべて `/gpio_5=false` で、意図しないtrue反転はなく、両ノードは継続生存しました。practice physical E-stop GPIO5 → `operation_manager` → `/emergency_stop` の非通電エンドツーエンド検証はPASSです。ログはローカルの `/home/scramble/questix-validation/pr140-practice-20260724-222036/` に保存しています。

## 追加レビュー対応

- CN7を通常の3pin GPIO breakoutから分離し、AutoReferee client用2pin入力（pin 1: 0 V非撃破／5 V撃破、pin 2: GND）と、HAT側フォトカプラによるGPIO27への反転伝達を明記しました。
- 不正な `enable_autoreferee=true / enable_gpio_ref=false` では、全node/includeを逆条件groupの内側へ置き、ERROR表示用timerの待機中もDrive、Shot、ESC、LiDAR、GPIO safety、RVizの子プロセスを評価しません。静的XMLテストとROS 2 runtime testで保証します。

## 残る実機検証

本日は追加の実機操作を行っていません。次回以降に次を確認します。

- GPIO27 AutoRefereeの撃破／非撃破実信号
- GPIO5信号ケーブル断線時
- watchdog timeout
- systemd competition起動
- Drive、Shot、ESC、LiDAR
- GPIO5とGPIO27を含む複合操作

AutoReferee未接続・クライアント無通電・一次側断線と非撃破を識別できない点は、現行ハードウェアの残存制約です。

Related: #139

