### PR TITLE
feat: improve kitting domain id and shipping defaults

### DIFF
--- a/.github/workflows/ansible-check.yaml
+++ b/.github/workflows/ansible-check.yaml
@@ -135,6 +135,33 @@ jobs:
               run: |
                   git ls-files -z -- '*.sh' | xargs -0 -r -n1 bash -n
 
+    kitting-contract-tests:
+        name: Kitting Resolver + Ansible Contract Tests
+        runs-on: ubuntu-24.04
+        timeout-minutes: 15
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Install Ansible
+              run: |
+                  python -m pip install --upgrade pip
+                  # Pinned for reproducibility; bump deliberately (see AGENTS.md).
+                  pip install "ansible==14.2.0"
+
+            - name: Run ROS_DOMAIN_ID resolver unit tests
+              run: python3 -m unittest scripts.test_resolve_ros_domain_id -v
+
+            # Source-only: runs against temp dirs, no become/root, never touches
+            # /etc/questix_robot. See ansible/tests/run_contract_tests.sh.
+            - name: Run kitting Ansible contract tests
+              run: ansible/tests/run_contract_tests.sh
+
     ansible-validate-inventory:
         name: Validate Ansible Configuration
         runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Recurring bug classes from this repository's fix history. Check each relevant it
 - **Launch dependencies in package.xml**: Every package referenced by a launch file via `pkg=` or `find-pkg-share` must be listed as `exec_depend` in that package's `package.xml`, and must actually exist in the workspace or ROS repos.
 - **CI must fail on failure**: Do not mask checks with `continue-on-error: true` or `|| true`. If a check cannot be enforced (e.g. Ansible check-mode limitations), leave a comment explaining why it is advisory.
 - **Installer/unit consistency**: Static `systemd/` unit files and their install-time substitutions (`scripts/install-robot-manager.sh`) and the Ansible templates in `ansible/roles/robot_autostart/templates/` describe the same services; when changing a user, path, or environment variable in one, update all three.
+- **Persisted-value precedence for kitting config (`ROS_DOMAIN_ID`)**: `/etc/questix_robot/launch.env` and the target user's `~/.bashrc` Ansible managed block are two independent persisted copies of the same value. Never let one silently win over the other, and never silently paper over a malformed persisted value — see `scripts/resolve_ros_domain_id.py` and its decision table in `ansible/playbooks/vars/README.md`. The resolver only reads and validates; only Ansible (`robot_autostart`/`robotics_workspace` roles) writes.
 
 ## Pull request titles
 

--- a/ansible/playbooks/setup_kit.yaml
+++ b/ansible/playbooks/setup_kit.yaml
@@ -53,6 +53,9 @@
       ansible.builtin.debug:
         msg: "Detected device: {{ pi_model.stdout }}"
 
+    - name: Validate ROS_DOMAIN_ID before any state-changing role runs
+      ansible.builtin.include_tasks: tasks/validate_ros_domain_id.yaml
+
   roles:
     - { role: ros2_installation }
     - { role: raspberry_pi_setup }

--- a/ansible/playbooks/tasks/validate_ros_domain_id.yaml
+++ b/ansible/playbooks/tasks/validate_ros_domain_id.yaml
@@ -1,0 +1,29 @@
+---
+# Reject an invalid ros_domain_id before any state-changing role runs.
+#
+# This must not rely on `ros_domain_id | int`, which silently coerces
+# non-numeric strings (e.g. "abc") to 0 - so first confirm the value is a
+# well-formed integer string, then range-check it.
+#
+# Range mirrors scripts/resolve_ros_domain_id.py (0-101 or 215-232); kept in
+# both places because this playbook can be invoked directly, bypassing the
+# resolver (e.g. scripts/apply-ansible-config.sh during ISO builds).
+
+- name: Assert ROS_DOMAIN_ID is a well-formed integer
+  ansible.builtin.assert:
+    that:
+      - (ros_domain_id | string) is regex('^-?[0-9]+$')
+    fail_msg: "ros_domain_id must be an integer, got: {{ ros_domain_id }}"
+    success_msg: "ros_domain_id is a well-formed integer: {{ ros_domain_id }}"
+
+- name: Assert ROS_DOMAIN_ID is within the allowed ranges (0-101 or 215-232)
+  ansible.builtin.assert:
+    that:
+      - (ros_domain_id | int) >= 0
+      - >-
+        (ros_domain_id | int) <= 101 or
+        ((ros_domain_id | int) >= 215 and (ros_domain_id | int) <= 232)
+    fail_msg: >-
+      ros_domain_id must be in the allowed ranges 0-101 or 215-232,
+      got: {{ ros_domain_id }}
+    success_msg: "ros_domain_id {{ ros_domain_id }} is within the allowed ranges"

--- a/ansible/playbooks/vars/README.md
+++ b/ansible/playbooks/vars/README.md
@@ -15,11 +15,36 @@
 - `install_dev_tools`: 開発ツールをインストールするかどうか（デフォルト: `true`）
 - `target_ubuntu_version`: 対象 Ubuntu バージョン（デフォルト: `"24.04"`）
 - `ros2_additional_packages`: インストールする追加の ROS2 パッケージのリスト
-- `ros_domain_id`: ROS2 ドメイン ID（デフォルト: `42`）
+- `ros_domain_id`: ROS2 ドメイン ID（デフォルト: `42`）。詳細は下記「ROS_DOMAIN_ID の解決」を参照
 - `workspace_path`: ワークスペースパス（デフォルト: `/home/{{ ansible_user }}/questix`。リポジトリのcloneをそのままcolconワークスペースとして使う）
 - `enable_i2c`: I2C を有効化（デフォルト: `true`）
 - `enable_spi`: SPI を有効化（デフォルト: `true`）
 - `configure_udev_rules`: udev ルールを設定（デフォルト: `true`）
+
+## ROS_DOMAIN_ID の解決
+
+`setup_kit_vars.yaml` の `ros_domain_id: 42` は **bootstrap / legacy / pre-kitting 用の値**です。
+`scripts/apply-ansible-config.sh` 経由の ARM64 ISO build（chroot 内で `setup_kit.yaml` を
+非対話実行）はこの値をそのまま使うため、削除・undefined 化すると ISO build を壊します。
+
+実機キッティングでは、`./setup.sh` が `scripts/resolve_ros_domain_id.py` を先に実行し、
+ロボット固有の ID を解決してから `-e "ros_domain_id=<resolved>"` として渡します。
+`setup_kit.yaml` を直接実行した場合でも、roles が始まる前に
+`ansible/playbooks/tasks/validate_ros_domain_id.yaml` が範囲を検証し、
+不正な値（範囲外・非整数）は fail します。
+
+**許可される範囲**: `0-101` または `215-232`（標準的な Linux ephemeral port range を
+前提とした値。範囲外の値は resolver・Ansible の両方で拒否されます）。
+
+- `0`: 有効だが ROS 2 のデフォルトドメインと衝突しうるため warning
+- `42`: 有効。ただし legacy/default 値として検出されるため、resolver は
+  対話環境では「42のまま」か「ロボット固有IDに変更」かの確認を求めます
+- 再setup時、42以外の有効な ID は確認なしでそのまま保持されます
+  （`launch.env` と `~/.bashrc` の Ansible managed block の両方が同期されます）
+- `launch.env` の ROS_DOMAIN_ID 以外の既存設定は再setupでも保持されます
+
+resolver 自体は `launch.env` や `.bashrc` を書き換えません。永続化は Ansible
+（`robot_autostart` / `robotics_workspace` ロール）の責務です。
 
 ### dev.yaml
 

