### PR TITLE
build: install launcher config and launch via symlink-friendly path

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -14,23 +14,10 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-# Install launch files
-install(DIRECTORY
-  launch/
-  DESTINATION share/${PROJECT_NAME}/launch
-  FILES_MATCHING PATTERN "*.xml"
-)
-
 # Install documentation
 install(FILES
   README.md
   DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY
-  config/
-  DESTINATION share/${PROJECT_NAME}/config
-  FILES_MATCHING PATTERN "*.yaml"
 )
 
 
@@ -54,4 +41,7 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package()
+# INSTALL_TO_SHARE + colcon --symlink-install で config/launch が symlink になり、
+# ソース YAML の編集が再ビルド無しで実機に反映される（旧 install(DIRECTORY) は
+# コピーになるため、編集済みソースと実行時 config が乖離する事故があった）。
+ament_auto_package(INSTALL_TO_SHARE launch config)


### PR DESCRIPTION
## 概要

#144 から `launcher` の CMake 変更だけを切り出した PR です（#144 のコミット `c46cac0` をそのまま cherry-pick）。

## 変更内容

- `launcher/CMakeLists.txt`: `install(DIRECTORY launch/ ...)` / `install(DIRECTORY config/ ...)` を削除し、`ament_auto_package(INSTALL_TO_SHARE launch config)` に統一。
- `install(DIRECTORY)` はコピーインストールのため、`colcon build --symlink-install` でも `launcher/config/*.yaml` と `launcher/launch/*.xml` が install 空間に symlink されず、ソース YAML を編集しても実機に反映されない。この経路で実機が約6項目乖離した古い `drive_component.yaml` で走行していた問題の修正。
- 他パッケージ（`motor_control_app` など）は既に `INSTALL_TO_SHARE` 経由で揃っているため、`questix_launcher` を同じ方式に合わせる。
- `launcher/launch` と `launcher/config` には `.xml` / `.yaml` 以外のファイルが無いため、旧 `FILES_MATCHING PATTERN` を外しても install される内容は変わらない。

## 検証

- `colcon build --symlink-install --packages-select questix_launcher` 成功
- `install/questix_launcher/share/questix_launcher/{config,launch}/` 配下の全ファイルが `launcher/{config,launch}/` へのシンボリックリンクになることを確認
- `git diff --check` OK

## 補足

- #144 は本 PR マージ後に main を取り込めば、このファイルは同一内容のため衝突しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)