--- a/ansible/roles/robot_autostart/README.md
+++ b/ansible/roles/robot_autostart/README.md
@@ -46,17 +46,27 @@ sudo nano /etc/questix_robot/launch.env
 sudo systemctl restart questix_robot
 ```
 
-設定項目:
+設定項目（出荷時のデフォルトは `ansible/roles/robot_autostart/defaults/main.yaml` が
+single source。`launch.env.j2` はそこから参照するのみで値を重複定義しません）:
 
-| 環境変数 | デフォルト | 説明 |
+| 環境変数 | 出荷時デフォルト | 説明 |
 |---------|-----------|------|
-| `ENABLE_LIDAR` | `true` | YDLiDAR の有効化 |
-| `ENABLE_SHOT` | `true` | 射出コンポーネントの有効化 |
-| `ENABLE_DRIVE` | `true` | 駆動コンポーネントの有効化 |
-| `ENABLE_GPIO_REF` | `true` | 手動開発・診断用の GPIO 安全系設定。competition systemd 起動では値を無視して常に有効 |
+| `ROS_DOMAIN_ID` | （kitting時に解決） | 詳細は `ansible/playbooks/vars/README.md` の「ROS_DOMAIN_ID の解決」を参照 |
+| `ENABLE_LIDAR` | `false` | YDLiDAR の有効化 |
+| `ENABLE_SHOT` | `false` | 射出コンポーネントの有効化 |
+| `ENABLE_DRIVE` | `false` | 駆動コンポーネントの有効化 |
+| `ENABLE_GPIO_REF` | `true` | 手動開発・診断用の GPIO 安全系設定。competition systemd 起動では値を無視して常に有効。他の項目と異なり出荷時も `true`（無効化すると手動 `ros2 launch` で GPIO 安全系がデフォルト無効になるため） |
 | `ENABLE_RVIZ` | `false` | RViz 可視化の有効化 |
+| `CONTROLLER_TYPE` | `dualshock` | コントローラ種別（`uart` または `dualshock`） |
 
-Ansible は `launch.env` を `force: false` で配置するため、既存ファイルを上書きしません。
+出荷時に全コンポーネントを無効（`ENABLE_GPIO_REF` を除く）にしているのは、初回起動時に
+モーターや LiDAR が意図せず動作しないようにするためです。運用者が必要なコンポーネントを
+明示的に有効化してください。
+
+Ansible は `launch.env` を `force: false` で配置するため、既存ファイルを上書きしません
+（新規作成時のみ上記の出荷時デフォルトが適用されます）。ただし `ROS_DOMAIN_ID` だけは
+再setup時にも resolver が解決した値へ同期されます（他の既存設定は保持されます）。
+
 既存環境に `ENABLE_GPIO_REF=false` が残っていても、competition ランチャーは
 `enable_gpio_ref:=true` を固定で渡すため安全系を無効化できません。
 `enable_autoreferee:=true` かつ `enable_gpio_ref:=false` は通常運用上の無効な

--- a/ansible/roles/robot_autostart/defaults/main.yaml
+++ b/ansible/roles/robot_autostart/defaults/main.yaml
@@ -5,9 +5,24 @@ target_user: "{{ ansible_user | default(ansible_env.SUDO_USER) }}"
 workspace_path: "/home/{{ target_user }}/robot_ws"
 ros2_distro: jazzy
 ros_domain_id: 42
+questix_robot_config_dir: /etc/questix_robot
 
 # Robot mode: "practice" (default, safe) or "competition" (auto-launch on boot)
 robot_mode: practice
+
+# Shipping defaults for a freshly-kitted launch.env (single source of truth for
+# ansible/roles/robot_autostart/templates/launch.env.j2). A robot ships with every
+# launch component off so a first boot never drives motors/LiDAR/RViz unexpectedly;
+# operators opt components in explicitly. ENABLE_GPIO_REF stays true: it is the
+# manual/diagnostic GPIO safety path (competition mode always forces it true
+# regardless of this value - see robot_autostart/README.md), so shipping it
+# disabled would default manual `ros2 launch` invocations to no GPIO safety.
+enable_lidar: false
+enable_shot: false
+enable_drive: false
+enable_gpio_ref: true
+enable_rviz: false
+controller_type: dualshock
 
 # Robot manager Web UI
 # Set to true to install robot-manager GUI

--- a/ansible/roles/robot_autostart/tasks/launch_env.yaml
+++ b/ansible/roles/robot_autostart/tasks/launch_env.yaml
@@ -1,0 +1,28 @@
+---
+# Deploy launch.env and synchronize ROS_DOMAIN_ID.
+#
+# Split out of tasks/main.yaml so it can be exercised directly (against a temp
+# directory, via questix_robot_config_dir) by ansible/tests/ contract tests
+# without running the rest of the role (which needs root/systemd).
+
+- name: Deploy launch environment file
+  ansible.builtin.template:
+    src: launch.env.j2
+    dest: "{{ questix_robot_config_dir }}/launch.env"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: "0644"
+    force: false
+
+# force: false above means an existing launch.env is never overwritten, so a
+# previously-resolved ROS_DOMAIN_ID would otherwise go stale across re-setups.
+# This keeps every other existing launch.env setting untouched.
+- name: Synchronize ROS_DOMAIN_ID in launch environment file
+  ansible.builtin.lineinfile:
+    path: "{{ questix_robot_config_dir }}/launch.env"
+    regexp: "^ROS_DOMAIN_ID="
+    line: "ROS_DOMAIN_ID={{ ros_domain_id }}"
+    insertafter: EOF
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: "0644"

--- a/ansible/roles/robot_autostart/tasks/main.yaml
+++ b/ansible/roles/robot_autostart/tasks/main.yaml
@@ -18,14 +18,8 @@
     mode: "0644"
     force: false
 
-- name: Deploy launch environment file
-  ansible.builtin.template:
-    src: launch.env.j2
-    dest: /etc/questix_robot/launch.env
-    owner: "{{ target_user }}"
-    group: "{{ target_user }}"
-    mode: "0644"
-    force: false
+- name: Deploy and synchronize launch environment file
+  ansible.builtin.include_tasks: launch_env.yaml
 
 - name: Create launcher script directory
   ansible.builtin.file:

--- a/ansible/roles/robot_autostart/templates/launch.env.j2
+++ b/ansible/roles/robot_autostart/templates/launch.env.j2
@@ -9,12 +9,12 @@ ROBOT_WS={{ workspace_path }}
 ROS_DOMAIN_ID={{ ros_domain_id }}
 
 # Launch component toggles
-ENABLE_LIDAR=true
-ENABLE_SHOT=true
-ENABLE_DRIVE=true
+ENABLE_LIDAR={{ enable_lidar | lower }}
+ENABLE_SHOT={{ enable_shot | lower }}
+ENABLE_DRIVE={{ enable_drive | lower }}
 # The competition systemd launcher always enables GPIO safety regardless of this value.
-ENABLE_GPIO_REF=true
-ENABLE_RVIZ=false
+ENABLE_GPIO_REF={{ enable_gpio_ref | lower }}
+ENABLE_RVIZ={{ enable_rviz | lower }}
 
 # Controller type: uart or dualshock
-CONTROLLER_TYPE={{ controller_type | default('uart') }}
+CONTROLLER_TYPE={{ controller_type }}

--- a/ansible/tests/run_contract_tests.sh
+++ b/ansible/tests/run_contract_tests.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Source-only contract tests for the kitting ROS_DOMAIN_ID resolver / shipping
+# defaults change. Everything runs against temp directories with no `become`
+# and no root — never touches /etc/questix_robot or real systemd state.
+#
+# Usage: ansible/tests/run_contract_tests.sh   (run from anywhere; cd's to repo root)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+    local file="$1" needle="$2" label="$3"
+    if grep -qF -- "$needle" "$file" 2>/dev/null; then
+        pass "$label"
+    else
+        fail "$label (expected to find: $needle)"
+    fi
+}
+
+assert_not_contains() {
+    local file="$1" needle="$2" label="$3"
+    if grep -qF -- "$needle" "$file" 2>/dev/null; then
+        fail "$label (did not expect to find: $needle)"
+    else
+        pass "$label"
+    fi
+}
+
+run_playbook() {
+    ansible-playbook "$@" -i localhost, --connection=local \
+        >/tmp/questix_contract_test_last.log 2>&1
+}
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# --- 1. Fresh launch.env rendering (shipping defaults) ----------------------
+FRESH_DIR="$TMP_ROOT/fresh"
+mkdir -p "$FRESH_DIR"
+if run_playbook ansible/tests/test_launch_env.yaml \
+    -e "questix_robot_config_dir=$FRESH_DIR" -e "ros_domain_id=11"; then
+    ENV_FILE="$FRESH_DIR/launch.env"
+    assert_contains "$ENV_FILE" "ENABLE_LIDAR=false" "fresh render: ENABLE_LIDAR default false"
+    assert_contains "$ENV_FILE" "ENABLE_SHOT=false" "fresh render: ENABLE_SHOT default false"
+    assert_contains "$ENV_FILE" "ENABLE_DRIVE=false" "fresh render: ENABLE_DRIVE default false"
+    assert_contains "$ENV_FILE" "ENABLE_GPIO_REF=true" "fresh render: ENABLE_GPIO_REF default true (manual-launch safety)"
+    assert_contains "$ENV_FILE" "ENABLE_RVIZ=false" "fresh render: ENABLE_RVIZ default false"
+    assert_contains "$ENV_FILE" "CONTROLLER_TYPE=dualshock" "fresh render: CONTROLLER_TYPE default dualshock"
+    assert_contains "$ENV_FILE" "ROS_DOMAIN_ID=11" "fresh render: ROS_DOMAIN_ID synced to resolved value"
+else
+    fail "fresh render: playbook run failed (see /tmp/questix_contract_test_last.log)"
+fi
+
+# --- 2. Existing launch.env preservation + domain-only sync -----------------
+PRESERVE_DIR="$TMP_ROOT/preserve"
+mkdir -p "$PRESERVE_DIR"
+cat >"$PRESERVE_DIR/launch.env" <<'EOF'
+# custom header a human wrote
+ENABLE_LIDAR=true
+ROS_DOMAIN_ID=42
+CONTROLLER_TYPE=uart
+EOF
+if run_playbook ansible/tests/test_launch_env.yaml \
+    -e "questix_robot_config_dir=$PRESERVE_DIR" -e "ros_domain_id=12"; then
+    ENV_FILE="$PRESERVE_DIR/launch.env"
+    assert_contains "$ENV_FILE" "ENABLE_LIDAR=true" "preserve: existing non-domain setting kept"
+    assert_contains "$ENV_FILE" "CONTROLLER_TYPE=uart" "preserve: existing non-domain setting kept (2)"
+    assert_contains "$ENV_FILE" "# custom header a human wrote" "preserve: existing comment kept"
+    assert_contains "$ENV_FILE" "ROS_DOMAIN_ID=12" "domain sync: ROS_DOMAIN_ID updated to resolved value"
+    assert_not_contains "$ENV_FILE" "ROS_DOMAIN_ID=42" "domain sync: stale legacy value removed"
+else
+    fail "preserve: playbook run failed (see /tmp/questix_contract_test_last.log)"
+fi
+
+# --- 3. Duplicate ROS_DOMAIN_ID lines (documented last-wins behavior) -------
+DUP_DIR="$TMP_ROOT/dup"
+mkdir -p "$DUP_DIR"
+cat >"$DUP_DIR/launch.env" <<'EOF'
+ROS_DOMAIN_ID=10
+ROS_DOMAIN_ID=20
+EOF
+if run_playbook ansible/tests/test_launch_env.yaml \
+    -e "questix_robot_config_dir=$DUP_DIR" -e "ros_domain_id=13"; then
+    ENV_FILE="$DUP_DIR/launch.env"
+    DOMAIN_LINE_COUNT=$(grep -c '^ROS_DOMAIN_ID=' "$ENV_FILE")
+    LAST_VALUE=$(grep '^ROS_DOMAIN_ID=' "$ENV_FILE" | tail -1)
+    if [ "$LAST_VALUE" = "ROS_DOMAIN_ID=13" ]; then
+        pass "duplicate ROS_DOMAIN_ID: last line reflects the resolved value (matches bash source semantics)"
+    else
+        fail "duplicate ROS_DOMAIN_ID: expected last line 'ROS_DOMAIN_ID=13', got: $LAST_VALUE"
+    fi
+    echo "INFO: duplicate ROS_DOMAIN_ID line count after sync: $DOMAIN_LINE_COUNT" \
+        "(lineinfile replaces only the last match; pre-existing duplicate lines are not deleted -- known limitation, see README)"
+else
+    fail "duplicate: playbook run failed (see /tmp/questix_contract_test_last.log)"
+fi
+
+# --- 4. bashrc synchronization -----------------------------------------------
+BASHRC_DIR="$TMP_ROOT/bashrc"
+mkdir -p "$BASHRC_DIR"
+BASHRC_FILE="$BASHRC_DIR/.bashrc"
+: >"$BASHRC_FILE"
+if run_playbook ansible/tests/test_bashrc_sync.yaml \
+    -e "bashrc_path=$BASHRC_FILE" -e "workspace_path=$BASHRC_DIR/robot_ws" -e "ros_domain_id=14"; then
+    assert_contains "$BASHRC_FILE" "export ROS_DOMAIN_ID=14" "bashrc sync: managed block exports resolved domain id"
+    assert_contains "$BASHRC_FILE" "# BEGIN ANSIBLE MANAGED BLOCK - ROS2 Robotics Kit" "bashrc sync: managed block markers present"
+else
+    fail "bashrc sync: playbook run failed (see /tmp/questix_contract_test_last.log)"
+fi
+
+if run_playbook ansible/tests/test_bashrc_sync.yaml \
+    -e "bashrc_path=$BASHRC_FILE" -e "workspace_path=$BASHRC_DIR/robot_ws" -e "ros_domain_id=15"; then
+    assert_contains "$BASHRC_FILE" "export ROS_DOMAIN_ID=15" "bashrc sync: re-run updates to the new resolved value"
+    assert_not_contains "$BASHRC_FILE" "export ROS_DOMAIN_ID=14" "bashrc sync: stale value replaced on re-run"
+else
+    fail "bashrc sync (re-run): playbook run failed (see /tmp/questix_contract_test_last.log)"
+fi
+
+# --- 5. Static shipping-default / mode / service-enabled regression checks --
+assert_contains "ansible/roles/robot_autostart/defaults/main.yaml" "robot_mode: practice" \
+    "shipping defaults: robot_mode defaults to practice"
+assert_contains "ansible/roles/robot_autostart/tasks/main.yaml" "enabled: true" \
+    "shipping defaults: questix_robot service enabled"
+
+# --- 6. ROS_DOMAIN_ID range assert (valid/invalid) ---------------------------
+assert_range_case() {
+    local value="$1" expect="$2"
+    local result
+    if ansible-playbook ansible/tests/test_validate_ros_domain_id.yaml \
+        -i localhost, --connection=local -e "ros_domain_id=$value" \
+        >/tmp/questix_contract_test_last.log 2>&1; then
+        result="pass"
+    else
+        result="fail"
+    fi
+    if [ "$result" = "$expect" ]; then
+        pass "range assert: ros_domain_id=$value -> $expect"
+    else
+        fail "range assert: ros_domain_id=$value expected $expect, got $result (see /tmp/questix_contract_test_last.log)"
+    fi
+}
+
+for v in 0 101 215 232; do assert_range_case "$v" pass; done
+for v in 102 214 233 -1 abc; do assert_range_case "$v" fail; done
+
+echo ""
+echo "==================================================================="
+echo "Contract tests: $PASS passed, $FAIL failed"
+echo "==================================================================="
+[ "$FAIL" -eq 0 ]

--- a/ansible/tests/test_bashrc_sync.yaml
+++ b/ansible/tests/test_bashrc_sync.yaml
@@ -1,0 +1,15 @@
+---
+# Source-only harness for the robotics_workspace role's bashrc block, which is
+# the other half of the launch.env == bashrc == resolved ros_domain_id
+# invariant. Exercises the real role tasks against a caller-supplied temp
+# bashrc/workspace path. See run_contract_tests.sh.
+
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    target_user: "{{ lookup('env', 'USER') }}"
+  tasks:
+    - name: Exercise robotics_workspace tasks
+      ansible.builtin.include_role:
+        name: robotics_workspace

--- a/ansible/tests/test_launch_env.yaml
+++ b/ansible/tests/test_launch_env.yaml
@@ -1,0 +1,15 @@
+---
+# Source-only harness for ansible/roles/robot_autostart/tasks/launch_env.yaml.
+# Exercises the real role task file (via include_role) against a caller-supplied
+# temp directory, never against /etc/questix_robot. See run_contract_tests.sh.
+
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    target_user: "{{ lookup('env', 'USER') }}"
+  tasks:
+    - name: Exercise robot_autostart launch_env tasks
+      ansible.builtin.include_role:
+        name: robot_autostart
+        tasks_from: launch_env.yaml

--- a/ansible/tests/test_validate_ros_domain_id.yaml
+++ b/ansible/tests/test_validate_ros_domain_id.yaml
@@ -1,0 +1,11 @@
+---
+# Source-only harness for ansible/playbooks/tasks/validate_ros_domain_id.yaml.
+# Runs the real assert tasks directly, bypassing setup_kit.yaml's ARM64/aarch64
+# pre_task gate so this can run on any dev machine (e.g. WSL amd64).
+
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Run the ROS_DOMAIN_ID validation tasks
+      ansible.builtin.include_tasks: ../playbooks/tasks/validate_ros_domain_id.yaml

--- a/launcher/test/test_gpio_safety_launch.py
+++ b/launcher/test/test_gpio_safety_launch.py
@@ -210,12 +210,19 @@ def test_competition_service_launchers_always_enable_gpio_safety():
 def test_launch_environment_defaults_enable_gpio_safety():
     systemd_env = (
         SOURCE_ROOT / 'systemd/questix_robot.env').read_text(encoding='utf-8')
+    role_defaults = load_yaml('ansible/roles/robot_autostart/defaults/main.yaml')
     ansible_env = (
         SOURCE_ROOT / 'ansible/roles/robot_autostart/templates/launch.env.j2'
     ).read_text(encoding='utf-8')
 
     assert 'ENABLE_GPIO_REF=true' in systemd_env.splitlines()
-    assert 'ENABLE_GPIO_REF=true' in ansible_env.splitlines()
+    # ENABLE_LIDAR/SHOT/DRIVE/RVIZ and CONTROLLER_TYPE ship disabled/dualshock
+    # (see robot_autostart/defaults/main.yaml), but GPIO safety is the
+    # exception: it must default to enabled even though the competition
+    # systemd launcher ignores this value and always forces it true, because
+    # this is also the default for manual/diagnostic `ros2 launch` runs.
+    assert role_defaults['enable_gpio_ref'] is True
+    assert 'ENABLE_GPIO_REF={{ enable_gpio_ref | lower }}' in ansible_env.splitlines()
 
 
 def test_installers_preserve_existing_environment_but_launcher_is_safe():
@@ -225,11 +232,15 @@ def test_installers_preserve_existing_environment_but_launcher_is_safe():
     ansible_tasks = (
         SOURCE_ROOT / 'ansible/roles/robot_autostart/tasks/main.yaml'
     ).read_text(encoding='utf-8')
+    launch_env_tasks = (
+        SOURCE_ROOT / 'ansible/roles/robot_autostart/tasks/launch_env.yaml'
+    ).read_text(encoding='utf-8')
 
     assert (
         '"${REPO_DIR}/systemd/questix_robot.env" > '
         '/etc/questix_robot/launch.env'
     ) in installer
     assert 'launch.env already exists, skipping' in installer
-    assert 'src: launch.env.j2' in ansible_tasks
-    assert 'force: false' in ansible_tasks
+    assert 'include_tasks: launch_env.yaml' in ansible_tasks
+    assert 'src: launch.env.j2' in launch_env_tasks
+    assert 'force: false' in launch_env_tasks

--- a/scripts/resolve_ros_domain_id.py
+++ b/scripts/resolve_ros_domain_id.py
@@ -182,7 +182,7 @@ def check_ephemeral_range(warn, path=EPHEMERAL_RANGE_PATH):
 
 
 def _read_answer_or_raise_on_eof(read_line, context):
-    """Read one line, distinguishing EOF ("") from a blank Enter ("\\n").
+    r"""Read one line, distinguishing EOF ("") from a blank Enter ("\n").
 
     read_line() returning the empty string means stdin was closed (EOF), not
     that the user pressed Enter. Conflating the two would let a closed/piped

--- a/scripts/resolve_ros_domain_id.py
+++ b/scripts/resolve_ros_domain_id.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# Resolves the effective ROS_DOMAIN_ID for a QUESTiX Raspberry Pi 5 kitting run.
+#
+# Responsibilities: read persisted state (launch.env, target user's ~/.bashrc
+# managed block), validate, detect conflicts, apply legacy/default (42)
+# handling, apply an explicit override, prompt interactively when a human
+# decision is required, warn on the ROS 2 default domain (0), and print the
+# final resolved integer.
+#
+# This script never writes to launch.env or .bashrc. Deploying the resolved
+# value is Ansible's responsibility (robot_autostart / robotics_workspace
+# roles), so re-running this resolver never has side effects on its own.
+#
+# stdout contract: the final resolved integer only, nothing else. Prompts,
+# warnings, diagnostics, and conflict explanations all go to stderr, so
+# `ROS_DOMAIN_ID="$(resolve_ros_domain_id.py)"` stays safe to use from
+# setup.sh even while a human is being prompted.
+
+import argparse
+import os
+import re
+import sys
+
+# Allowed ROS_DOMAIN_ID values, chosen to stay inside the standard Linux
+# ephemeral port range (32768-60999) per the DDS/RTPS discovery port formula
+# (7400 + 250 * domain_id [+ 2 for user traffic]); see
+# ansible/playbooks/vars/README.md for the derivation.
+ALLOWED_RANGES = ((0, 101), (215, 232))
+LEGACY_DOMAIN_ID = 42
+STANDARD_EPHEMERAL_RANGE = (32768, 60999)
+EPHEMERAL_RANGE_PATH = "/proc/sys/net/ipv4/ip_local_port_range"
+
+BASHRC_BEGIN_MARKER = "# BEGIN ANSIBLE MANAGED BLOCK - ROS2 Robotics Kit"
+BASHRC_END_MARKER = "# END ANSIBLE MANAGED BLOCK - ROS2 Robotics Kit"
+
+DEFAULT_LAUNCH_ENV_PATH = "/etc/questix_robot/launch.env"
+
+
+class ResolutionError(Exception):
+    """Raised when the domain ID cannot be resolved (caller should exit non-zero)."""
+
+
+def eprint(message):
+    print(message, file=sys.stderr)
+
+
+def is_in_allowed_range(value):
+    return any(low <= value <= high for low, high in ALLOWED_RANGES)
+
+
+def parse_strict_int(raw):
+    """Parse a plain (optionally quoted) integer string; reject anything else."""
+    if raw is None:
+        return None
+    text = raw.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+        text = text[1:-1].strip()
+    if re.fullmatch(r"-?[0-9]+", text):
+        return int(text)
+    return None
+
+
+def classify_domain_id(raw):
+    """Classify a raw string as ('missing'|'invalid'|'valid', int_value_or_None)."""
+    if raw is None:
+        return "missing", None
+    value = parse_strict_int(raw)
+    if value is None or not is_in_allowed_range(value):
+        return "invalid", None
+    return "valid", value
+
+
+def _split_lines(content):
+    return content.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
+def _last_assignment(lines, key):
+    """Return (raw_value_or_None, occurrence_count) for `key=value` lines.
+
+    Comment lines are ignored. When a key is assigned more than once, bash
+    `source` honors the last occurrence, so we mirror that instead of
+    guessing which line is authoritative.
+    """
+    pattern = re.compile(r"^" + re.escape(key) + r"=(.*)$")
+    matches = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        m = pattern.match(stripped)
+        if m:
+            matches.append(m.group(1))
+    if not matches:
+        return None, 0
+    return matches[-1], len(matches)
+
+
+def read_launch_env_domain_id(path, warn):
+    try:
+        with open(path, "r", newline="", encoding="utf-8") as fh:
+            content = fh.read()
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeDecodeError) as exc:
+        # Distinct from "missing": the file exists but we could not read it
+        # (permissions, a directory in its place, bad encoding, ...). This
+        # must not be silently treated the same as an absent file.
+        raise ResolutionError(f"Could not read {path}: {exc}") from None
+    lines = _split_lines(content)
+    value, count = _last_assignment(lines, "ROS_DOMAIN_ID")
+    if count > 1:
+        warn(
+            f"{path}: found {count} ROS_DOMAIN_ID assignments; using the last "
+            "one (matches bash `source` semantics)."
+        )
+    return value
+
+
+def _extract_managed_blocks(content):
+    blocks = []
+    current = None
+    for line in _split_lines(content):
+        if line.strip() == BASHRC_BEGIN_MARKER:
+            current = []
+            continue
+        if line.strip() == BASHRC_END_MARKER:
+            if current is not None:
+                blocks.append(current)
+            current = None
+            continue
+        if current is not None:
+            current.append(line)
+    return blocks
+
+
+def read_bashrc_domain_id(path, warn):
+    try:
+        with open(path, "r", newline="", encoding="utf-8") as fh:
+            content = fh.read()
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeDecodeError) as exc:
+        # See read_launch_env_domain_id: "unreadable" must not collapse into
+        # "missing".
+        raise ResolutionError(f"Could not read {path}: {exc}") from None
+    blocks = _extract_managed_blocks(content)
+    if not blocks:
+        return None
+    if len(blocks) > 1:
+        warn(
+            f"{path}: found {len(blocks)} ANSIBLE MANAGED BLOCK sections; "
+            "using the last one."
+        )
+    value, count = _last_assignment(blocks[-1], "export ROS_DOMAIN_ID")
+    if count > 1:
+        warn(
+            f"{path}: found {count} ROS_DOMAIN_ID exports inside the managed "
+            "block; using the last one."
+        )
+    return value
+
+
+def check_ephemeral_range(warn, path=EPHEMERAL_RANGE_PATH):
+    try:
+        with open(path, "r") as fh:
+            parts = fh.read().split()
+        low, high = int(parts[0]), int(parts[1])
+    except (OSError, IndexError, ValueError):
+        warn(
+            f"Could not read/parse {path}; unable to confirm that the "
+            "configured allowed ROS_DOMAIN_ID range assumes the standard "
+            "Linux ephemeral port range."
+        )
+        return
+    if (low, high) != STANDARD_EPHEMERAL_RANGE:
+        warn(
+            f"Ephemeral port range is {low}-{high}, not the standard "
+            f"{STANDARD_EPHEMERAL_RANGE[0]}-{STANDARD_EPHEMERAL_RANGE[1]}. "
+            "The configured allowed ROS_DOMAIN_ID range assumes the "
+            "standard Linux ephemeral port range."
+        )
+
+
+def _read_answer_or_raise_on_eof(read_line, context):
+    """Read one line, distinguishing EOF ("") from a blank Enter ("\\n").
+
+    read_line() returning the empty string means stdin was closed (EOF), not
+    that the user pressed Enter. Conflating the two would let a closed/piped
+    stdin silently pick "keep the current value" (or spin forever re-prompting
+    on an already-exhausted stream) instead of failing loudly.
+    """
+    raw = read_line()
+    if raw == "":
+        raise ResolutionError(
+            f"Input closed (EOF) while {context}; refusing to guess. "
+            "Re-run interactively, or set QUESTIX_ROS_DOMAIN_ID=<id> explicitly."
+        )
+    return raw.strip()
+
+
+def _prompt_for_new_value(warn, read_line, intro_lines):
+    for line in intro_lines:
+        warn(line)
+    while True:
+        warn("Enter ROS_DOMAIN_ID (0-101 or 215-232): ")
+        answer = _read_answer_or_raise_on_eof(read_line, "waiting for a ROS_DOMAIN_ID")
+        state, value = classify_domain_id(answer)
+        if state == "valid":
+            return value
+        warn(f"'{answer}' is not a valid ROS_DOMAIN_ID (0-101 or 215-232). Try again.")
+
+
+def _confirm_or_change(warn, read_line, candidate, intro_lines):
+    for line in intro_lines:
+        warn(line)
+    while True:
+        warn(f"Press Enter to keep {candidate}, or type a new ROS_DOMAIN_ID (0-101 or 215-232): ")
+        answer = _read_answer_or_raise_on_eof(read_line, "confirming ROS_DOMAIN_ID")
+        if answer == "":
+            return candidate
+        state, value = classify_domain_id(answer)
+        if state == "valid":
+            return value
+        warn(f"'{answer}' is not a valid ROS_DOMAIN_ID (0-101 or 215-232). Try again.")
+
+
+def _require_interactive(interactive, message):
+    if not interactive:
+        raise ResolutionError(
+            message + " Re-run interactively, or set QUESTIX_ROS_DOMAIN_ID=<id> explicitly."
+        )
+
+
+def _finalize(warn, value):
+    if value == 0:
+        warn("ROS_DOMAIN_ID=0 overlaps the ROS 2 default domain; proceeding with a warning.")
+    return value
+
+
+def resolve(override_raw, launch_raw, bashrc_raw, interactive, read_line, warn):
+    """Resolve the effective ROS_DOMAIN_ID, or raise ResolutionError."""
+    if override_raw is not None:
+        state, value = classify_domain_id(override_raw)
+        if state != "valid":
+            raise ResolutionError(
+                f"QUESTIX_ROS_DOMAIN_ID override '{override_raw}' is invalid; "
+                "must be an integer in 0-101 or 215-232."
+            )
+        if value == LEGACY_DOMAIN_ID:
+            warn(
+                f"Explicit override to legacy/default domain {LEGACY_DOMAIN_ID} "
+                "accepted without interactive confirmation."
+            )
+        return _finalize(warn, value)
+
+    launch_state, launch_value = classify_domain_id(launch_raw)
+    bashrc_state, bashrc_value = classify_domain_id(bashrc_raw)
+
+    if launch_state == "missing" and bashrc_state == "missing":
+        _require_interactive(
+            interactive, "No persisted ROS_DOMAIN_ID found in launch.env or ~/.bashrc."
+        )
+        value = _prompt_for_new_value(
+            warn, read_line, ["No persisted ROS_DOMAIN_ID found in launch.env or ~/.bashrc."]
+        )
+        return _finalize(warn, value)
+
+    if launch_state == "valid" and bashrc_state == "valid":
+        if launch_value == bashrc_value:
+            candidate = launch_value
+        else:
+            _require_interactive(
+                interactive,
+                f"ROS_DOMAIN_ID conflict: launch.env={launch_value}, "
+                f"~/.bashrc={bashrc_value}. Refusing to pick one silently.",
+            )
+            value = _confirm_or_change(
+                warn,
+                read_line,
+                launch_value,
+                [
+                    f"ROS_DOMAIN_ID conflict: launch.env={launch_value}, "
+                    f"~/.bashrc={bashrc_value}.",
+                    "This will not be resolved silently.",
+                ],
+            )
+            return _finalize(warn, value)
+    elif launch_state == "valid" and bashrc_state == "missing":
+        candidate = launch_value
+    elif bashrc_state == "valid" and launch_state == "missing":
+        candidate = bashrc_value
+    else:
+        # At least one side is present but malformed/out-of-range. This is
+        # deliberately NOT treated the same as "one side simply unset" -
+        # a corrupt persisted value must never be silently ignored.
+        diagnostics = []
+        if launch_state == "invalid":
+            diagnostics.append(f"launch.env has a malformed/out-of-range ROS_DOMAIN_ID: {launch_raw!r}")
+        if bashrc_state == "invalid":
+            diagnostics.append(
+                f"~/.bashrc managed block has a malformed/out-of-range ROS_DOMAIN_ID: {bashrc_raw!r}"
+            )
+        valid_side_value = (
+            launch_value if launch_state == "valid"
+            else bashrc_value if bashrc_state == "valid"
+            else None
+        )
+        if valid_side_value is not None:
+            diagnostics.append(
+                "One persisted source is valid and the other is invalid; this "
+                "is not treated as a simple missing value."
+            )
+            _require_interactive(interactive, " ".join(diagnostics))
+            value = _confirm_or_change(warn, read_line, valid_side_value, diagnostics)
+            return _finalize(warn, value)
+        diagnostics.append("Both persisted sources are invalid.")
+        _require_interactive(interactive, " ".join(diagnostics))
+        value = _prompt_for_new_value(warn, read_line, diagnostics)
+        return _finalize(warn, value)
+
+    if candidate == LEGACY_DOMAIN_ID:
+        _require_interactive(
+            interactive,
+            f"Persisted ROS_DOMAIN_ID is {LEGACY_DOMAIN_ID} (legacy/default); "
+            "keeping or changing it requires an explicit decision.",
+        )
+        value = _confirm_or_change(
+            warn,
+            read_line,
+            candidate,
+            [
+                f"Persisted ROS_DOMAIN_ID is {LEGACY_DOMAIN_ID} (legacy/default "
+                "bootstrap value). Keep it, or change to a robot-specific ID?",
+            ],
+        )
+        return _finalize(warn, value)
+
+    return _finalize(warn, candidate)
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Resolve the effective ROS_DOMAIN_ID for QUESTiX kitting."
+    )
+    parser.add_argument("--launch-env-path", default=DEFAULT_LAUNCH_ENV_PATH)
+    parser.add_argument("--bashrc-path", default=os.path.expanduser("~/.bashrc"))
+    parser.add_argument(
+        "--override",
+        default=None,
+        help="Defaults to $QUESTIX_ROS_DOMAIN_ID if unset.",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Force non-interactive mode regardless of stdin.",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    override = args.override
+    if override is None:
+        override = os.environ.get("QUESTIX_ROS_DOMAIN_ID")
+    interactive = (not args.non_interactive) and sys.stdin.isatty()
+
+    check_ephemeral_range(eprint)
+
+    try:
+        if override is not None:
+            # An explicit override is authoritative on its own; it must not
+            # depend on launch.env/bashrc being present or even readable.
+            value = resolve(override, None, None, interactive, sys.stdin.readline, eprint)
+        else:
+            launch_raw = read_launch_env_domain_id(args.launch_env_path, eprint)
+            bashrc_raw = read_bashrc_domain_id(args.bashrc_path, eprint)
+            value = resolve(None, launch_raw, bashrc_raw, interactive, sys.stdin.readline, eprint)
+    except ResolutionError as exc:
+        eprint(f"ERROR: {exc}")
+        return 1
+
+    print(value)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_resolve_ros_domain_id.py
+++ b/scripts/test_resolve_ros_domain_id.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+# Unit tests for scripts/resolve_ros_domain_id.py.
+#
+# Run with: python3 -m unittest scripts.test_resolve_ros_domain_id -v
+# (from the repository root), or: python3 scripts/test_resolve_ros_domain_id.py
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import resolve_ros_domain_id as rdi  # noqa: E402
+
+
+SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "resolve_ros_domain_id.py")
+
+
+def scripted_read_line(answers):
+    """Return a read_line() callable that yields each answer once, then ''."""
+    queue = list(answers)
+
+    def read_line():
+        if queue:
+            return queue.pop(0) + "\n"
+        return ""
+
+    return read_line
+
+
+class RangeValidationTests(unittest.TestCase):
+    def test_boundary_and_gap_values(self):
+        expectations = {
+            "0": "valid",
+            "11": "valid",
+            "42": "valid",
+            "101": "valid",
+            "102": "invalid",
+            "214": "invalid",
+            "215": "valid",
+            "232": "valid",
+            "233": "invalid",
+            "-1": "invalid",
+            "abc": "invalid",
+        }
+        for raw, expected in expectations.items():
+            with self.subTest(raw=raw):
+                state, _ = rdi.classify_domain_id(raw)
+                self.assertEqual(state, expected)
+
+    def test_missing_is_distinct_from_invalid(self):
+        state, value = rdi.classify_domain_id(None)
+        self.assertEqual(state, "missing")
+        self.assertIsNone(value)
+
+
+class ParsingTests(unittest.TestCase):
+    def _write(self, tmpdir, name, content):
+        path = os.path.join(tmpdir, name)
+        with open(path, "wb") as fh:
+            fh.write(content.encode("utf-8"))
+        return path
+
+    def test_launch_env_basic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "launch.env", "ENABLE_LIDAR=false\nROS_DOMAIN_ID=11\n")
+            warnings = []
+            self.assertEqual(rdi.read_launch_env_domain_id(path, warnings.append), "11")
+            self.assertEqual(warnings, [])
+
+    def test_launch_env_missing_file(self):
+        self.assertIsNone(rdi.read_launch_env_domain_id("/nonexistent/launch.env", lambda m: None))
+
+    def test_launch_env_commented_out_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "launch.env", "#ROS_DOMAIN_ID=99\n")
+            self.assertIsNone(rdi.read_launch_env_domain_id(path, lambda m: None))
+
+    def test_launch_env_whitespace_around_value_is_tolerated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "launch.env", "  ROS_DOMAIN_ID=11  \n")
+            self.assertEqual(rdi.read_launch_env_domain_id(path, lambda m: None).strip(), "11")
+
+    def test_launch_env_crlf(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "launch.env", "ENABLE_LIDAR=false\r\nROS_DOMAIN_ID=11\r\n")
+            self.assertEqual(rdi.read_launch_env_domain_id(path, lambda m: None), "11")
+
+    def test_launch_env_duplicate_uses_last_and_warns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "launch.env", "ROS_DOMAIN_ID=11\nROS_DOMAIN_ID=12\n")
+            warnings = []
+            value = rdi.read_launch_env_domain_id(path, warnings.append)
+            self.assertEqual(value, "12")
+            self.assertTrue(any("2 ROS_DOMAIN_ID assignments" in w for w in warnings))
+
+    def test_bashrc_reads_only_managed_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            content = (
+                "export ROS_DOMAIN_ID=999\n"  # unrelated user line outside the block
+                f"{rdi.BASHRC_BEGIN_MARKER}\n"
+                "export ROS_DOMAIN_ID=11\n"
+                f"{rdi.BASHRC_END_MARKER}\n"
+            )
+            path = self._write(tmp, "bashrc", content)
+            self.assertEqual(rdi.read_bashrc_domain_id(path, lambda m: None), "11")
+
+    def test_bashrc_missing_block_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "bashrc", "export ROS_DOMAIN_ID=11\nalias ll='ls -la'\n")
+            self.assertIsNone(rdi.read_bashrc_domain_id(path, lambda m: None))
+
+    def test_bashrc_duplicate_managed_block_uses_last_and_warns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            content = (
+                f"{rdi.BASHRC_BEGIN_MARKER}\nexport ROS_DOMAIN_ID=11\n{rdi.BASHRC_END_MARKER}\n"
+                f"{rdi.BASHRC_BEGIN_MARKER}\nexport ROS_DOMAIN_ID=12\n{rdi.BASHRC_END_MARKER}\n"
+            )
+            path = self._write(tmp, "bashrc", content)
+            warnings = []
+            value = rdi.read_bashrc_domain_id(path, warnings.append)
+            self.assertEqual(value, "12")
+            self.assertTrue(any("2 ANSIBLE MANAGED BLOCK" in w for w in warnings))
+
+
+class EphemeralRangeTests(unittest.TestCase):
+    def test_standard_range_no_warning(self):
+        m = mock.mock_open(read_data="32768\t60999\n")
+        warnings = []
+        with mock.patch("builtins.open", m):
+            rdi.check_ephemeral_range(warnings.append)
+        self.assertEqual(warnings, [])
+
+    def test_custom_range_warns(self):
+        m = mock.mock_open(read_data="1024\t65000\n")
+        warnings = []
+        with mock.patch("builtins.open", m):
+            rdi.check_ephemeral_range(warnings.append)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("standard Linux ephemeral port range", warnings[0])
+
+    def test_unreadable_warns_but_does_not_raise(self):
+        with mock.patch("builtins.open", side_effect=OSError("nope")):
+            warnings = []
+            rdi.check_ephemeral_range(warnings.append)
+        self.assertEqual(len(warnings), 1)
+
+
+class ResolveLogicTests(unittest.TestCase):
+    def test_both_unset_interactive_prompts(self):
+        warnings = []
+        read_line = scripted_read_line(["11"])
+        value = rdi.resolve(None, None, None, True, read_line, warnings.append)
+        self.assertEqual(value, 11)
+
+    def test_both_unset_non_interactive_fails(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, None, None, False, scripted_read_line([]), lambda m: None)
+
+    def test_legacy_42_confirmation_path_keep(self):
+        warnings = []
+        read_line = scripted_read_line([""])  # blank -> keep 42
+        value = rdi.resolve(None, "42", "42", True, read_line, warnings.append)
+        self.assertEqual(value, 42)
+
+    def test_legacy_42_confirmation_path_change(self):
+        read_line = scripted_read_line(["11"])
+        value = rdi.resolve(None, "42", "42", True, read_line, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_legacy_42_non_interactive_fails(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "42", "42", False, scripted_read_line([]), lambda m: None)
+
+    def test_matching_non_legacy_preserved_without_prompt(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        value = rdi.resolve(None, "11", "11", True, boom, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_launch_only_resolves_without_prompt(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        value = rdi.resolve(None, "11", None, True, boom, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_bashrc_only_resolves_without_prompt(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        value = rdi.resolve(None, None, "11", True, boom, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_conflict_11_vs_42_interactive(self):
+        read_line = scripted_read_line(["11"])
+        value = rdi.resolve(None, "11", "42", True, read_line, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_conflict_11_vs_12_interactive(self):
+        read_line = scripted_read_line(["12"])
+        value = rdi.resolve(None, "11", "12", True, read_line, lambda m: None)
+        self.assertEqual(value, 12)
+
+    def test_conflict_non_interactive_fails(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "11", "12", False, scripted_read_line([]), lambda m: None)
+
+    def test_launch_invalid_bashrc_valid_no_silent_fallback(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "abc", "11", False, scripted_read_line([]), lambda m: None)
+        read_line = scripted_read_line(["11"])
+        value = rdi.resolve(None, "abc", "11", True, read_line, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_launch_valid_bashrc_invalid_no_silent_fallback(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "11", "abc", False, scripted_read_line([]), lambda m: None)
+        read_line = scripted_read_line(["11"])
+        value = rdi.resolve(None, "11", "abc", True, read_line, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_both_invalid_interactive_prompts_new_value(self):
+        read_line = scripted_read_line(["11"])
+        value = rdi.resolve(None, "abc", "-1", True, read_line, lambda m: None)
+        self.assertEqual(value, 11)
+
+    def test_both_invalid_non_interactive_fails(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "abc", "-1", False, scripted_read_line([]), lambda m: None)
+
+    def test_valid_override_accepted(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        value = rdi.resolve("12", "99999", "99999", False, boom, lambda m: None)
+        self.assertEqual(value, 12)
+
+    def test_override_42_accepted_without_confirmation(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        warnings = []
+        value = rdi.resolve("42", None, None, False, boom, warnings.append)
+        self.assertEqual(value, 42)
+        self.assertTrue(any("without interactive confirmation" in w for w in warnings))
+
+    def test_invalid_override_fails_immediately(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve("999", "11", "11", True, boom, lambda m: None)
+
+    def test_domain_zero_warns_but_accepts(self):
+        warnings = []
+        value = rdi.resolve("0", None, None, False, scripted_read_line([]), warnings.append)
+        self.assertEqual(value, 0)
+        self.assertTrue(any("overlaps the ROS 2 default domain" in w for w in warnings))
+
+    def test_domain_zero_from_persisted_state_warns(self):
+        warnings = []
+
+        def boom():
+            raise AssertionError("must not prompt")
+
+        value = rdi.resolve(None, "0", "0", True, boom, warnings.append)
+        self.assertEqual(value, 0)
+        self.assertTrue(any("overlaps the ROS 2 default domain" in w for w in warnings))
+
+
+class EofHandlingTests(unittest.TestCase):
+    """B-01: EOF ("") must never be conflated with a blank Enter ("\\n")."""
+
+    def test_1_persisted_42_interactive_eof_raises(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "42", "42", True, scripted_read_line([]), lambda m: None)
+
+    def test_2_conflict_interactive_eof_raises(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "11", "12", True, scripted_read_line([]), lambda m: None)
+
+    def test_3_both_missing_interactive_eof_raises(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, None, None, True, scripted_read_line([]), lambda m: None)
+
+    def test_4_blank_enter_confirming_42_still_keeps_42(self):
+        # scripted_read_line([""]) yields "\n" (Enter with no text), which is
+        # distinct from scripted_read_line([]) yielding "" (EOF) above.
+        value = rdi.resolve(None, "42", "42", True, scripted_read_line([""]), lambda m: None)
+        self.assertEqual(value, 42)
+
+    def test_eof_during_invalid_persisted_confirmation_raises(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "abc", "11", True, scripted_read_line([]), lambda m: None)
+
+    def test_eof_during_both_invalid_prompt_raises(self):
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve(None, "abc", "-1", True, scripted_read_line([]), lambda m: None)
+
+
+class UnreadableFileTests(unittest.TestCase):
+    """B-02: unreadable persisted files must fail closed, distinct from missing."""
+
+    def test_5_unreadable_launch_env_without_override_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "launch.env")
+            with open(path, "w") as fh:
+                fh.write("ROS_DOMAIN_ID=11\n")
+            os.chmod(path, 0o000)
+            try:
+                if os.access(path, os.R_OK):
+                    self.skipTest("running as a user that bypasses file permissions (e.g. root)")
+                with self.assertRaises(rdi.ResolutionError):
+                    rdi.read_launch_env_domain_id(path, lambda m: None)
+            finally:
+                os.chmod(path, 0o644)
+
+    def test_6_unreadable_bashrc_without_override_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "bashrc")
+            with open(path, "w") as fh:
+                fh.write(f"{rdi.BASHRC_BEGIN_MARKER}\nexport ROS_DOMAIN_ID=11\n{rdi.BASHRC_END_MARKER}\n")
+            os.chmod(path, 0o000)
+            try:
+                if os.access(path, os.R_OK):
+                    self.skipTest("running as a user that bypasses file permissions (e.g. root)")
+                with self.assertRaises(rdi.ResolutionError):
+                    rdi.read_bashrc_domain_id(path, lambda m: None)
+            finally:
+                os.chmod(path, 0o644)
+
+    def test_6b_undecodable_file_fails_without_traceback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "launch.env")
+            with open(path, "wb") as fh:
+                fh.write(b"ROS_DOMAIN_ID=\xff\xfe11\n")
+            with self.assertRaises(rdi.ResolutionError):
+                rdi.read_launch_env_domain_id(path, lambda m: None)
+
+    def test_7_nonexistent_files_are_still_treated_as_missing(self):
+        self.assertIsNone(
+            rdi.read_launch_env_domain_id("/nonexistent/launch.env", lambda m: None)
+        )
+        self.assertIsNone(
+            rdi.read_bashrc_domain_id("/nonexistent/bashrc", lambda m: None)
+        )
+
+    def test_8_valid_override_usable_without_persisted_state(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        # override path in resolve() never inspects launch_raw/bashrc_raw.
+        value = rdi.resolve("12", None, None, False, boom, lambda m: None)
+        self.assertEqual(value, 12)
+
+    def test_8b_valid_override_cli_ignores_unreadable_persisted_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            launch_env = os.path.join(tmp, "launch.env")
+            bashrc = os.path.join(tmp, "bashrc")
+            with open(launch_env, "w") as fh:
+                fh.write("ROS_DOMAIN_ID=11\n")
+            os.chmod(launch_env, 0o000)
+            try:
+                if os.access(launch_env, os.R_OK):
+                    self.skipTest("running as a user that bypasses file permissions (e.g. root)")
+                env = dict(os.environ)
+                env["QUESTIX_ROS_DOMAIN_ID"] = "12"
+                result = subprocess.run(
+                    [
+                        sys.executable, SCRIPT_PATH,
+                        "--launch-env-path", launch_env,
+                        "--bashrc-path", bashrc,
+                        "--non-interactive",
+                    ],
+                    env=env,
+                    input="",
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "12\n")
+            finally:
+                os.chmod(launch_env, 0o644)
+
+    def test_9_invalid_override_fails_immediately(self):
+        def boom():
+            raise AssertionError("must not prompt")
+
+        with self.assertRaises(rdi.ResolutionError):
+            rdi.resolve("abc", None, None, False, boom, lambda m: None)
+
+
+class CliContractTests(unittest.TestCase):
+    def _run(self, env_overrides=None, extra_args=None, stdin_data=""):
+        env = dict(os.environ)
+        env.pop("QUESTIX_ROS_DOMAIN_ID", None)
+        if env_overrides:
+            env.update(env_overrides)
+        args = [sys.executable, SCRIPT_PATH]
+        if extra_args:
+            args.extend(extra_args)
+        return subprocess.run(
+            args,
+            env=env,
+            input=stdin_data,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_stdout_is_final_integer_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            launch_env = os.path.join(tmp, "launch.env")  # does not exist
+            bashrc = os.path.join(tmp, "bashrc")  # does not exist
+            result = self._run(
+                env_overrides={"QUESTIX_ROS_DOMAIN_ID": "12"},
+                extra_args=[
+                    "--launch-env-path", launch_env,
+                    "--bashrc-path", bashrc,
+                    "--non-interactive",
+                ],
+            )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "12\n")
+
+    def test_invalid_override_fails_with_empty_stdout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run(
+                env_overrides={"QUESTIX_ROS_DOMAIN_ID": "abc"},
+                extra_args=[
+                    "--launch-env-path", os.path.join(tmp, "launch.env"),
+                    "--bashrc-path", os.path.join(tmp, "bashrc"),
+                    "--non-interactive",
+                ],
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("invalid", result.stderr)
+
+    def test_non_interactive_unresolved_state_fails_instead_of_hanging(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run(
+                extra_args=[
+                    "--launch-env-path", os.path.join(tmp, "launch.env"),
+                    "--bashrc-path", os.path.join(tmp, "bashrc"),
+                    "--non-interactive",
+                ],
+                stdin_data="",
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.sh
+++ b/setup.sh
@@ -2,4 +2,8 @@
 set -euo pipefail
 
 cd "$(dirname "$0")"
-ansible-playbook ansible/playbooks/setup_kit.yaml -i localhost, --connection=local --ask-become-pass
+
+ROS_DOMAIN_ID="$(python3 scripts/resolve_ros_domain_id.py)"
+
+ansible-playbook ansible/playbooks/setup_kit.yaml -i localhost, --connection=local --ask-become-pass \
+    -e "ros_domain_id=${ROS_DOMAIN_ID}"

--- a/systemd/questix_robot.env
+++ b/systemd/questix_robot.env
@@ -9,12 +9,12 @@ ROBOT_WS=/home/ubuntu/robot_ws
 ROS_DOMAIN_ID=42
 
 # Launch component toggles
-ENABLE_LIDAR=true
-ENABLE_SHOT=true
-ENABLE_DRIVE=true
+ENABLE_LIDAR=false
+ENABLE_SHOT=false
+ENABLE_DRIVE=false
 # The competition systemd launcher always enables GPIO safety regardless of this value.
 ENABLE_GPIO_REF=true
 ENABLE_RVIZ=false
 
 # Controller type: uart or dualshock
-CONTROLLER_TYPE=uart
+CONTROLLER_TYPE=dualshock


### PR DESCRIPTION
## 概要

QUESTiX Raspberry Pi 5 のキッティングを、機体固有 `ROS_DOMAIN_ID` の安全な決定と、初回起動時の安全側 shipping defaults の2点で改善します。

本PRは drive-control refactor の #144 とは独立しており、`main@5dbdd7b44fd9dfda7cffc4a9f026858f6c2341cf` をbaseに実装しています。

Draft理由: source-only validation は完了していますが、GitHub Actions CI と Raspberry Pi 5 fresh-SD physical validation は未完了です。

## ROS_DOMAIN_ID kitting

- Linux標準 ephemeral port range を前提に、許可範囲を `0..101` / `215..232` に限定
- `setup.sh` 前段で `scripts/resolve_ros_domain_id.py` を実行し、最終値を Ansible へ `-e ros_domain_id=<resolved>` で渡す
- persisted state は以下を確認
  - `/etc/questix_robot/launch.env`
  - target user の `~/.bashrc` Ansible managed block
- 有効な非42値が一致していれば保持し、再setup時にpromptしない
- `42` は有効だが legacy/bootstrap default として扱い、interactive時は保持/変更を確認
- 2箇所の値が異なる場合は silent に決定しない
- 一方が malformed / unreadable の場合も silent fallback しない
- `0` は許可するが ROS 2 default domainとの衝突warningを出す
- `QUESTIX_ROS_DOMAIN_ID=<id> ./setup.sh` による明示overrideをサポート
- overrideも同じrange validationを受ける
- `/proc/sys/net/ipv4/ip_local_port_range` が標準値と異なる場合はwarning
- EOFはblank Enterと区別し、operator confirmationとして誤認しない
- persisted fileの不存在と読取不能を区別し、読取不能はfail closed

Ansible側にも同じrange assertを追加し、`setup.sh`を迂回してplaybookを直接実行した場合もinvalid値を拒否します。

`setup_kit_vars.yaml` の `ros_domain_id: 42` は ARM64 ISO build の bootstrap / pre-kitting value として維持しています。

## Shipping defaults

fresh `launch.env` のdefaultを以下に変更します。

```text
mode=practice
questix_robot.service=enabled

ROS_DOMAIN_ID=<kittingで確定した値>

ENABLE_LIDAR=false
ENABLE_SHOT=false
ENABLE_DRIVE=false
ENABLE_GPIO_REF=true
ENABLE_RVIZ=false

CONTROLLER_TYPE=dualshock
```

`ENABLE_GPIO_REF=true` は意図的な安全仕様です。LiDAR / shot / drive は初回起動時に無効化しますが、GPIO E-stop経路は手動・診断起動時もdefaultで有効に保ちます。competition systemd launcherは従来どおりGPIO safetyを強制有効化します。

shipping defaults は `ansible/roles/robot_autostart/defaults/main.yaml` をsingle sourceとし、`launch.env.j2` はそこから参照します。

## 再setup時の保存契約

- 既存 `launch.env` は `force: false` を維持し、Domain ID以外の設定を上書きしない
- `ROS_DOMAIN_ID` のみresolved valueへ同期
- `.bashrc` のAnsible managed blockも同じresolved valueへ同期

最終 invariant:

```text
launch.env ROS_DOMAIN_ID
==
~/.bashrc managed-block ROS_DOMAIN_ID
==
resolved ros_domain_id
```

## Test / validation

Exact commit:

```text
f28b1e89bb4b81afdcc4596022b0393fb63ead1d
```

Source-only local validation:

- `python3 -m unittest scripts.test_resolve_ros_domain_id -v`: **50/50 PASS**
- `ansible/tests/run_contract_tests.sh`: **28/28 PASS**
- `QUESTIX_SOURCE_ROOT="$PWD" pytest launcher/test/test_gpio_safety_launch.py`: **6/6 PASS**
- `bash -n setup.sh`: PASS
- `ansible-playbook ansible/playbooks/setup_kit.yaml --syntax-check -i localhost,`: PASS
- `ansible-playbook ansible/playbooks/setup_dev.yaml --syntax-check -i localhost,`: PASS
- `git diff origin/main...HEAD --check`: PASS

`yamllint` / `ansible-lint` はローカルWSL環境にdependencyが無かったため未実行です。既存GitHub Actionsで確認します。

## Physical validation

**NOT RUN** — Raspberry Pi 5 / Ubuntu 24.04 のfresh SDで以下を別Gateとして実施予定です。

- initial setup / Domain ID 12
- shipping defaults
- idempotent re-setup
- legacy 42 migration
- invalid ID rejection
- existing launch setting preservation
- reboot後 `practice` / service enabled / ROS nodesなし
- clean build / colcon test
- dependency / Git identity確認

## Scope外 / follow-up

- IPv4 preference (`/etc/gai.conf`)、固定IPv4、IPv6 disable、NetworkManager設計は変更しない
- `robot_manager` は現在 `ROS_DOMAIN_ID=0..232` を許可しており、`102..214` exclusionと不整合があるためfollow-up候補
- duplicate `ROS_DOMAIN_ID` の正規化は本PRでは行わず、現状はlast-wins semantics + warningで扱う
- competition launcher内部のfallback値はshipping defaultsとは別契約のため変更しない

## Merge gate

本PRは以下が完了するまでDraftのままとします。

1. GitHub Actions CI 全PASS
2. Raspberry Pi 5 fresh-SD physical validation PASS
3. exact PR HEADで最終review
